### PR TITLE
Bump JaCoCo to 0.8.8 for official Java 17 support

### DIFF
--- a/src/main/resources/META-INF/rewrite/jacoco.yml
+++ b/src/main/resources/META-INF/rewrite/jacoco.yml
@@ -26,4 +26,4 @@ recipeList:
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.jacoco
       artifactId: jacoco-maven-plugin
-      newVersion: 0.8.7
+      newVersion: 0.8.8

--- a/src/test/kotlin/org/openrewrite/java/migrate/jacoco/UpgradeJaCoCoMavenPluginVersionTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/jacoco/UpgradeJaCoCoMavenPluginVersionTest.kt
@@ -69,7 +69,7 @@ class UpgradeJaCoCoMavenPluginVersionTest : MavenRecipeTest {
               <modelVersion>4.0.0</modelVersion>
                
               <properties>
-                <jacoco.version>0.8.7</jacoco.version>
+                <jacoco.version>0.8.8</jacoco.version>
               </properties>
               
               <groupId>com.mycompany.app</groupId>


### PR DESCRIPTION
https://github.com/jacoco/jacoco/releases/tag/v0.8.8

Not planning on doing a bump for each version, but official Java 17 support seems notable enough.