### PR TITLE
remove thread destroy method recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethod.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethod.java
@@ -27,7 +27,9 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -37,12 +39,17 @@ public class RemoveThreadDestroyMethod extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Remove deprecated Thread.destroy() statement";
+        return "Remove deprecated `Thread.destroy()`";
     }
 
     @Override
     public String getDescription() {
-        return "Remove deprecated invocations of Thread.destroy() which have no alternatives needed.";
+        return "Remove deprecated invocations of `Thread.destroy()` which have no alternatives needed.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("JDK-8204260");
     }
 
     @Override
@@ -53,7 +60,11 @@ public class RemoveThreadDestroyMethod extends Recipe {
                     @Override
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
-                        return (Objects.nonNull(mi.getSelect()) && TypeUtils.isAssignableTo(JAVA_LANG_THREAD, mi.getSelect().getType()) && mi.getSimpleName().equals("destroy")) ? null : mi;
+                        if (Objects.nonNull(mi.getSelect())
+                                && TypeUtils.isAssignableTo(JAVA_LANG_THREAD, mi.getSelect().getType())
+                                && mi.getSimpleName().equals("destroy"))
+                            return null;
+                        return mi;
                     }
                 });
     }

--- a/src/main/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethod.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethod.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openrewrite.java.migrate.lang;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.Objects;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class RemoveThreadDestroyMethod extends Recipe {
+
+    public static final String JAVA_LANG_THREAD = "java.lang.Thread";
+
+    @Override
+    public String getDisplayName() {
+        return "Remove deprecated Thread.destroy() statement";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove deprecated invocations of Thread.destroy() which have no alternatives needed.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return Preconditions.check(new UsesType<>(JAVA_LANG_THREAD, false),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                        return (Objects.nonNull(mi.getSelect()) && TypeUtils.isAssignableTo(JAVA_LANG_THREAD, mi.getSelect().getType()) && mi.getSimpleName().equals("destroy")) ? null : mi;
+                    }
+                });
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethodTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openrewrite.java.migrate.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+class RemoveThreadDestroyMethodTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveThreadDestroyMethod()).allSources(s -> s.markers(javaVersion(8)));
+    }
+
+    @Test
+    void removeDestroyCall() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.lang.*;
+                              
+              class FooBar{
+                  public void test() {
+                      Thread thread = Thread.currentThread();
+                      thread.setName("Main Thread");
+                      thread.destroy();
+                  }
+              }
+               """,
+            """
+              import java.lang.*;
+                              
+              class FooBar{
+                  public void test() {
+                      Thread thread = Thread.currentThread();
+                      thread.setName("Main Thread");
+                  }
+              }
+               """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithoutDestroy() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.lang.*;
+                              
+              class FooBar{
+                  public void test() {
+                      Thread thread = Thread.currentThread();
+                      thread.setName("Main Thread");
+                  }
+              }
+               """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithoutThreadDestroy() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.lang.*;
+                              
+              class FooBar{
+                  public void test() {
+                      FooBar f = new FooBar();
+                      f.destroy();
+                  }
+                  public void destroy(){
+                  }
+              }
+               """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/RemoveThreadDestroyMethodTest.java
@@ -27,7 +27,7 @@ class RemoveThreadDestroyMethodTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new RemoveThreadDestroyMethod()).allSources(s -> s.markers(javaVersion(8)));
+        spec.recipe(new RemoveThreadDestroyMethod());//.allSources(s -> s.markers(javaVersion(8)));
     }
 
     @Test
@@ -36,8 +36,6 @@ class RemoveThreadDestroyMethodTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import java.lang.*;
-                              
               class FooBar{
                   public void test() {
                       Thread thread = Thread.currentThread();
@@ -47,8 +45,6 @@ class RemoveThreadDestroyMethodTest implements RewriteTest {
               }
                """,
             """
-              import java.lang.*;
-                              
               class FooBar{
                   public void test() {
                       Thread thread = Thread.currentThread();
@@ -66,8 +62,6 @@ class RemoveThreadDestroyMethodTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import java.lang.*;
-                              
               class FooBar{
                   public void test() {
                       Thread thread = Thread.currentThread();
@@ -85,8 +79,6 @@ class RemoveThreadDestroyMethodTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import java.lang.*;
-                              
               class FooBar{
                   public void test() {
                       FooBar f = new FooBar();


### PR DESCRIPTION
## What's changed?
To remove Thread.destroy deprecated method

## What's your motivation?
To automate JDK migration to a greater extent

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
