### PR TITLE
Java 11 recipe no longer adds JDeprScan plugin

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -36,8 +36,6 @@ recipeList:
   - org.openrewrite.java.migrate.javax.AddJaxbDependencies
   - org.openrewrite.java.migrate.javax.AddJaxwsDependencies
   - org.openrewrite.java.migrate.javax.AddInjectDependencies
-  # Add jdeprscan plugin to a maven-based build.
-  - org.openrewrite.java.migrate.AddJDeprScanPlugin
   # Remediate deprecations
   - org.openrewrite.java.cleanup.BigDecimalRoundingConstantsToEnums
   - org.openrewrite.java.cleanup.PrimitiveWrapperClassConstructorToValueOf


### PR DESCRIPTION
By my estimation, the Java 11 recipe has outgrown this. A client could plausibly run this recipe and successfully migrate (replacing most relevant deprecations), and at that point, the additional plugin is just noise, which they'll likely want to remove later.

And for a user who does want to use jdeprscan, the syntax even without an explicitly-configured plugin is pretty concise:
```shell
mvn compile jdeprscan:jdeprscan -Drelease=11
```