### PR TITLE
Fix UseVarForObject description

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -43,8 +43,8 @@ public class UseVarForObject extends Recipe {
     @Override
     public String getDescription() {
         //language=markdown
-        return "Try to apply local variable type inference `var` to variables containing Objects where possible." +
-               "This recipe will not touch variable declaration with genrics or initializer containing ternary operators.";
+        return "Try to apply local variable type inference `var` to variables containing Objects where possible. " +
+               "This recipe will not touch variable declarations with generics or initializers containing ternary operators.";
     }
 
 


### PR DESCRIPTION
Adds missing space and fixes spelling and grammar issues.
