### PR TITLE
Migrate `java.net. MulticastSocket` deprecated APIs of `getTTL` and `setTTL`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/net/MigrateMulticastSocketSetTTLToSetTimeToLive.java
+++ b/src/main/java/org/openrewrite/java/migrate/net/MigrateMulticastSocketSetTTLToSetTimeToLive.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.net;
+
+import lombok.SneakyThrows;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.ChangeMethodName;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+public class MigrateMulticastSocketSetTTLToSetTimeToLive extends Recipe {
+    private static final MethodMatcher MATCHER = new MethodMatcher("java.net.MulticastSocket setTTL(byte)");
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `java.net.MulticastSocket#setTTL(byte)`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrates the deprecated method `java.net.MulticastSocket#setTTL(byte)` to `java.net.MulticastSocket#setTimeToLive(int)` using " +
+                "`Byte.valueOf(byte).intValue()`. The result being `java.net.MulticastSocket#setTimeToLive(Byte.valueOf(byte).intValue())`.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesMethod<>(MATCHER);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MigrateMulticastSocketSetTTLToSetTimeToLiveVisitor();
+    }
+
+    private static class MigrateMulticastSocketSetTTLToSetTimeToLiveVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @SneakyThrows
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = method;
+            if (MATCHER.matches(m)) {
+                m = m.withTemplate(
+                        template("Byte.valueOf(#{any(byte)}).intValue()").build(),
+                        m.getCoordinates().replaceArguments(),
+                        m.getArguments().get(0)
+                );
+                doAfterVisit(new ChangeMethodName("java.net.MulticastSocket setTTL(byte)", "setTimeToLive"));
+            }
+            return super.visitMethodInvocation(m, ctx);
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/migrate/net/package-info.java
+++ b/src/main/java/org/openrewrite/java/migrate/net/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.java.migrate.net;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/resources/META-INF/rewrite/java8-to-java11.yml
+++ b/src/main/resources/META-INF/rewrite/java8-to-java11.yml
@@ -29,3 +29,4 @@ recipeList:
   - org.openrewrite.java.migrate.AddJdeprscanPlugin
   - org.openrewrite.java.migrate.AddJaxbDependencies
   - org.openrewrite.java.migrate.DeprecatedLoggingAPIs
+  - org.openrewrite.java.migrate.DeprecatedNetAPIs

--- a/src/main/resources/META-INF/rewrite/migrate-deprecated-java-net-apis.yml
+++ b/src/main/resources/META-INF/rewrite/migrate-deprecated-java-net-apis.yml
@@ -1,0 +1,35 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.DeprecatedNetAPIs
+displayName: Migrate from deprecated java.net APIs
+description: Certain Java networking APIs have become deprecated and their usages changed, necessitating usage changes.
+tags:
+  - networking
+recipeList:
+  - org.openrewrite.java.migrate.net.MigrateMulticastSocketSetTTLToSetTimeToLive
+  - org.openrewrite.java.migrate.net.MigrateMulticastSocketGetTTL
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.net.MigrateMulticastSocketGetTTL
+displayName: Migrate `java.net.MulticastSocket#getTTL()`
+description: Migrates the deprecated method `java.net.MulticastSocket#getTTL()` to `java.net.MulticastSocket#getTimeToLive()`.
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.net.MulticastSocket getTTL()
+      newMethodName: getTimeToLive

--- a/src/test/kotlin/org/openrewrite/java/migrate/net/MigrateDeprecatedNetAPIsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/net/MigrateDeprecatedNetAPIsTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.net
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.config.Environment
+import org.openrewrite.java.JavaRecipeTest
+
+class MigrateDeprecatedNetAPIsTest : JavaRecipeTest {
+    override val recipe: Recipe = Environment.builder()
+        .scanRuntimeClasspath("org.openrewrite.java.migrate")
+        .build()
+        .activateRecipes("org.openrewrite.java.migrate.DeprecatedNetAPIs")
+
+    @Test
+    fun multicastSocketGetTTLToGetTimeToLive() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.net.MulticastSocket;
+
+            public class Test {
+                public static void method() {
+                    MulticastSocket s = new MulticastSocket(0);
+                    s.getTTL();
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.net.MulticastSocket;
+
+            public class Test {
+                public static void method() {
+                    MulticastSocket s = new MulticastSocket(0);
+                    s.getTimeToLive();
+                }
+            }
+        """
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/java/migrate/net/MigrateMulticastSocketSetTTLToSetTimeToLiveTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/net/MigrateMulticastSocketSetTTLToSetTimeToLiveTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.net
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+class MigrateMulticastSocketSetTTLToSetTimeToLiveTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = MigrateMulticastSocketSetTTLToSetTimeToLive()
+
+    @Test
+    fun multicastSocketSetTTLToSetTimeToLive() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.net.MulticastSocket;
+
+            public class Test {
+                public static void method() {
+                    MulticastSocket s = new MulticastSocket(0);
+                    s.setTTL((byte) 1);
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.net.MulticastSocket;
+
+            public class Test {
+                public static void method() {
+                    MulticastSocket s = new MulticastSocket(0);
+                    s.setTimeToLive(Byte.valueOf((byte) 1).intValue());
+                }
+            }
+        """
+    )
+
+    @Test
+    fun multicastSocketSetTTLToSetTimeToLiveFromOtherMethod() = assertChanged(
+        before = """
+            package org.openrewrite.example;
+
+            import java.net.MulticastSocket;
+
+            public class Test {
+                public static byte takeByte() {
+                    return 127;
+                }
+
+                public static void method() {
+                    MulticastSocket s = new MulticastSocket(0);
+                    s.setTTL(takeByte());
+                }
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import java.net.MulticastSocket;
+
+            public class Test {
+                public static byte takeByte() {
+                    return 127;
+                }
+
+                public static void method() {
+                    MulticastSocket s = new MulticastSocket(0);
+                    s.setTimeToLive(Byte.valueOf(takeByte()).intValue());
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
starts filling out `net`-related recipes as addressed in https://github.com/openrewrite/rewrite-migrate-java/issues/7