### PR TITLE
Migrate deprecated java.util.logging APIs

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/logging/MigrateLogRecordSetMillisToSetInstant.java
+++ b/src/main/java/org/openrewrite/java/migrate/logging/MigrateLogRecordSetMillisToSetInstant.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.ChangeMethodName;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+public class MigrateLogRecordSetMillisToSetInstant extends Recipe {
+    private static final MethodMatcher SET_MILLIS_MATCHER = new MethodMatcher("java.util.logging.LogRecord setMillis(long)");
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `LogRecord#setMillis(long)` to `LogRecord#setInstant(Instant.ofEpochMilli(long))`.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate `LogRecord#setMillis(long)`, which is deprecated in favor of `LogRecord#setInstant(Instant.ofEpochMilli(long))`.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesMethod<>(SET_MILLIS_MATCHER);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MigrateLogRecordSetMillisToSetInstantVisitor();
+    }
+
+    private static class MigrateLogRecordSetMillisToSetInstantVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = method;
+            if (SET_MILLIS_MATCHER.matches(m)) {
+                m = m.withTemplate(
+                        template("Instant.ofEpochMilli(#{any(long)})")
+                                .imports("java.time.Instant")
+                                .build(),
+                        m.getCoordinates().replaceArguments(),
+                        m.getArguments().get(0)
+                );
+                maybeAddImport("java.time.Instant");
+                doAfterVisit(new ChangeMethodName("java.util.logging.LogRecord setMillis(long)", "setInstant"));
+            }
+            return super.visitMethodInvocation(m, ctx);
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggerGlobalToGetGlobal.java
+++ b/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggerGlobalToGetGlobal.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+
+public class MigrateLoggerGlobalToGetGlobal extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Migrate `Logger.global` to `Logger#getGlobal()`.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The preferred way to get the global logger object is via the call `Logger#getGlobal()`.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<>("java.util.logging.Logger");
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MigrateLoggerGlobalToGetGlobalVisitor();
+    }
+
+    private static class MigrateLoggerGlobalToGetGlobalVisitor extends JavaVisitor<ExecutionContext> {
+        @Override
+        public J visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
+            J j = super.visitFieldAccess(fieldAccess, ctx);
+            J.FieldAccess asFieldAccess = (J.FieldAccess) j;
+
+            if (TypeUtils.isOfClassType(asFieldAccess.getTarget().getType(), "java.util.logging.Logger") && asFieldAccess.getSimpleName().equals("global")) {
+                j = new J.MethodInvocation(
+                        Tree.randomId(),
+                        asFieldAccess.getPrefix(),
+                        Markers.EMPTY,
+                        JRightPadded.build(asFieldAccess.getTarget()),
+                        null,
+                        asFieldAccess.getName().withName("getGlobal"),
+                        JContainer.build(Collections.emptyList()),
+                        TypeUtils.asMethod(asFieldAccess.getTarget().getType())
+                );
+            }
+
+            return j;
+        }
+
+
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggingMXBeanToGetPlatformMXBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggingMXBeanToGetPlatformMXBean.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+public class MigrateLoggingMXBeanToGetPlatformMXBean extends Recipe {
+    private static final MethodMatcher LOG_MANAGER_GET_LOGGING_MX_BEAN_MATCHER = new MethodMatcher("java.util.logging.LogManager getLoggingMXBean()");
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `LogManager#getLoggingMXBean()` to `ManagementFactory#getPlatformMXBean(PlatformLoggingMXBean.class)`.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "`java.util.logging.LoggingMXBean` is deprecated and replaced with `java.lang.management.PlatformLoggingMXBean`. Use `java.lang.management.ManagementFactory#getPlatformMXBean(PlatformLoggingMXBean.class)` instead.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesMethod<>(LOG_MANAGER_GET_LOGGING_MX_BEAN_MATCHER);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MigrateLoggingMXBeanToGetPlatformMXBeanVisitor();
+    }
+
+    private static class MigrateLoggingMXBeanToGetPlatformMXBeanVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = method;
+            if (LOG_MANAGER_GET_LOGGING_MX_BEAN_MATCHER.matches(m)) {
+                m = m.withTemplate(
+                        template("ManagementFactory.getPlatformMXBean(PlatformLoggingMXBean.class)")
+                                .imports("java.lang.management.ManagementFactory", "java.lang.management.PlatformLoggingMXBean")
+                                .build(),
+                        m.getCoordinates().replace()
+                );
+                maybeAddImport("java.lang.management.ManagementFactory");
+                maybeAddImport("java.lang.management.PlatformLoggingMXBean");
+                maybeRemoveImport("java.util.logging.LogManager");
+            }
+            return super.visitMethodInvocation(m, ctx);
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/migrate/logging/package-info.java
+++ b/src/main/java/org/openrewrite/java/migrate/logging/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.java.migrate.logging;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/resources/META-INF/rewrite/deprecated-logging-apis.yml
+++ b/src/main/resources/META-INF/rewrite/deprecated-logging-apis.yml
@@ -1,0 +1,29 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.DeprecatedLoggingAPIs
+displayName: Migrate from deprecated java.util.logging APIs
+description: Certain Java logging APIs have become deprecated and their usages changed, necessitating usage changes.
+tags:
+  - logging
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: java.util.logging.LoggingMXBean
+      newFullyQualifiedTypeName: java.lang.management.PlatformLoggingMXBean
+  - org.openrewrite.java.migrate.logging.MigrateLoggerGlobalToGetGlobal
+  - org.openrewrite.java.migrate.logging.MigrateLoggingMXBeanToGetPlatformMXBean
+  - org.openrewrite.java.migrate.logging.MigrateLogRecordSetMillisToSetInstant

--- a/src/test/kotlin/org/openrewrite/java/migrate/logging/DeprecatedLoggingAPIsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/logging/DeprecatedLoggingAPIsTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.config.Environment
+import org.openrewrite.java.JavaRecipeTest
+
+/**
+ * Holds the declarative tests for the deprecated-logging-apis.yml composite recipe.
+ */
+class DeprecatedLoggingAPIsTest : JavaRecipeTest {
+    override val recipe: Recipe = Environment.builder()
+        .scanRuntimeClasspath("org.openrewrite.java.migrate")
+        .build()
+        .activateRecipes("org.openrewrite.java.migrate.DeprecatedLoggingAPIs")
+
+    @Test
+    fun loggingMXBeanInterfaceToPlatformLoggingMXBeanInterface() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.LoggingMXBean;
+
+            public class B {
+                public static void method() {
+                    LoggingMXBean loggingBean = null;
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.lang.management.PlatformLoggingMXBean;
+
+            public class B {
+                public static void method() {
+                    PlatformLoggingMXBean loggingBean = null;
+                }
+            }
+        """
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLogRecordSetMillisToSetInstantTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLogRecordSetMillisToSetInstantTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+class MigrateLogRecordSetMillisToSetInstantTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = MigrateLogRecordSetMillisToSetInstant()
+
+    @Test
+    fun setMillisToSetInstantWhenParameterIsIdentifier() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Level;
+            import java.util.logging.LogRecord;
+
+            public class B {
+                public static void method(long millis) {
+                    LogRecord logRecord = new LogRecord(Level.parse("0"), "msg");
+                    logRecord.setMillis(millis);
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.time.Instant;
+            import java.util.logging.Level;
+            import java.util.logging.LogRecord;
+
+            public class B {
+                public static void method(long millis) {
+                    LogRecord logRecord = new LogRecord(Level.parse("0"), "msg");
+                    logRecord.setInstant(Instant.ofEpochMilli(millis));
+                }
+            }
+        """
+    )
+
+    @Test
+    fun setMillisToSetInstantWhenParameterIsMethodCall() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Level;
+            import java.util.logging.LogRecord;
+
+            public class B {
+                private static long getLong() {
+                    return 1L;
+                }
+
+                public static void method() {
+                    LogRecord logRecord = new LogRecord(Level.parse("0"), "msg");
+                    logRecord.setMillis(getLong());
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.time.Instant;
+            import java.util.logging.Level;
+            import java.util.logging.LogRecord;
+
+            public class B {
+                private static long getLong() {
+                    return 1L;
+                }
+
+                public static void method() {
+                    LogRecord logRecord = new LogRecord(Level.parse("0"), "msg");
+                    logRecord.setInstant(Instant.ofEpochMilli(getLong()));
+                }
+            }
+        """
+    )
+
+    @Test
+    fun setMillisToSetInstantWhenParameterIsLiteral() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Level;
+            import java.util.logging.LogRecord;
+
+            public class B {
+                public static void method() {
+                    LogRecord logRecord = new LogRecord(Level.parse("0"), "msg");
+                    logRecord.setMillis(1L);
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.time.Instant;
+            import java.util.logging.Level;
+            import java.util.logging.LogRecord;
+
+            public class B {
+                public static void method() {
+                    LogRecord logRecord = new LogRecord(Level.parse("0"), "msg");
+                    logRecord.setInstant(Instant.ofEpochMilli(1L));
+                }
+            }
+        """
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLoggerGlobalToGetGlobalTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLoggerGlobalToGetGlobalTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+class MigrateLoggerGlobalToGetGlobalTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = MigrateLoggerGlobalToGetGlobal()
+
+    @Test
+    fun globalToGetGlobal() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Logger;
+
+            public class B {
+                public static void method() {
+                    Logger logger = Logger.global;
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Logger;
+
+            public class B {
+                public static void method() {
+                    Logger logger = Logger.getGlobal();
+                }
+            }
+        """
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLoggingMXBeanToGetPlatformMXBeanTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLoggingMXBeanToGetPlatformMXBeanTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+class MigrateLoggingMXBeanToGetPlatformMXBeanTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = MigrateLoggingMXBeanToGetPlatformMXBean()
+
+    @Test
+    fun getLoggingMXBeanToGetPlatformMXBean() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.LoggingMXBean;
+            import java.util.logging.LogManager;
+
+            public class B {
+                public static void method() {
+                    LoggingMXBean loggingBean = LogManager.getLoggingMXBean();
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.lang.management.ManagementFactory;
+            import java.lang.management.PlatformLoggingMXBean;
+            import java.util.logging.LoggingMXBean;
+
+            public class B {
+                public static void method() {
+                    LoggingMXBean loggingBean = ManagementFactory.getPlatformMXBean(PlatformLoggingMXBean.class);
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
see: https://github.com/openrewrite/rewrite-migrate-java/issues/14

Addresses all aspects of https://github.com/openrewrite/rewrite-migrate-java/issues/14 except `logrb`, which I'll put out in a separate PR soon.