### PR TITLE
Fixed dependency causing java 8 incompatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("org.projectlombok:lombok:latest.release")
 
     annotationProcessor("org.openrewrite:rewrite-templating:latest.integration")
-    implementation("com.google.errorprone:error_prone_core:2.19.1:with-dependencies") {
+    compileOnly("com.google.errorprone:error_prone_core:2.19.1:with-dependencies") {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
 


### PR DESCRIPTION
## What's changed?
Changed com.google.errorprone dependency from implementation to compileOnly

## What's your motivation?
Being an implementation dependency it was causing to grab at runtime all transitive dependencies, and there is one incompatible dependency with java 8 (caffeine 3.0.5).
Since we are only using this dependency right now for an example recipe (https://github.com/openrewrite/rewrite-migrate-java/blob/5b7b4a4ccc3fd7412317044aadea659295fab943/src/main/java/org/openrewrite/java/migrate/lang/UseStringIsEmpty.java) there is no need to have the dependency as implementation and we can have it as compileOnly for now.

## Anyone you would like to review specifically?
<!-- @knutwannheden @timtebeek  them here -->
