### PR TITLE
Replace lombok.val with final var on projects using Java 11 or higher

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,7 @@ val rewriteVersion = if(project.hasProperty("releasing")) {
 dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
+    testImplementation("org.projectlombok:lombok:latest.release")
 
     implementation("org.openrewrite:rewrite-java:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-maven:${rewriteVersion}")

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lombok;
+
+import org.openrewrite.Applicability;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+import java.time.Duration;
+
+public class LombokValToFinalVar extends Recipe {
+
+    private static final String LOMBOK_VAL = "lombok.val";
+
+    @Override
+    public String getDisplayName() {
+        return "Replace `lombok.val` with `final var`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `lombok.val` with `final var` on projects using Java 11 or higher.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return Applicability.and(
+                new UsesJavaVersion<>(11),
+                new UsesType<>(LOMBOK_VAL));
+    }
+
+    @Override
+    protected LombokValToFinalVarVisitor getVisitor() {
+        return new LombokValToFinalVarVisitor();
+    }
+
+    private static class LombokValToFinalVarVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private static final String FINAL_VAR_ANY = "final var #{} = #{any()};";
+
+        @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations mv, ExecutionContext p) {
+            if (mv.getTypeAsFullyQualified().isAssignableTo(LOMBOK_VAL)) {
+                maybeRemoveImport(LOMBOK_VAL);
+                return mv.withTemplate(
+                        JavaTemplate.builder(this::getCursor, FINAL_VAR_ANY)
+                                .javaParser(() -> JavaParser.fromJavaVersion().build())
+                                .build(),
+                        mv.getCoordinates().replace(),
+                        mv.getVariables().get(0).getName().getSimpleName(),
+                        mv.getVariables().get(0).getInitializer());
+            }
+            return super.visitVariableDeclarations(mv, p);
+        }
+
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+}

--- a/src/test/kotlin/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lombok
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
+import org.openrewrite.java.Assertions.*
+import org.openrewrite.java.JavaParser
+import org.openrewrite.test.RecipeSpec
+import org.openrewrite.test.RewriteTest
+
+class LombokValToFinalVarTest : RewriteTest {
+    override fun defaults(spec: RecipeSpec) {
+        spec.recipe(LombokValToFinalVar())
+        spec.parser(JavaParser.fromJavaVersion().classpath("lombok"))
+    }
+
+    @Test
+    fun replaceAssignment() = rewriteRun(
+        version(
+            java(
+                """
+                import lombok.val;
+                class A {
+                    void bar() {
+                        val foo = "foo";
+                    }
+                }
+                """,
+                """
+                class A {
+                    void bar() {
+                        final var foo = "foo";
+                    }
+                }
+                """),
+                17))
+
+    @Test
+    fun retainPrefixComment() = rewriteRun(
+        version(
+            java(
+                """
+                import lombok.val;
+                class A {
+                    void bar() {
+                        // Prefix
+                        val foo = "foo";
+                    }
+                }
+                """,
+                """
+                class A {
+                    void bar() {
+                        // Prefix
+                        final var foo = "foo";
+                    }
+                }
+                """),
+                17))
+
+    @Test
+    fun retainInfixComment() = rewriteRun(
+        version(
+            java(
+                """
+                import lombok.val;
+                class A {
+                    void bar() {
+                        val foo = 
+                        // Infix
+                        "foo";
+                    }
+                }
+                """,
+                """
+                class A {
+                    void bar() {
+                        final var foo = 
+                        // Infix
+                        "foo";
+                    }
+                }
+                """),
+                17))
+
+    @Test
+    fun retainSuffixComment() = rewriteRun(
+        version(
+            java(
+                """
+                import lombok.val;
+                class A {
+                    void bar() {
+                        val foo = "foo";
+                        // Suffix
+                    }
+                }
+                """,
+                """
+                class A {
+                    void bar() {
+                        final var foo = "foo";
+                        // Suffix
+                    }
+                }
+                """),
+                17))
+
+    @Test
+    fun retainWhitespace() = rewriteRun(
+        version(
+            java(
+                """
+                import lombok.val;
+                class A {
+                    void bar() {
+                        val foo =
+                            "foo";
+                    }
+                }
+                """,
+                """
+                class A {
+                    void bar() {
+                        final var foo =
+                            "foo";
+                    }
+                }
+                """),
+                17))
+
+}


### PR DESCRIPTION
Figured this would be a fun one, and learning exercise. It replaces `lombok.val` with `final var`, as there's not a lot of value in retaining `lombok.val` nowadays. As a bonus it makes projects more compatible with OpenRewrite, at least until there's integrated support.

Only thing that I'm not yet sure how to resolve is the tests containing infix whitespace & comment. Some guidance there would be appreciated once again. My attempts at using `maybeAutoFormat` failed up to now.

Fixes https://github.com/projectlombok/lombok/issues/3207 
Fixes https://github.com/openrewrite/rewrite/issues/1297

TODO
- [ ] Reference from META-INF yaml
- [ ] Either fix or ignore infix whitespace & comments