### PR TITLE
JDeprScan release 17

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -32,3 +32,5 @@ recipeList:
       newValue: 17
       addIfMissing: false
   - org.openrewrite.java.migrate.lang.StringFormatted
+  - org.openrewrite.java.migrate.AddJDeprScanPlugin:
+      release: 17


### PR DESCRIPTION
Figured for Java 17 we'd want bump the release to Java 17.
Would `AddPlugin` also change the configuration if already present?
Noticed there's no tests for this recipe yet; could be added if needed. 