### PR TITLE
Prefer Objects.requireNonNull and StandardCharsets over Guava

### DIFF
--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -186,10 +186,10 @@ recipeList:
       methodPattern: com.google.common.base.Preconditions checkNotNull(Object)
       newMethodName: requireNonNull
   - org.openrewrite.java.ChangeMethodTargetToStatic:
-      methodPattern: com.google.common.base.Preconditions checkNotNull(Object)
+      methodPattern: com.google.common.base.Preconditions requireNonNull(Object)
       fullyQualifiedTargetTypeName: java.util.Objects
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.google.common.base.Preconditions checkNotNull(Object, String)
+      methodPattern: com.google.common.base.Preconditions requireNonNull(Object, String)
       newMethodName: requireNonNull
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: com.google.common.base.Preconditions checkNotNull(Object, String)

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -188,12 +188,6 @@ recipeList:
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: com.google.common.base.Preconditions requireNonNull(Object)
       fullyQualifiedTargetTypeName: java.util.Objects
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.google.common.base.Preconditions requireNonNull(Object, String)
-      newMethodName: requireNonNull
-  - org.openrewrite.java.ChangeMethodTargetToStatic:
-      methodPattern: com.google.common.base.Preconditions checkNotNull(Object, String)
-      fullyQualifiedTargetTypeName: java.util.Objects
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -32,12 +32,14 @@ recipeList:
   - org.openrewrite.java.migrate.guava.NoGuavaSetsNewHashSet
   - org.openrewrite.java.migrate.guava.NoGuavaSetsNewConcurrentHashSet
   - org.openrewrite.java.migrate.guava.NoGuavaSetsNewLinkedHashSet
+  - org.openrewrite.java.migrate.guava.PreferJavaNioCharsetStandardCharsets
   - org.openrewrite.java.migrate.guava.PreferJavaUtilOptional
   - org.openrewrite.java.migrate.guava.PreferJavaUtilFunction
   - org.openrewrite.java.migrate.guava.PreferJavaUtilPredicate
   - org.openrewrite.java.migrate.guava.PreferJavaUtilSupplier
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsEquals
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsHashCode
+  - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNull
   - org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsUnmodifiableNavigableMap
   - org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsSynchronizedNavigableMap
   - org.openrewrite.java.migrate.guava.PreferCharCompare
@@ -58,6 +60,18 @@ recipeList:
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableListOf
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableMapOf
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableSetOf
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.guava.PreferJavaNioCharsetStandardCharsets
+displayName: Prefer `java.nio.charset.StandardCharsets`
+description: Prefer `java.nio.charset.StandardCharsets` instead of using `com.google.common.base.Charsets`.
+tags:
+  - guava
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.google.common.base.Charsets
+      newFullyQualifiedTypeName: java.nio.charset.StandardCharsets
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -158,6 +172,27 @@ recipeList:
       newMethodName: hash
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: com.google.common.base.Objects hash(..)
+      fullyQualifiedTargetTypeName: java.util.Objects
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNull
+displayName: Prefer `java.util.Objects#requireNonNull`
+description: Prefer `java.util.Objects#requireNonNull` instead of using `com.google.common.base.Preconditions#checkNotNull`.
+tags:
+  - guava
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.google.common.base.Preconditions checkNotNull(Object)
+      newMethodName: requireNonNull
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: com.google.common.base.Preconditions checkNotNull(Object)
+      fullyQualifiedTargetTypeName: java.util.Objects
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.google.common.base.Preconditions checkNotNull(Object, String)
+      newMethodName: requireNonNull
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: com.google.common.base.Preconditions checkNotNull(Object, String)
       fullyQualifiedTargetTypeName: java.util.Objects
 
 ---

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class PreferJavaUtilObjectsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(
+            Environment.builder()
+              .scanRuntimeClasspath("org.openrewrite.java.migrate.guava")
+              .build()
+              .activateRecipes("org.openrewrite.java.migrate.guava.NoGuava")
+          )
+          .parser(JavaParser.fromJavaVersion().classpath("rewrite-java", "guava"));
+    }
+
+    @DocumentExample
+    @Test
+    void preconditionsCheckNotNullToObjectsRequireNonNull() {
+        //language=java
+        rewriteRun(java("""
+          import com.google.common.base.Preconditions;
+
+          class A {
+              Object foo(Object obj) {
+                  return Preconditions.checkNotNull(obj);
+              }
+          }
+          """, """
+          import java.util.Objects;
+
+          class A {
+              Object foo(Object obj) {
+                  return Objects.requireNonNull(obj);
+              }
+          }
+          """));
+    }
+
+    @Test
+    void preconditionsCheckNotNullToObjectsRequireNonNullStatic() {
+        //language=java
+        rewriteRun(java("""
+          import static com.google.common.base.Preconditions.checkNotNull;
+
+          class A {
+              Object foo(Object obj) {
+                  return checkNotNull(obj);
+              }
+          }
+          """, """
+          import static java.util.Objects.requireNonNull;
+
+          class A {
+              Object foo(Object obj) {
+                  return requireNonNull(obj);
+              }
+          }
+          """));
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
@@ -54,6 +55,32 @@ class PreferJavaUtilObjectsTest implements RewriteTest {
           class A {
               Object foo(Object obj) {
                   return Objects.requireNonNull(obj);
+              }
+          }
+          """));
+    }
+
+    @Test
+    @ExpectedToFail("""
+        Preconditions has both `checkNotNull(Object, Object)` and `checkNotNull(Object, String, Object...)`,
+        meaning we can't exactly match only the `(Object, String)` case which Objects.requireNonNull supports.
+      """)
+    void preconditionsCheckNotNullToObjectsRequireNonNullTwoArguments() {
+        //language=java
+        rewriteRun(java("""
+          import com.google.common.base.Preconditions;
+
+          class A {
+              Object foo(Object obj) {
+                  return Preconditions.checkNotNull(obj, "foo");
+              }
+          }
+          """, """
+          import java.util.Objects;
+
+          class A {
+              Object foo(Object obj) {
+                  return Objects.requireNonNull(obj, "foo");
               }
           }
           """));


### PR DESCRIPTION
## What's changed?
Added recipes for these two transformations
com.google.common.base.Preconditions.checkNotNull -> Objects.requireNonNull
com.google.common.base.Charsets.UTF_8 -> java.nio.charset.StandardCharsets.UTF_8

## What's your motivation?
As discovered on https://github.com/wiremock/wiremock/issues/2111#issuecomment-1581474504