### PR TITLE
Migrate deprecated `java.util.logging.Logger#logrb` APIs

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggerLogrbToUseResourceBundle.java
+++ b/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggerLogrbToUseResourceBundle.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+public class MigrateLoggerLogrbToUseResourceBundle extends Recipe {
+    private static final MethodMatcher MATCHER = new MethodMatcher("java.util.logging.Logger logrb(java.util.logging.Level, String, String, String, String, ..)");
+
+    @Override
+    public String getDisplayName() {
+        return "Use `Logger#logrb(.., ResourceBundle bundleName, ..)`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "`java.util.logging.Logger#logrb(.., String bundleName, ..)` has been deprecated.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesMethod<>(MATCHER);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MigrateLoggerLogrbToUseResourceBundleVisitor();
+    }
+
+    private static class MigrateLoggerLogrbToUseResourceBundleVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = method;
+            if (MATCHER.matches(m)) {
+                m = m.withTemplate(
+                        template("#{any(java.util.logging.Level)}, #{any(String)}, #{any(String)}, ResourceBundle.getBundle(#{any(String)}), #{any(String)}" + (m.getArguments().size() == 6 ? ", #{any()}}" : ""))
+                                .imports("java.util.ResourceBundle")
+                                .build(),
+                        m.getCoordinates().replaceArguments(),
+                        m.getArguments().toArray()
+                );
+                maybeAddImport("java.util.ResourceBundle");
+            }
+            return super.visitMethodInvocation(m, ctx);
+        }
+
+    }
+
+}

--- a/src/main/resources/META-INF/rewrite/java-logging-apis.yml
+++ b/src/main/resources/META-INF/rewrite/java-logging-apis.yml
@@ -23,6 +23,7 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.logging.MigrateGetLoggingMXBeanToGetPlatformMXBean
   - org.openrewrite.java.migrate.logging.MigrateLoggerGlobalToGetGlobal
+  - org.openrewrite.java.migrate.logging.MigrateLoggerLogrbToUseResourceBundle
   - org.openrewrite.java.migrate.logging.MigrateLogRecordSetMillisToSetInstant
   - org.openrewrite.java.migrate.logging.MigrateInterfaceLoggingMXBeanToPlatformLoggingMXBean
 

--- a/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLoggerLogrbToUseResourceBundleTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/logging/MigrateLoggerLogrbToUseResourceBundleTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.logging
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+@Suppress("deprecation")
+class MigrateLoggerLogrbToUseResourceBundleTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = MigrateLoggerLogrbToUseResourceBundle()
+
+    @Test
+    fun logrbToLogrbResourceBundle() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", "bundleName", "msg");
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.util.ResourceBundle;
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", ResourceBundle.getBundle("bundleName"), "msg");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun logrbToLogrbResourceBundleWithTrailingObject() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", "bundleName", "msg", new Object());
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.util.ResourceBundle;
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", ResourceBundle.getBundle("bundleName"), "msg", new Object());
+                }
+            }
+        """
+    )
+
+    @Test
+    fun logrbToLogrbResourceBundleWithTrailingObjectVarargs() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    Object[] objects = new Object[]{};
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", "bundleName", "msg", objects);
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.util.ResourceBundle;
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    Object[] objects = new Object[]{};
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", ResourceBundle.getBundle("bundleName"), "msg", objects);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun logrbToLogrbResourceBundleWithTrailingThrowable() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", "bundleName", "msg", new Exception());
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.util.ResourceBundle;
+            import java.util.logging.Level;
+            import java.util.logging.Logger;
+
+            public class Test {
+                Logger logger = Logger.getLogger("myLogger");
+
+                public void method() {
+                    logger.logrb(Level.parse("0"), "sourceClass", "sourceMethod", ResourceBundle.getBundle("bundleName"), "msg", new Exception());
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
closes https://github.com/openrewrite/rewrite-migrate-java/issues/14
