### PR TITLE
Add UpgradeToJava20 recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-20.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-20.yml
@@ -1,0 +1,43 @@
+#
+# Copyright 2022 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.UpgradeToJava20
+displayName: Migrate to Java 20
+description: >
+  This recipe will apply changes commonly needed when migrating to Java 20. This recipe will also replace deprecated API
+  with equivalents when there is a clear migration strategy. Build files will also be updated to use Java 20 as the
+  target/source and plugins will be also be upgraded to versions that are compatible with Java 20.
+tags:
+  - java20
+  - lombok
+recipeList:
+  - org.openrewrite.java.migrate.UpgradeToJava17
+  - org.openrewrite.java.migrate.util.UseLocaleOf
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.JavaVersion20
+displayName: Change Maven Java version property values to 20
+description: Change maven.compiler.source and maven.compiler.target values to 20.
+tags:
+  - java20
+  - compiler
+recipeList:
+  - org.openrewrite.java.migrate.UpgradeJavaVersion:
+      version: 20
+  - org.openrewrite.java.migrate.maven.UseMavenCompilerPluginReleaseConfiguration:
+      releaseVersion: 20


### PR DESCRIPTION
Figured it could help to have a container for Java 20+ specific recipes, such as the [recently added UseLocaleOf](https://github.com/openrewrite/rewrite-migrate-java/commit/29364aef0f3626381b8981b0e4c5a3ffe9e0d9d3), and [the upcoming Replace URL constructor](https://github.com/openrewrite/rewrite-migrate-java/issues/191).