### PR TITLE
Remove finalizer from classes in util.zip 

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openrewrite.java.migrate.util;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class RemoveFinalizerFromZip extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove invocations of deprecated invocations from Deflater, Inflater, ZipFile ";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove invocations of finalize() deprecated invocations from Deflater, Inflater, ZipFile.";
+    }
+
+    @Override
+    public JavaIsoVisitor<ExecutionContext> getVisitor() {
+
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+                boolean extendExists = Objects.nonNull(cd.getExtends());
+                AtomicBoolean finalizeOverride = new AtomicBoolean(false);
+                if(extendExists && (cd.getExtends().toString().contains("Deflater") || cd.getExtends().toString().contains("Inflater") || cd.getExtends().toString().contains("ZipFile")) ){
+                    cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), mdStmt -> {
+                        if (mdStmt instanceof J.MethodDeclaration) {
+                            J.MethodDeclaration md = (J.MethodDeclaration) mdStmt;
+                            mdStmt = md.withBody(md.getBody().withStatements(ListUtils.map(md.getBody().getStatements(), miStmt ->
+                            {   if(miStmt instanceof  J.MethodInvocation){
+                                J.MethodInvocation mi = (J.MethodInvocation) miStmt;
+                                if (mi.getName().toString().contains("finalize")){
+                                    miStmt = null;
+                                }
+                            }
+                                return miStmt;
+                            })));
+                        }
+                        return mdStmt;
+                    })));
+                    return cd;
+                }
+                return cd;
+            }
+
+        };
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
@@ -43,26 +43,23 @@ public class RemoveFinalizerFromZip extends Recipe {
 
     @Override
     public JavaIsoVisitor<ExecutionContext> getVisitor() {
-
         return new JavaIsoVisitor<ExecutionContext>() {
-
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
                 boolean extendExists = Objects.nonNull(cd.getExtends());
-                AtomicBoolean finalizeOverride = new AtomicBoolean(false);
-                if(extendExists && (cd.getExtends().toString().contains("Deflater") || cd.getExtends().toString().contains("Inflater") || cd.getExtends().toString().contains("ZipFile")) ){
+                if (extendExists && (cd.getExtends().toString().contains("Deflater") || cd.getExtends().toString().contains("Inflater") || cd.getExtends().toString().contains("ZipFile"))) {
                     cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), mdStmt -> {
                         if (mdStmt instanceof J.MethodDeclaration) {
                             J.MethodDeclaration md = (J.MethodDeclaration) mdStmt;
                             mdStmt = md.withBody(md.getBody().withStatements(ListUtils.map(md.getBody().getStatements(), miStmt ->
-                            {   if(miStmt instanceof  J.MethodInvocation){
-                                J.MethodInvocation mi = (J.MethodInvocation) miStmt;
-                                if (mi.getName().toString().contains("finalize")){
-                                    miStmt = null;
+                            {
+                                if (miStmt instanceof J.MethodInvocation) {
+                                    J.MethodInvocation mi = (J.MethodInvocation) miStmt;
+                                    if (mi.getName().toString().contains("finalize")) {
+                                        miStmt = null;
+                                    }
                                 }
-                            }
                                 return miStmt;
                             })));
                         }

--- a/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
@@ -24,10 +24,8 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.Statement;
 
 import java.util.Objects;
 
@@ -57,9 +55,9 @@ public class RemoveFinalizerFromZip extends Recipe {
                     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
                         J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
                         if (Objects.nonNull(cd.getExtends()) &&
-                                (String.valueOf(cd.getExtends().getType()).equals("java.util.zip.Deflater")
-                                        || String.valueOf(cd.getExtends().getType()).equals("java.util.zip.Inflater")
-                                        || String.valueOf(cd.getExtends().getType()).equals("java.util.zip.ZipFile"))
+                            (String.valueOf(cd.getExtends().getType()).equals("java.util.zip.Deflater")
+                             || String.valueOf(cd.getExtends().getType()).equals("java.util.zip.Inflater")
+                             || String.valueOf(cd.getExtends().getType()).equals("java.util.zip.ZipFile"))
                         ) {
                             String currentClassName = cd.getSimpleName();
                             cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), mdStmt -> {
@@ -70,8 +68,8 @@ public class RemoveFinalizerFromZip extends Recipe {
                                         if (miStmt instanceof J.MethodInvocation) {
                                             J.MethodInvocation mi = (J.MethodInvocation) miStmt;
                                             if (Objects.nonNull(mi.getSelect())
-                                                    && String.valueOf(mi.getSelect().getType()).equals(currentClassName)
-                                                    && String.valueOf(mi.getName()).contains("finalize")) {
+                                                && String.valueOf(mi.getSelect().getType()).equals(currentClassName)
+                                                && String.valueOf(mi.getName()).contains("finalize")) {
                                                 miStmt = !mi.getSelect().getSideEffects().isEmpty() ? (J.NewClass) mi.getSelect().getSideEffects().get(0) : null;
                                             }
                                         }

--- a/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
@@ -24,6 +24,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
@@ -54,10 +55,12 @@ public class RemoveFinalizerFromZip extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.or(
-                        new UsesType<>(JAVA_UTIL_ZIP_DEFLATER, false),
-                        new UsesType<>(JAVA_UTIL_ZIP_INFLATER, false),
-                        new UsesType<>(JAVA_UTIL_ZIP_ZIP_FILE, false)),
+        return Preconditions.check(Preconditions.and(
+                        new UsesJavaVersion<>(12),
+                        Preconditions.or(
+                                new UsesType<>(JAVA_UTIL_ZIP_DEFLATER, false),
+                                new UsesType<>(JAVA_UTIL_ZIP_INFLATER, false),
+                                new UsesType<>(JAVA_UTIL_ZIP_ZIP_FILE, false))),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
                     public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {

--- a/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
 
 import java.util.Objects;
 
@@ -48,9 +49,9 @@ public class RemoveFinalizerFromZip extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 Preconditions.or(
-                                new UsesType<>("java.util.zip.Deflater", false),
-                                new UsesType<>("java.util.zip.Inflater", false),
-                                new UsesType<>("java.util.zip.ZipFile", false)),
+                        new UsesType<>("java.util.zip.Deflater", false),
+                        new UsesType<>("java.util.zip.Inflater", false),
+                        new UsesType<>("java.util.zip.ZipFile", false)),
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
@@ -71,7 +72,7 @@ public class RemoveFinalizerFromZip extends Recipe {
                                             if (Objects.nonNull(mi.getSelect())
                                                     && String.valueOf(mi.getSelect().getType()).equals(currentClassName)
                                                     && String.valueOf(mi.getName()).contains("finalize")) {
-                                                miStmt = null;
+                                                miStmt = !mi.getSelect().getSideEffects().isEmpty() ? (J.NewClass) mi.getSelect().getSideEffects().get(0) : null;
                                             }
                                         }
                                         return miStmt;

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -17,6 +17,7 @@
 package org.openrewrite.java.migrate.util;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -31,6 +32,7 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     void removeFinalizerForInflater() {
         //language=java
         rewriteRun(
@@ -39,9 +41,9 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
               """
                 import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
+                class FooInflater extends Inflater {
                     public void test() {
-                        FooBar obj = new FooBar();
+                        FooInflater obj = new FooInflater();
                         obj.finalize();
                     }
                 }
@@ -49,9 +51,9 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
               """
                 import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
+                class FooInflater extends Inflater {
                     public void test() {
-                        FooBar obj = new FooBar();
+                        FooInflater obj = new FooInflater();
                     }
                 }
                  """
@@ -306,6 +308,25 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
                 class FooBar{
                     public void test() {
                         new Object().finalize();
+                    }
+                }
+                 """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithoutExtendsOrSelect() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                class FooBar{
+                    public void test() {
+                        finalize();
                     }
                 }
                  """

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -130,7 +130,8 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
                 import java.util.zip.Inflater;
 
                 class FooBar extends Inflater {
-                    public void test() {new FooBar();
+                    public void test() {
+                        new FooBar();
                     }
                 }
                  """

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -1,0 +1,172 @@
+package org.openrewrite.java.migrate.util;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+class RemoveFinalizerFromZipTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveFinalizerFromZip());
+    }
+
+    @Test
+    void removeFinalizerForInflater() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+               import java.util.zip.Inflater;
+
+               class FooBar extends Inflater{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                      obj.finalize();
+                  }                    
+               }
+                """,
+              """
+               import java.util.zip.Inflater;
+
+               class FooBar extends Inflater{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                  }
+               }
+                """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithoutFinalizerForInflater() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+               import java.util.zip.Inflater;
+
+               class FooBar extends Inflater{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                  }                    
+               }
+                """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void removeFinalizerForDeflater() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+               import java.util.zip.Deflater;
+
+               class FooBar extends Deflater{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                      obj.finalize();
+                  }                    
+               }
+                """,
+              """
+               import java.util.zip.Deflater;
+
+               class FooBar extends Deflater{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                  }
+               }
+                """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithoutFinalizerForDeflater() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+               import java.util.zip.Deflater;
+
+               class FooBar extends Deflater{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                  }                    
+               }
+                """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void removeFinalizerForZipFile() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+               import java.util.zip.ZipFile;
+
+               class FooBar extends ZipFile{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                      obj.finalize();
+                  }                    
+               }
+                """,
+              """
+               import java.util.zip.ZipFile;
+
+               class FooBar extends ZipFile{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                  }
+               }
+                """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithoutFinalizerForZipFile() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+               import java.util.zip.ZipFile;
+
+               class FooBar extends ZipFile{
+                  public void test(){
+                      FooBar obj = new FooBar();
+                  }                    
+               }
+                """
+            ),
+            12
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -77,6 +77,14 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
                         finalize();
                     }
                 }
+                 """,
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                    }
+                }
                  """
             ),
             12

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -62,6 +62,115 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
     }
 
     @Test
+    void removeCallsToSelfFinalize() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                        finalize();
+                    }
+                }
+                 """,
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                    }
+                }
+                 """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void removeCallsToThisFinalize() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                        this.finalize();
+                    }
+                }
+                 """,
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                    }
+                }
+                 """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void removeWhileKeepingSideEffects() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                        new FooBar().finalize();
+                    }
+                }
+                 """,
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                        new FooBar();
+                    }
+                }
+                 """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithFinalizeOnObject() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.zip.Inflater;
+
+                class FooBar extends Inflater {
+                    public void test() {
+                        new Object().finalize();
+                    }
+                }
+                 """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
     void noChangeWithoutFinalizerForInflater() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -130,8 +130,7 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
                 import java.util.zip.Inflater;
 
                 class FooBar extends Inflater {
-                    public void test() {
-                        new FooBar();
+                    public void test() {new FooBar();
                     }
                 }
                  """

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openrewrite.java.migrate.util;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -75,14 +75,6 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
                         finalize();
                     }
                 }
-                 """,
-              """
-                import java.util.zip.Inflater;
-
-                class FooBar extends Inflater {
-                    public void test() {
-                    }
-                }
                  """
             ),
             12
@@ -296,6 +288,25 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
                    public void test() {
                        FooBar obj = new FooBar();
                    }
+                }
+                 """
+            ),
+            12
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithoutExtends() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                class FooBar{
+                    public void test() {
+                        new Object().finalize();
+                    }
                 }
                  """
             ),

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -21,326 +21,252 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.java.Assertions.*;
 
 class RemoveFinalizerFromZipTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new RemoveFinalizerFromZip());
+        spec.recipe(new RemoveFinalizerFromZip()).allSources(s -> s.markers(javaVersion(12)));
     }
 
     @Test
     @DocumentExample
     void removeFinalizerForInflater() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Inflater;
+        rewriteRun(java("""
+          import java.util.zip.Inflater;
 
-                class FooInflater extends Inflater {
-                    public void test() {
-                        FooInflater obj = new FooInflater();
-                        obj.finalize();
-                    }
-                }
-                 """,
-              """
-                import java.util.zip.Inflater;
+          class FooInflater extends Inflater {
+              public void test() {
+                  FooInflater obj = new FooInflater();
+                  obj.finalize();
+              }
+          }
+           """, """
+          import java.util.zip.Inflater;
 
-                class FooInflater extends Inflater {
-                    public void test() {
-                        FooInflater obj = new FooInflater();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooInflater extends Inflater {
+              public void test() {
+                  FooInflater obj = new FooInflater();
+              }
+          }
+           """));
     }
 
     @Test
     void removeCallsToSelfFinalize() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Inflater;
+        rewriteRun(java("""
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                        finalize();
-                    }
-                }
-                 """,
-              """
-                import java.util.zip.Inflater;
+          class FooBar extends Inflater {
+              public void test() {
+                  finalize();
+              }
+          }
+           """, """
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends Inflater {
+              public void test() {
+              }
+          }
+           """));
     }
 
     @Test
     void removeCallsToThisFinalize() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Inflater;
+        rewriteRun(java("""
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                        this.finalize();
-                    }
-                }
-                 """,
-              """
-                import java.util.zip.Inflater;
+          class FooBar extends Inflater {
+              public void test() {
+                  this.finalize();
+              }
+          }
+           """, """
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends Inflater {
+              public void test() {
+              }
+          }
+           """));
     }
 
     @Test
     void removeWhileKeepingSideEffects() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Inflater;
+        rewriteRun(java("""
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                        new FooBar().finalize();
-                    }
-                }
-                 """,
-              """
-                import java.util.zip.Inflater;
+          class FooBar extends Inflater {
+              public void test() {
+                  new FooBar().finalize();
+              }
+          }
+           """, """
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                        new FooBar();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends Inflater {
+              public void test() {
+                  new FooBar();
+              }
+          }
+           """));
     }
 
     @Test
     void noChangeWithFinalizeOnObject() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Inflater;
+        rewriteRun(java("""
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                        new Object().finalize();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends Inflater {
+              public void test() {
+                  new Object().finalize();
+              }
+          }
+           """));
     }
 
     @Test
     void noChangeWithoutFinalizerForInflater() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Inflater;
+        rewriteRun(java("""
+          import java.util.zip.Inflater;
 
-                class FooBar extends Inflater {
-                    public void test() {
-                        FooBar obj = new FooBar();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends Inflater {
+              public void test() {
+                  FooBar obj = new FooBar();
+              }
+          }
+           """));
     }
 
     @Test
     void removeFinalizerForDeflater() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Deflater;
+        rewriteRun(java("""
+          import java.util.zip.Deflater;
 
-                class FooBar extends Deflater {
-                    public void test() {
-                        FooBar obj = new FooBar();
-                        obj.finalize();
-                    }
-                }
-                 """,
-              """
-                import java.util.zip.Deflater;
+          class FooBar extends Deflater {
+              public void test() {
+                  FooBar obj = new FooBar();
+                  obj.finalize();
+              }
+          }
+           """, """
+          import java.util.zip.Deflater;
 
-                class FooBar extends Deflater {
-                    public void test() {
-                        FooBar obj = new FooBar();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends Deflater {
+              public void test() {
+                  FooBar obj = new FooBar();
+              }
+          }
+           """));
     }
 
     @Test
     void noChangeWithoutFinalizerForDeflater() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.Deflater;
+        rewriteRun(java("""
+          import java.util.zip.Deflater;
 
-                class FooBar extends Deflater {
-                    public void test() {
-                        FooBar obj = new FooBar();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends Deflater {
+              public void test() {
+                  FooBar obj = new FooBar();
+              }
+          }
+           """));
     }
 
     @Test
     void removeFinalizerForZipFile() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.ZipFile;
+        rewriteRun(java("""
+          import java.util.zip.ZipFile;
 
-                class FooBar extends ZipFile {
-                    FooBar(){
-                        super("");
-                    }
-                    public void test() {
-                        FooBar obj = new FooBar();
-                        obj.finalize();
-                    }
-                }
-                 """,
-              """
-                import java.util.zip.ZipFile;
+          class FooBar extends ZipFile {
+              FooBar(){
+                  super("");
+              }
+              public void test() {
+                  FooBar obj = new FooBar();
+                  obj.finalize();
+              }
+          }
+           """, """
+          import java.util.zip.ZipFile;
 
-                class FooBar extends ZipFile {
-                    FooBar(){
-                        super("");
-                    }
-                    public void test() {
-                        FooBar obj = new FooBar();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends ZipFile {
+              FooBar(){
+                  super("");
+              }
+              public void test() {
+                  FooBar obj = new FooBar();
+              }
+          }
+           """));
     }
 
     @Test
     void noChangeWithoutFinalizerForZipFile() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.util.zip.ZipFile;
+        rewriteRun(java("""
+          import java.util.zip.ZipFile;
 
-                class FooBar extends ZipFile {
-                    FooBar(){
-                        super("");
-                    }
-                   public void test() {
-                       FooBar obj = new FooBar();
-                   }
-                }
-                 """
-            ),
-            12
-          )
-        );
+          class FooBar extends ZipFile {
+              FooBar(){
+                  super("");
+              }
+              public void test() {
+                  FooBar obj = new FooBar();
+              }
+          }
+           """));
     }
 
     @Test
     void noChangeWithoutExtends() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                class FooBar{
-                    public void test() {
-                        new Object().finalize();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+        rewriteRun(java("""
+          class FooBar {
+              public void test() {
+                  new Object().finalize();
+              }
+          }
+           """));
     }
 
     @Test
     void noChangeWithoutExtendsOrSelect() {
         //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                class FooBar{
-                    public void test() {
-                        finalize();
-                    }
-                }
-                 """
-            ),
-            12
-          )
-        );
+        rewriteRun(java("""
+          class FooBar {
+              public void test() {
+                  finalize();
+              }
+          }
+           """));
+    }
+
+    @Test
+    void noChangeOnJava11() {
+        //language=java
+        rewriteRun(version(java("""
+          import java.util.zip.ZipFile;
+          
+          class FooBar extends ZipFile {
+              FooBar(){
+                  super("");
+              }
+              public void test() {
+                  finalize();
+              }
+          }
+           """), 11));
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZipTest.java
@@ -37,24 +37,24 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
           version(
             java(
               """
-               import java.util.zip.Inflater;
+                import java.util.zip.Inflater;
 
-               class FooBar extends Inflater{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                      obj.finalize();
-                  }                    
-               }
-                """,
+                class FooBar extends Inflater {
+                    public void test() {
+                        FooBar obj = new FooBar();
+                        obj.finalize();
+                    }
+                }
+                 """,
               """
-               import java.util.zip.Inflater;
+                import java.util.zip.Inflater;
 
-               class FooBar extends Inflater{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                  }
-               }
-                """
+                class FooBar extends Inflater {
+                    public void test() {
+                        FooBar obj = new FooBar();
+                    }
+                }
+                 """
             ),
             12
           )
@@ -68,14 +68,14 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
           version(
             java(
               """
-               import java.util.zip.Inflater;
+                import java.util.zip.Inflater;
 
-               class FooBar extends Inflater{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                  }                    
-               }
-                """
+                class FooBar extends Inflater {
+                    public void test() {
+                        FooBar obj = new FooBar();
+                    }
+                }
+                 """
             ),
             12
           )
@@ -89,24 +89,24 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
           version(
             java(
               """
-               import java.util.zip.Deflater;
+                import java.util.zip.Deflater;
 
-               class FooBar extends Deflater{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                      obj.finalize();
-                  }                    
-               }
-                """,
+                class FooBar extends Deflater {
+                    public void test() {
+                        FooBar obj = new FooBar();
+                        obj.finalize();
+                    }
+                }
+                 """,
               """
-               import java.util.zip.Deflater;
+                import java.util.zip.Deflater;
 
-               class FooBar extends Deflater{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                  }
-               }
-                """
+                class FooBar extends Deflater {
+                    public void test() {
+                        FooBar obj = new FooBar();
+                    }
+                }
+                 """
             ),
             12
           )
@@ -120,14 +120,14 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
           version(
             java(
               """
-               import java.util.zip.Deflater;
+                import java.util.zip.Deflater;
 
-               class FooBar extends Deflater{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                  }                    
-               }
-                """
+                class FooBar extends Deflater {
+                    public void test() {
+                        FooBar obj = new FooBar();
+                    }
+                }
+                 """
             ),
             12
           )
@@ -141,24 +141,30 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
           version(
             java(
               """
-               import java.util.zip.ZipFile;
+                import java.util.zip.ZipFile;
 
-               class FooBar extends ZipFile{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                      obj.finalize();
-                  }                    
-               }
-                """,
+                class FooBar extends ZipFile {
+                    FooBar(){
+                        super("");
+                    }
+                    public void test() {
+                        FooBar obj = new FooBar();
+                        obj.finalize();
+                    }
+                }
+                 """,
               """
-               import java.util.zip.ZipFile;
+                import java.util.zip.ZipFile;
 
-               class FooBar extends ZipFile{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                  }
-               }
-                """
+                class FooBar extends ZipFile {
+                    FooBar(){
+                        super("");
+                    }
+                    public void test() {
+                        FooBar obj = new FooBar();
+                    }
+                }
+                 """
             ),
             12
           )
@@ -172,14 +178,17 @@ class RemoveFinalizerFromZipTest implements RewriteTest {
           version(
             java(
               """
-               import java.util.zip.ZipFile;
+                import java.util.zip.ZipFile;
 
-               class FooBar extends ZipFile{
-                  public void test(){
-                      FooBar obj = new FooBar();
-                  }                    
-               }
-                """
+                class FooBar extends ZipFile {
+                    FooBar(){
+                        super("");
+                    }
+                   public void test() {
+                       FooBar obj = new FooBar();
+                   }
+                }
+                 """
             ),
             12
           )


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
finalize method has been removed from the ZipFile, Deflater and Inflalter of the util package for which the needed automation has been done as part of the recipe created

## What's your motivation?
To automate JDK migration to a greater extent

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
