### PR TITLE
Update `UpgradeJavaVersion` to support more case of maven java version upgrade

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UpgradeJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/UpgradeJavaVersion.java
@@ -26,11 +26,15 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.search.FindTags;
 import org.openrewrite.xml.tree.Xml;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Value
@@ -117,22 +121,41 @@ public class UpgradeJavaVersion extends Recipe {
         }
     }
 
+    private static final List<String> JAVA_VERSION_XPATHS = Arrays.asList(
+        "/project/properties/java.version",
+        "/project/properties/jdk.version",
+        "/project/properties/javaVersion",
+        "/project/properties/jdkVersion",
+        "/project/properties/maven.compiler.source",
+        "/project/properties/maven.compiler.target",
+        "/project/properties/maven.compiler.release",
+        "/project/build/plugins/plugin[artifactId='maven-compiler-plugin']/configuration/source",
+        "/project/build/plugins/plugin[artifactId='maven-compiler-plugin']/configuration/target",
+        "/project/build/plugins/plugin[artifactId='maven-compiler-plugin']/configuration/release");
+
+    private static final List<XPathMatcher> JAVA_VERSION_XPATH_MATCHERS =
+        JAVA_VERSION_XPATHS.stream().map(XPathMatcher::new).collect(Collectors.toList());
+
+
     private class MavenUpdateJavaVersionVisitor extends MavenVisitor<ExecutionContext> {
         @Override
         public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
-            Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
-            if (!isPropertyTag()) {
-                return t;
+            tag = (Xml.Tag) super.visitTag(tag, ctx);
+
+            if (JAVA_VERSION_XPATH_MATCHERS.stream().anyMatch(matcher -> matcher.matches(getCursor()))) {
+                Optional<Float> maybeVersion = tag.getValue().map(Float::parseFloat);
+                if (!maybeVersion.isPresent()) {
+                    SearchResult.found(tag, "Attempted to update to Java version to " + version
+                                               + "  but was unsuccessful, please update manually");
+                }
+                float currentVersion = maybeVersion.get();
+                if (currentVersion >= version) {
+                    return tag;
+                }
+                return tag.withValue(String.valueOf(version));
             }
-            if (!"java.version".equals(t.getName()) && !"maven.compiler.source".equals(t.getName()) && !"maven.compiler.target".equals(t.getName()) ||
-                (tag.getValue().isPresent() && tag.getValue().get().startsWith("${"))) {
-                return t;
-            }
-            float value = tag.getValue().map(Float::parseFloat).orElse(0f);
-            if (value >= version) {
-                return t;
-            }
-            return t.withValue(String.valueOf(version));
+
+            return tag;
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/UpgradeJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/UpgradeJavaVersion.java
@@ -143,10 +143,18 @@ public class UpgradeJavaVersion extends Recipe {
             tag = (Xml.Tag) super.visitTag(tag, ctx);
 
             if (JAVA_VERSION_XPATH_MATCHERS.stream().anyMatch(matcher -> matcher.matches(getCursor()))) {
-                Optional<Float> maybeVersion = tag.getValue().map(Float::parseFloat);
+                Optional<Float> maybeVersion = tag.getValue().flatMap(
+                    value -> {
+                        try {
+                            return Optional.of(Float.parseFloat(value));
+                        } catch (NumberFormatException e) {
+                            return Optional.empty();
+                        }
+                    }
+                );
+
                 if (!maybeVersion.isPresent()) {
-                    SearchResult.found(tag, "Attempted to update to Java version to " + version
-                                               + "  but was unsuccessful, please update manually");
+                    return tag;
                 }
                 float currentVersion = maybeVersion.get();
                 if (currentVersion >= version) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -116,11 +116,12 @@ public class UseTextBlocks extends Recipe {
                 }
 
                 StringBuilder sb = new StringBuilder();
-
+                StringBuilder originalContent = new StringBuilder();
                 stringLiterals = stringLiterals.stream().filter(s -> !s.getValue().toString().isEmpty()).collect(Collectors.toList());
                 for (int i = 0; i < stringLiterals.size(); i++) {
                     String s = stringLiterals.get(i).getValue().toString();
                     sb.append(s);
+                    originalContent.append(s);
                     if (i != stringLiterals.size() - 1) {
                         String nextLine = stringLiterals.get(i + 1).getValue().toString();
                         char nextChar = nextLine.charAt(0);
@@ -152,7 +153,7 @@ public class UseTextBlocks extends Recipe {
                     content = content + "\\\n" + indentation;
                 }
 
-                return new J.Literal(randomId(), binary.getPrefix(), Markers.EMPTY, content,
+                return new J.Literal(randomId(), binary.getPrefix(), Markers.EMPTY, originalContent.toString(),
                     String.format("\"\"\"%s\"\"\"", content), null, JavaType.Primitive.String);
             }
         };

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeJavaVersionTest.java
@@ -29,7 +29,7 @@ import static org.openrewrite.maven.Assertions.pomXml;
 class UpgradeJavaVersionTest implements RewriteTest {
 
     @Test
-    void mavenUpgradeFromJava8ToJava17() {
+    void mavenUpgradeFromJava8ToJava17ViaProperties() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeJavaVersion(17)),
           //language=xml
@@ -62,6 +62,56 @@ class UpgradeJavaVersionTest implements RewriteTest {
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void mavenUpgradeFromJava8ToJava17ViaConfiguration() {
+        //language=xml
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeJavaVersion(17)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.8.0</version>
+                      <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                      </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.8.0</version>
+                      <configuration>
+                        <source>17</source>
+                        <target>17</target>
+                      </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
               </project>
               """
           )


### PR DESCRIPTION
This PR is to address the comment [here](https://github.com/openrewrite/rewrite-migrate-java/commit/2ca989a44b8088603a041d41eba54b41816ac21b#r109777249)

to support another couple of maven java version formats we'd want to support.

This PR depends on https://github.com/openrewrite/rewrite/pull/3145 to update `XPathMatcher` to support the conditional tag.