### PR TITLE
Fix escaping bugs in UseTextBlocks

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -142,6 +142,7 @@ public class UseTextBlocks extends Recipe {
 
                 boolean isEndsWithNewLine = content.endsWith("\n");
                 content = content.replace("\\", "\\\\"); // Escape backslashes
+                content = content.replace("\"\"\"", "\"\"\\\""); // Escape triple quotes
                 content = content.replace(" \n", "\\s\n");
                 content = content.replace("\n", "\n" + indentation);
                 content = content.replace(passPhrase, "\\\n" + indentation);

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -141,6 +141,7 @@ public class UseTextBlocks extends Recipe {
                 String indentation = getIndents(concatenation.toString(), useTab, tabSize);
 
                 boolean isEndsWithNewLine = content.endsWith("\n");
+                content = content.replace("\\", "\\\\"); // Escape backslashes
                 content = content.replace(" \n", "\\s\n");
                 content = content.replace("\n", "\n" + indentation);
                 content = content.replace(passPhrase, "\\\n" + indentation);

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -141,10 +141,20 @@ public class UseTextBlocks extends Recipe {
                 String indentation = getIndents(concatenation.toString(), useTab, tabSize);
 
                 boolean isEndsWithNewLine = content.endsWith("\n");
-                content = content.replace("\\", "\\\\"); // Escape backslashes
-                content = content.replace("\"\"\"", "\"\"\\\""); // Escape triple quotes
+
+                // references:
+                //  - https://docs.oracle.com/en/java/javase/14/docs/specs/text-blocks-jls.html
+                //  - https://javaalmanac.io/features/textblocks/
+
+                // escape backslashes
+                content = content.replace("\\", "\\\\");
+                // escape triple quotes
+                content = content.replace("\"\"\"", "\"\"\\\"");
+                // preserve trailing spaces
                 content = content.replace(" \n", "\\s\n");
+                // handle preceding indentation
                 content = content.replace("\n", "\n" + indentation);
+                // handle line continuations
                 content = content.replace(passPhrase, "\\\n" + indentation);
 
                 // add first line

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -150,7 +150,8 @@ public class UseTextBlocks extends Recipe {
                 // add first line
                 content = "\n" + indentation + content;
 
-                // add last line to ensure the closing delimiter is in a new line to manage indentation
+                // add last line to ensure the closing delimiter is in a new line to manage indentation & remove the
+                // need to escape ending quote in the content
                 if (!isEndsWithNewLine) {
                     content = content + "\\\n" + indentation;
                 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -562,6 +562,87 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
+    /**
+     * Single escaping a quote in a string literal provides: " -> \"
+     * <p>
+     * On converting this to a text block, we can let go of the escaping for the double quote: \" -> "
+     */
+    @Test
+    void singleEscapedQuote() {
+        rewriteRun(
+          //language=java
+          java(
+            // Before:
+            // String json = "{" +
+            //               "\"key\": \"value\"" +
+            //               "}";
+            """
+              class Test {
+                  String json = "{" +
+                                "\\"key\\": \\"value\\"" +
+                                "}";
+              }
+              """,
+            // After:
+            // String json = """
+            //               {\
+            //               "key": "value"\
+            //               }\
+            //               """;
+            """
+              class Test {
+                  String json = ""\"
+                                {\\
+                                "key": "value"\\
+                                }\\
+                                ""\";
+              }
+              """
+          )
+        );
+    }
+
+    /**
+     * Double escaping a quote in a string literal provides: " -> \" -> \\\"
+     * <p>
+     * On converting this to a text block, the escaped backslash should remain, but we can let go of the
+     * escaping for the double quote: \\\" -> \\"
+     */
+    @Test
+    void doubleEscapedQuote() {
+        rewriteRun(
+          //language=java
+          java(
+            // Before:
+            // String stringifiedJson = "{" +
+            //                          "\\\"key\\\": \\\"value\\\"" +
+            //                          "}";
+            """
+              class Test {
+                  String stringifiedJson = "{" +
+                                           "\\\\\\"key\\\\\\": \\\\\\"value\\\\\\"" +
+                                           "}";
+              }
+              """,
+            // After:
+            // String stringifiedJson = """
+            //                          {\
+            //                          \\"key\\": \\"value\\"\
+            //                          }\
+            //                          """;
+            """
+              class Test {
+                  String stringifiedJson = ""\"
+                                           {\\
+                                           \\\\"key\\\\": \\\\"value\\\\"\\
+                                           }\\
+                                           ""\";
+              }
+              """
+          )
+        );
+    }
+
     @Disabled
     @Test
     void grouping() {

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -643,6 +643,50 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
+    /**
+     * Triple quotes in a string literal are escaped as: """ -> \"\"\"
+     * <p>
+     * On converting this to a text block, only one of the quotes needs to be escaped: \"\"\" -> ""\"
+     */
+    @Test
+    void tripleQuotes() {
+        rewriteRun(
+          //language=java
+          java(
+            // Before:
+            // String myFaceInASCII = "\"\"\"\"\"\"\"\"\n" +
+            //                        "| o  o |\n" +
+            //                        "|  ==  |\n" +
+            //                        "\\------/\n";
+            """
+              class Test {
+                  String myFaceInASCII = "\\"\\"\\"\\"\\"\\"\\"\\"\\n" +
+                                         "| o  o |\\n" +
+                                         "|  ==  |\\n" +
+                                         "\\\\------/\\n";
+              }
+              """,
+            // After:
+            // String myFaceInASCII = """
+            //                        ""\"""\"""
+            //                        | o  o |
+            //                        |  ==  |
+            //                        \\------/
+            //                        """;
+            """
+              class Test {
+                  String myFaceInASCII = ""\"
+                                         ""\\""\"\\""\"
+                                         | o  o |
+                                         |  ==  |
+                                         \\\\------/
+                                         ""\";
+              }
+              """
+          )
+        );
+    }
+
     @Disabled
     @Test
     void grouping() {

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -687,6 +687,52 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
+    /**
+     * Quote in a string literal is escaped as: " -> \"
+     * <p>
+     * On converting this to a text block, it needs to be escaped if it is the last character:
+     * <pre>
+     *             """
+     * "test\"" -> test\""""
+     * </pre>
+     * However, this is not required in case we use the newline escape (\) to put the ending delimiter on the next line:
+     * <pre>
+     *             """
+     * "test\"" -> test"\
+     *             """
+     * </pre>
+     */
+    @Test
+    void endingQuote() {
+        rewriteRun(
+          //language=java
+          java(
+            // Before:
+            // String myPlay = "Alice: \"Hi Bob!\"\n" +
+            //                 "Bob: \"Don't use plaintext Alice!\"";
+            """
+              class Test {
+                  String myPlay = "Alice: \\"Hi Bob!\\"\\n" +
+                                  "Bob: \\"Don't use plaintext Alice!\\"";
+              }
+              """,
+            // After:
+            // String myPlay = """
+            //                 Alice: "Hi Bob!"
+            //                 Bob: "Don't use plaintext Alice!"\
+            //                 """;
+            """
+              class Test {
+                  String myPlay = ""\"
+                                  Alice: "Hi Bob!"
+                                  Bob: "Don't use plaintext Alice!"\\
+                                  ""\";
+              }
+              """
+          )
+        );
+    }
+
     @Disabled
     @Test
     void grouping() {


### PR DESCRIPTION
I recently happened upon this amazing project, kudos to all involved, I absolutely love the idea and implementation! I decided to use it for one of my projects, and it worked very well except for some minor cases, for which I decided to submit fixes:
- Backslashes are not escaped properly, for example in case of a double escaped quote
- Triple quotes are not escaped properly
- Added a test for the special case of ending quote as well for completion

Thanks again for making this wonderful project, let me know if any further changes required here!