### PR TITLE
Update `UseTextBlocks` to return same tabs as prefix instead of convert it to whitespaces

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
+++ b/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
@@ -42,8 +42,8 @@ public class UseJavaUtilBase64 extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
         return Applicability.or(
-                new UsesType<>(sunPackage + ".BASE64Encoder"),
-                new UsesType<>(sunPackage + ".BASE64Decoder")
+                new UsesType<>(sunPackage + ".BASE64Encoder", false),
+                new UsesType<>(sunPackage + ".BASE64Decoder", false)
         );
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/codec/ApacheBase64ToJavaBase64.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/codec/ApacheBase64ToJavaBase64.java
@@ -52,7 +52,7 @@ public class ApacheBase64ToJavaBase64 extends Recipe {
 
     @Override
     protected UsesType<ExecutionContext> getSingleSourceApplicableTest() {
-        return new UsesType<>("org.apache.commons.codec.binary.Base64");
+        return new UsesType<>("org.apache.commons.codec.binary.Base64", false);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheFileUtilsToJavaFiles.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheFileUtilsToJavaFiles.java
@@ -47,7 +47,7 @@ public class ApacheFileUtilsToJavaFiles extends Recipe {
 
     @Override
     protected UsesType<ExecutionContext> getSingleSourceApplicableTest() {
-        return new UsesType<>("org.apache.commons.io.FileUtils");
+        return new UsesType<>("org.apache.commons.io.FileUtils", false);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheIOUtilsUseExplicitCharset.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheIOUtilsUseExplicitCharset.java
@@ -89,7 +89,7 @@ public class ApacheIOUtilsUseExplicitCharset extends Recipe {
 
     @Override
     protected UsesType<ExecutionContext> getSingleSourceApplicableTest() {
-        return new UsesType<>("org.apache.commons.io.IOUtils");
+        return new UsesType<>("org.apache.commons.io.IOUtils", false);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaCreateTempDir.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaCreateTempDir.java
@@ -54,7 +54,7 @@ public class NoGuavaCreateTempDir extends Recipe {
 
     @Override
     protected UsesType<ExecutionContext> getApplicableTest() {
-        return new UsesType<>("com.google.common.io.Files");
+        return new UsesType<>("com.google.common.io.Files", false);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
@@ -57,7 +57,7 @@ public class NoGuavaImmutableListOf extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
         return Applicability.and(new UsesJavaVersion<>(9),
-                new UsesType<>("com.google.common.collect.ImmutableList"));
+                new UsesType<>("com.google.common.collect.ImmutableList", false));
     }
 
     // Code is shared between `NoGuavaImmutableMapOf`, `NoGuavaImmutableListOf`, and `NoGuavaImmutableSetOf`.

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
@@ -57,7 +57,7 @@ public class NoGuavaImmutableMapOf extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
         return  Applicability.and(new UsesJavaVersion<>(9),
-                new UsesType<>("com.google.common.collect.ImmutableMap"));
+                new UsesType<>("com.google.common.collect.ImmutableMap", false));
     }
 
     // Code is shared between `NoGuavaImmutableMapOf`, `NoGuavaImmutableListOf`, and `NoGuavaImmutableSetOf`.

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
@@ -61,7 +61,7 @@ public class NoGuavaImmutableSetOf extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
         return Applicability.and(new UsesJavaVersion<>(9),
-                new UsesType<>("com.google.common.collect.ImmutableSet"));
+                new UsesType<>("com.google.common.collect.ImmutableSet", false));
     }
 
     // Code is shared between `NoGuavaImmutableMapOf`, `NoGuavaImmutableListOf`, and `NoGuavaImmutableSetOf`.

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -79,7 +79,6 @@ public class UseTextBlocks extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
-
             @Override
             public J visitBinary(J.Binary binary, ExecutionContext ctx) {
                 List<J.Literal> stringLiterals = new ArrayList<>();
@@ -201,12 +200,14 @@ public class UseTextBlocks extends Recipe {
 
     private static String getIndents(String concatenation, boolean useTabCharacter, int tabSize) {
         int[] tabAndSpaceCounts = shortestPrefixAfterNewline(concatenation, tabSize);
+        int tabCount = tabAndSpaceCounts[0];
+        int spaceCount = tabAndSpaceCounts[1];
         if (useTabCharacter) {
-            return StringUtils.repeat("\t", tabAndSpaceCounts[0]) +
-                   StringUtils.repeat(" ", tabAndSpaceCounts[1]);
+            return StringUtils.repeat("\t", tabCount) +
+                   StringUtils.repeat(" ", spaceCount);
         } else {
             // replace tab with spaces if the style is using spaces
-            return StringUtils.repeat(" ", tabAndSpaceCounts[0] * tabSize + tabAndSpaceCounts[1]);
+            return StringUtils.repeat(" ", tabCount * tabSize + spaceCount);
         }
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggerGlobalToGetGlobal.java
+++ b/src/main/java/org/openrewrite/java/migrate/logging/MigrateLoggerGlobalToGetGlobal.java
@@ -44,7 +44,7 @@ public class MigrateLoggerGlobalToGetGlobal extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
-        return new UsesType<>("java.util.logging.Logger");
+        return new UsesType<>("java.util.logging.Logger", false);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
@@ -53,7 +53,7 @@ public class LombokValToFinalVar extends Recipe {
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
         return Applicability.and(
 //                new UsesJavaVersion<>(11),
-                new UsesType<>(LOMBOK_VAL));
+                new UsesType<>(LOMBOK_VAL, false));
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/net/MigrateHttpURLConnectionHttpServerErrorToHttpInternalError.java
+++ b/src/main/java/org/openrewrite/java/migrate/net/MigrateHttpURLConnectionHttpServerErrorToHttpInternalError.java
@@ -51,7 +51,7 @@ public class MigrateHttpURLConnectionHttpServerErrorToHttpInternalError extends 
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
-        return new UsesType<>("java.net.HttpURLConnection");
+        return new UsesType<>("java.net.HttpURLConnection", false);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/search/AboutJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/search/AboutJavaVersion.java
@@ -60,7 +60,7 @@ public class AboutJavaVersion extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
-        return StringUtils.isBlank(whenUsesType) ? null : new UsesType<>(whenUsesType);
+        return StringUtils.isBlank(whenUsesType) ? null : new UsesType<>(whenUsesType, false);
     }
 
     @Override

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -18,10 +18,18 @@ package org.openrewrite.java.migrate.lang;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.style.TabsAndIndentsStyle;
+import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.Assertions.*;
 
 class UseTextBlocksTest implements RewriteTest {
@@ -309,7 +317,7 @@ class UseTextBlocksTest implements RewriteTest {
     }
 
     @Test
-    void indentationsWithTabs() {
+    void indentationsWithTabsOnly() {
         rewriteRun(
           //language=java
           java(
@@ -323,10 +331,77 @@ class UseTextBlocksTest implements RewriteTest {
             """
               class Test {
               	String query = \"""
-                          SELECT * FROM
-                          my_table
-                          WHERE something = 1;
-                          \""";
+              			SELECT * FROM
+              			my_table
+              			WHERE something = 1;
+              			\""";
+              }
+              """
+          )
+        );
+    }
+
+    private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with, int tabSize) {
+        return spec -> spec.recipe(new UseTextBlocks())
+          .parser(JavaParser.fromJavaVersion().styles(singletonList(
+            new NamedStyles(
+              randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is 1", emptySet(),
+              singletonList(with.apply(buildTabsAndIndents(1)))
+            )
+          )));
+    }
+
+    private static TabsAndIndentsStyle buildTabsAndIndents(int tabSize) {
+        return new TabsAndIndentsStyle(true, tabSize, tabSize, tabSize * 2, false,
+          new TabsAndIndentsStyle.MethodDeclarationParameters(true));
+    }
+
+    @Test
+    void indentationsWithTabsOnlyAndTabSizeIs1() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true), 1),
+          //language=java
+          java(
+            """
+              class Test {
+              	String query = "SELECT * FROM\\n" +
+              			"my_table\\n" +
+              			"WHERE something = 1;\\n";
+              }
+              """,
+            """
+              class Test {
+              	String query = \"""
+              			SELECT * FROM
+              			my_table
+              			WHERE something = 1;
+              			\""";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void indentationsWithTabsAndWhitespacesCombined() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true), 8),
+          //language=java
+          java(
+            """
+              class Test {
+              	String query = "SELECT * FROM\\n" +
+              			    "my_table\\n" +
+              			    "WHERE something = 1;\\n";
+              }
+              """,
+            """
+              class Test {
+              	String query = \"""
+              			    SELECT * FROM
+              			    my_table
+              			    WHERE something = 1;
+              			    \""";
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -342,11 +342,10 @@ class UseTextBlocksTest implements RewriteTest {
     }
 
     private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with, int tabSize) {
-        return spec -> spec.recipe(new UseTextBlocks())
-          .parser(JavaParser.fromJavaVersion().styles(singletonList(
+        return spec -> spec.parser(JavaParser.fromJavaVersion().styles(singletonList(
             new NamedStyles(
               randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is 1", emptySet(),
-              singletonList(with.apply(buildTabsAndIndents(1)))
+              singletonList(with.apply(buildTabsAndIndents(tabSize)))
             )
           )));
     }

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -319,6 +319,7 @@ class UseTextBlocksTest implements RewriteTest {
     @Test
     void indentationsWithTabsOnly() {
         rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true), 4),
           //language=java
           java(
             """
@@ -335,6 +336,32 @@ class UseTextBlocksTest implements RewriteTest {
               			my_table
               			WHERE something = 1;
               			\""";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void indentationsWithTabsOnlyAndReplaceToSpaces() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(false), 4),
+          //language=java
+          java(
+            """
+              class Test {
+              	String query = "SELECT * FROM\\n" +
+              			"my_table\\n" +
+              			"WHERE something = 1;\\n";
+              }
+              """,
+            """
+              class Test {
+              	String query = \"""
+                          SELECT * FROM
+                          my_table
+                          WHERE something = 1;
+                          \""";
               }
               """
           )
@@ -344,7 +371,7 @@ class UseTextBlocksTest implements RewriteTest {
     private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with, int tabSize) {
         return spec -> spec.parser(JavaParser.fromJavaVersion().styles(singletonList(
             new NamedStyles(
-              randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is 1", emptySet(),
+              randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is x", emptySet(),
               singletonList(with.apply(buildTabsAndIndents(tabSize)))
             )
           )));
@@ -353,32 +380,6 @@ class UseTextBlocksTest implements RewriteTest {
     private static TabsAndIndentsStyle buildTabsAndIndents(int tabSize) {
         return new TabsAndIndentsStyle(true, tabSize, tabSize, tabSize * 2, false,
           new TabsAndIndentsStyle.MethodDeclarationParameters(true));
-    }
-
-    @Test
-    void indentationsWithTabsOnlyAndTabSizeIs1() {
-        rewriteRun(
-          tabsAndIndents(style -> style.withUseTabCharacter(true), 1),
-          //language=java
-          java(
-            """
-              class Test {
-              	String query = "SELECT * FROM\\n" +
-              			"my_table\\n" +
-              			"WHERE something = 1;\\n";
-              }
-              """,
-            """
-              class Test {
-              	String query = \"""
-              			SELECT * FROM
-              			my_table
-              			WHERE something = 1;
-              			\""";
-              }
-              """
-          )
-        );
     }
 
     @Test


### PR DESCRIPTION
This PR is to fix not aligned indentations cases.
Before the change, it converts the tab to whitespaces by multiple the tab count to `TabsAndIndentsStyle. getTabSize()`.
This PR changed to determine the replacement of tab/space from autoDetect `TabsAndIndentsStyle`.
If the style is using tabs, then replace all tabs with `tabSize` spaces, otherwise, keep them unchanged.


an example under-indenting case, after this change, the prefix tabs will keep unchanged.
![image (2)](https://user-images.githubusercontent.com/122563761/228077124-26d209a2-3ba4-4398-923e-6f6df44398b9.png)

This PR integrated the latest rewrite version as well (UseType changes).
