### PR TITLE
Remove Cobertura Maven Plugin, as it is not compatible with Java 11.

### DIFF
--- a/src/main/resources/META-INF/rewrite/java8-to-java11.yml
+++ b/src/main/resources/META-INF/rewrite/java8-to-java11.yml
@@ -43,6 +43,7 @@ recipeList:
   - org.openrewrite.java.migrate.javax.JavaxLangModelUtil
   - org.openrewrite.java.migrate.javax.JavaxManagementMonitorAPIs
   - org.openrewrite.java.migrate.javax.JavaxXmlStreamAPIs
+  - org.openrewrite.java.migrate.cobertura.RemoveCoberturaMavenPlugin
   - org.openrewrite.java.migrate.wro4j.UpgradeWro4jMavenPluginVersion
   - org.openrewrite.java.migrate.jacoco.UpgradeJaCoCoMavenPluginVersion
   - org.openrewrite.java.migrate.JavaVersion11

--- a/src/main/resources/META-INF/rewrite/remove-cobertura-maven-plugin.yml
+++ b/src/main/resources/META-INF/rewrite/remove-cobertura-maven-plugin.yml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.cobertura.RemoveCoberturaMavenPlugin
+displayName: Remove Cobertura Maven plugin
+description: This recipe will remove Cobertura, as it is not compatible with Java 11.
+tags:
+  - java11
+  - cobertura
+
+recipeList:
+  - org.openrewrite.maven.RemovePlugin:
+      groupId: org.codehaus.mojo
+      artifactId: cobertura-maven-plugin


### PR DESCRIPTION
While JaCoCo is a likely replacement, actually plugging that in would
likely also require integration with whatever the build was using to
visualize the results. It is unlikely there is a direct replacement
option there.

Removing Cobertura at least ensures the build is not left in a broken
state, even though Coverage information may then be missing. Any
coverage visualization is likely to surface that for users.