### PR TITLE
Add simple Refaster-based example recipe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,9 @@ dependencies {
     testImplementation("org.projectlombok:lombok:latest.release")
 
     annotationProcessor("org.openrewrite:rewrite-templating:latest.integration")
+    implementation("com.google.errorprone:error_prone_core:2.10.0:with-dependencies") {
+        exclude("com.google.auto.service", "auto-service-annotations")
+    }
 
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
     implementation("org.openrewrite:rewrite-java")
@@ -45,9 +48,9 @@ dependencies {
     testImplementation("org.apache.maven.shared:maven-shared-utils:3.+")
 
     testRuntimeOnly("commons-io:commons-io:2.+")
-    testRuntimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr353:latest.release")
-    testRuntimeOnly("com.fasterxml.jackson.core:jackson-core:latest.release")
-    testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind:latest.release")
+    testRuntimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr353")
+    testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
+    testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
     testRuntimeOnly(gradleApi())
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseStringIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseStringIsEmpty.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+public class UseStringIsEmpty {
+    @BeforeTemplate
+    boolean before(String s) {
+        return s.length() > 0;
+    }
+
+    @AfterTemplate
+    boolean after(String s) {
+        return !s.isEmpty();
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseStringIsEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseStringIsEmptyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UseStringIsEmptyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UseStringIsEmptyRecipe());
+    }
+
+    @Test
+    void lengthGreaterZero() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void m(String s) {
+                      boolean b = s.length() > 0;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void m(String s) {
+                      boolean b = !s.isEmpty();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void lengthGreaterOne() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void m(String s) {
+                      boolean b = s.length() > 1;
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
This is for demo purposes: A new `UseStringIsEmpty` recipe replacing `str.length() > 0` with `!str.isEmpty()`.

Issue: openrewrite/rewrite#3110