### PR TITLE
build: update gradle wrapper to 7.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionSha256Sum=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright Â© 2015-2021 the original authors.
+# Copyright © 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
-#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
-#         * compound commands having a testable exit status, especially Â«caseÂ»;
-#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
+#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
+#         * compound commands having a testable exit status, especially «case»;
+#         * various built-in commands including «command», «set», and «ulimit».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
I generated this pull request using the wrapper itself

` ./gradlew wrapper --gradle-version 7.6`

I also configured the checksum verification as it was missing 

> 
> Here are the highlights of this release:
>  - Added support for Java 19.
>  - Introduced `--rerun` flag for individual task rerun.
>  - Improved dependency block for test suites to be strongly typed.
>  - Added a pluggable system for Java toolchains provisioning.
> 
> For more details see https://docs.gradle.org/7.6/release-notes.html

