### PR TITLE
Maybe remove static import String.format & do not wrap method invocation

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -64,10 +64,11 @@ public class StringFormatted extends Recipe {
 
             List<Expression> arguments = mi.getArguments();
             String template = String.format(
-                    arguments.get(0) instanceof J.Literal
+                    arguments.get(0) instanceof J.Literal || arguments.get(0) instanceof J.MethodInvocation
                             ? "#{any(java.lang.String)}.formatted(%s)"
                             : "(#{any(java.lang.String)}).formatted(%s)",
                     String.join(", ", Collections.nCopies(arguments.size() - 1, "#{any()}")));
+            maybeRemoveImport("java.lang.String.format");
             return mi.withTemplate(
                     JavaTemplate.builder(this::getCursor, template)
                             .javaParser(() -> JavaParser.fromJavaVersion().build())

--- a/src/test/kotlin/org/openrewrite/java/migrate/lang/StringFormattedTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/lang/StringFormattedTest.kt
@@ -118,4 +118,41 @@ class StringFormattedTest : RewriteTest {
         """)
     )
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/77")
+    fun doNotWrapMethodInvocation() = rewriteRun(
+        java("""
+            class A {
+                String str = String.format(someMethod(), "a");
+                String someMethod() {
+                    return "foo %s";
+                }
+            }
+        """,
+        """
+            class A {
+                String str = someMethod().formatted("a");
+                String someMethod() {
+                    return "foo %s";
+                }
+            }
+        """)
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/77")
+    fun removeStaticImport() = rewriteRun(
+        java("""
+            import static java.lang.String.format;
+            class A {
+                String str = format("foo %s", "a");
+            }
+        """,
+        """
+            class A {
+                String str = "foo %s".formatted("a");
+            }
+        """)
+    )
+
 }


### PR DESCRIPTION
As per: https://rewriteoss.slack.com/archives/C01A843MWG5/p1661154774028769?thread_ts=1661106275.091829&cid=C01A843MWG5
> No point in leaving behind an unused static import