### PR TITLE
Add Gradle AddDependency/RemoveDependency

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -76,6 +76,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.activation.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.activation
+      artifactId: jakarta.activation-api
+      version: latest.release
+      onlyIfUsing: javax.activation.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.activation
       artifactId: jakarta.activation-api
@@ -85,6 +90,9 @@ recipeList:
       newPackageName: jakarta.activation
       recursive: true
   - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.activation
+      artifactId: javax.activation-api
+  - org.openrewrite.gradle.RemoveDependency:
       groupId: javax.activation
       artifactId: javax.activation-api
 
@@ -104,12 +112,20 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.annotation..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api
+      version: latest.release
+      onlyIfUsing: javax.annotation..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.annotation
       artifactId: jakarta.annotation-api
       newVersion: latest.release
   - org.openrewrite.java.migrate.jakarta.ChangeJavaxAnnotationToJakarta
   - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.annotation
+      artifactId: javax.annotation-api
+  - org.openrewrite.gradle.RemoveDependency:
       groupId: javax.annotation
       artifactId: javax.annotation-api
 
@@ -220,6 +236,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.security.auth.message..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.authentication
+      artifactId: jakarta.authentication-api
+      version: latest.release
+      onlyIfUsing: javax.authentication.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.authentication
       artifactId: jakarta.authentication-api
@@ -229,6 +250,9 @@ recipeList:
       newPackageName: jakarta.security.auth.message
       recursive: true
   - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.security.auth.message
+      artifactId: javax.security.auth.message-api
+  - org.openrewrite.gradle.RemoveDependency:
       groupId: javax.security.auth.message
       artifactId: javax.security.auth.message-api
 
@@ -250,6 +274,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.security.jacc..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.authorization
+      artifactId: jakarta.authorization-api
+      version: latest.release
+      onlyIfUsing: javax.security.jacc..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.authorization
       artifactId: jakarta.authorization-api
@@ -259,6 +288,9 @@ recipeList:
       newPackageName: jakarta.security.jacc
       recursive: true
   - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.security.jacc
+      artifactId: javax.security.jacc-api
+  - org.openrewrite.gradle.RemoveDependency:
       groupId: javax.security.jacc
       artifactId: javax.security.jacc-api
 
@@ -279,6 +311,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.batch..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.batch
+      artifactId: jakarta.batch-api
+      version: latest.release
+      onlyIfUsing: javax.batch.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.batch
       artifactId: jakarta.batch-api
@@ -290,7 +327,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.batch
       artifactId: javax.batch-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.batch
+      artifactId: javax.batch-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxValidationMigrationToJakartaValidation
@@ -308,6 +347,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.validation..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.validation
+      artifactId: jakarta.validation-api
+      version: latest.release
+      onlyIfUsing: javax.validation.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.validation
       artifactId: jakarta.validation-api
@@ -319,7 +363,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.validation
       artifactId: validation-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.validation
+      artifactId: validation-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxDecoratorToJakartaDecorator
@@ -332,6 +378,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.decorator.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.enterprise
+      artifactId: jakarta.enterprise.cdi-api
+      version: latest.release
+      onlyIfUsing: javax.decorator.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.enterprise
       artifactId: jakarta.enterprise.cdi-api
@@ -343,7 +394,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.enterprise
       artifactId: cdi-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.enterprise
+      artifactId: cdi-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxEjbToJakartaEjb
@@ -356,6 +409,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.ejb.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.inject
+      artifactId: jakarta.ejb-api
+      version: latest.release
+      onlyIfUsing: javax.ejb.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.ejb
       artifactId: jakarta.ejb-api
@@ -367,7 +425,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.ejb
       artifactId: javax.ejb-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.ejb
+      artifactId: javax.ejb-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxElToJakartaEl
@@ -380,6 +440,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.el.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.inject
+      artifactId: jakarta.el-api
+      version: latest.release
+      onlyIfUsing: javax.el.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.el
       artifactId: jakarta.el-api
@@ -391,7 +456,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.el
       artifactId: javax.el-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.el
+      artifactId: javax.el-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxEnterpriseToJakartaEnterprise
@@ -404,6 +471,11 @@ recipeList:
       version: 3.0.1
       onlyIfUsing: javax.enterprise.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.inject
+      artifactId: jakarta.enterprise.cdi-api
+      version: 3.0.1
+      onlyIfUsing: javax.enterprise.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.enterprise
       artifactId: jakarta.enterprise.cdi-api
@@ -415,7 +487,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.enterprise
       artifactId: cdi-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.enterprise
+      artifactId: cdi-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxFacesToJakartaFaces
@@ -428,6 +502,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.faces.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.faces
+      artifactId: jakarta.faces-api
+      version: latest.release
+      onlyIfUsing: javax.faces.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.faces
       artifactId: jakarta.faces-api
@@ -442,7 +521,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: org.glassfish
       artifactId: javax.faces
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: org.glassfish
+      artifactId: javax.faces
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxInjectMigrationToJakartaInject
@@ -460,6 +541,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.inject.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.inject
+      artifactId: jakarta.inject-api
+      version: latest.release
+      onlyIfUsing: javax.inject.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.inject
       artifactId: jakarta.inject-api
@@ -471,7 +557,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.inject
       artifactId: javax.inject-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.inject
+      artifactId: javax.inject-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxInterceptorToJakartaInterceptor
@@ -484,6 +572,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.interceptor.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.interceptor
+      artifactId: jakarta.interceptor-api
+      version: latest.release
+      onlyIfUsing: javax.interceptor.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.interceptor
       artifactId: jakarta.interceptor-api
@@ -495,7 +588,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.interceptor
       artifactId: javax.interceptor-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.interceptor
+      artifactId: javax.interceptor-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxJmsToJakartaJms
@@ -508,6 +603,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.jms.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.jms
+      artifactId: jakarta.jms-api
+      version: latest.release
+      onlyIfUsing: javax.jms.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.jms
       artifactId: jakarta.jms-api
@@ -519,7 +619,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.jms
       artifactId: javax.jms-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.jms
+      artifactId: javax.jms-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxJsonToJakartaJson
@@ -532,6 +634,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.json.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.json
+      artifactId: jakarta.json-api
+      version: latest.release
+      onlyIfUsing: javax.json.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.json
       artifactId: jakarta.json-api
@@ -543,7 +650,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.json
       artifactId: javax.json-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.json
+      artifactId: javax.json-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxJwsToJakartaJws
@@ -556,6 +665,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.jws.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.jws
+      artifactId: jakarta.jws-api
+      version: latest.release
+      onlyIfUsing: javax.jws.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.jws
       artifactId: jakarta.jws-api
@@ -567,7 +681,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.jws
       artifactId: javax.jws-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.jws
+      artifactId: javax.jws-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxMailToJakartaMail
@@ -580,6 +696,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.mail.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.mail
+      artifactId: jakarta.mail-api
+      version: latest.release
+      onlyIfUsing: javax.mail.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.mail
       artifactId: jakarta.mail-api
@@ -591,7 +712,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.mail
       artifactId: javax.mail-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.mail
+      artifactId: javax.mail-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxPersistenceToJakartaPersistence
@@ -604,6 +727,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.persistence.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.persistence
+      artifactId: jakarta.persistence-api
+      version: latest.release
+      onlyIfUsing: javax.persistence.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.persistence
       artifactId: jakarta.persistence-api
@@ -618,7 +746,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: org.eclipse.persistence
       artifactId: javax.persistence
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: org.eclipse.persistence
+      artifactId: javax.persistence
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxResourceToJakartaResource
@@ -631,6 +761,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.resource.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.resource
+      artifactId: jakarta.resource-api
+      version: latest.release
+      onlyIfUsing: javax.resource.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.resource
       artifactId: jakarta.resource-api
@@ -642,7 +777,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.resource
       artifactId: javax.resource-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.resource
+      artifactId: javax.resource-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxSecurityToJakartaSecurity
@@ -655,6 +792,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.security.enterprise..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.security.enterprise
+      artifactId: jakarta.security.enterprise-api
+      version: latest.release
+      onlyIfUsing: javax.security.enterprise..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.security.enterprise
       artifactId: jakarta.security.enterprise-api
@@ -666,7 +808,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.security.enterprise
       artifactId: javax.security.enterprise-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.security.enterprise
+      artifactId: javax.security.enterprise-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxServletToJakartaServlet
@@ -703,7 +847,12 @@ recipeList:
       version: 6.x
       onlyIfUsing: javax.servlet.*
       acceptTransitive: true
-
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.servlet
+      artifactId: jakarta.servlet-api
+      version: 6.x
+      onlyIfUsing: javax.servlet.*
+      configuration: implementation
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxTransactionMigrationToJakartaTransaction
@@ -721,6 +870,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.transaction.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.transaction
+      artifactId: jakarta.transaction-api
+      version: latest.release
+      onlyIfUsing: javax.transaction.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.transaction
       artifactId: jakarta.transaction-api
@@ -732,7 +886,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.transaction
       artifactId: javax.transaction-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.transaction
+      artifactId: javax.transaction-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxWebsocketToJakartaWebsocket
@@ -745,6 +901,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.websocket.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.websocket
+      artifactId: jakarta.websocket-api
+      version: latest.release
+      onlyIfUsing: javax.websocket.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.websocket
       artifactId: jakarta.websocket-api
@@ -756,7 +917,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.websocket
       artifactId: javax.websocket-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.websocket
+      artifactId: javax.websocket-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxWsToJakartaWs
@@ -769,6 +932,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.ws.rs.*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.ws.rs
+      artifactId: jakarta.ws.rs-api
+      version: latest.release
+      onlyIfUsing: javax.ws.rs.*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.ws.rs
       artifactId: jakarta.ws.rs-api
@@ -780,7 +948,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.ws.rs
       artifactId: javax.ws.rs-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.ws.rs
+      artifactId: javax.ws.rs-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxXmlBindMigrationToJakartaXmlBind
@@ -798,6 +968,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.xml.bind..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.xml.bind
+      artifactId: jakarta.xml.bind-api
+      version: latest.release
+      onlyIfUsing: javax.xml.bind..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.xml.bind
       artifactId: jakarta.xml.bind-api
@@ -809,6 +984,11 @@ recipeList:
       scope: runtime
       onlyIfUsing: javax.xml.bind..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: org.glassfish.jaxb
+      artifactId: jaxb-runtime
+      version: latest.release
+      onlyIfUsing: javax.xml.bind..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.glassfish.jaxb
       artifactId: jaxb-runtime
@@ -823,7 +1003,12 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: com.sun.xml.bind
       artifactId: jaxb-impl
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.xml.bind
+      artifactId: jaxb-api
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: com.sun.xml.bind
+      artifactId: jaxb-impl
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxXmlSoapToJakartaXmlSoap
@@ -836,6 +1021,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.xml.soap..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.xml.soap
+      artifactId: jakarta.xml.soap-api
+      version: latest.release
+      onlyIfUsing: javax.xml.soap..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.xml.soap
       artifactId: jakarta.xml.soap-api
@@ -845,6 +1035,9 @@ recipeList:
       newPackageName: jakarta.xml.soap
       recursive: true
   - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.xml.soap
+      artifactId: javax.xml.soap-api
+  - org.openrewrite.gradle.RemoveDependency:
       groupId: javax.xml.soap
       artifactId: javax.xml.soap-api
 
@@ -865,6 +1058,11 @@ recipeList:
       version: latest.release
       onlyIfUsing: javax.xml.ws..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: jakarta.xml.ws
+      artifactId: jakarta.xml.ws-api
+      version: latest.release
+      onlyIfUsing: javax.xml.ws..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.xml.ws
       artifactId: jakarta.xml.ws-api
@@ -876,6 +1074,11 @@ recipeList:
       scope: runtime
       onlyIfUsing: javax.xml.ws..*
       acceptTransitive: true
+  - org.openrewrite.gradle.AddDependency:
+      groupId: com.sun.xml.ws
+      artifactId: jaxws-rt
+      version: latest.release
+      onlyIfUsing: javax.xml.ws..*
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: com.sun.xml.ws
       artifactId: jaxws-rt
@@ -887,7 +1090,9 @@ recipeList:
   - org.openrewrite.maven.RemoveDependency:
       groupId: javax.xml.ws
       artifactId: jaxws-api
-
+  - org.openrewrite.gradle.RemoveDependency:
+      groupId: javax.xml.ws
+      artifactId: jaxws-api
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxPersistenceXmlToJakartaPersistenceXml


### PR DESCRIPTION
This adds a Gradle AddDependency/RemoveDependency for the same artifacts that was already done for Maven. This way the recipe doesn't leave broken builds.