### PR TITLE
Disable JavaUtilAPIs in Java8toJava11 over null safety

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -50,7 +50,9 @@ recipeList:
   - org.openrewrite.java.migrate.wro4j.UpgradeWro4jMavenPluginVersion
   - org.openrewrite.java.migrate.jacoco.UpgradeJaCoCoMavenPluginVersion
   - org.openrewrite.java.migrate.JavaVersion11
-  - org.openrewrite.java.migrate.util.JavaUtilAPIs
+# Disabled due to null safety issues in the current implementation
+# https://github.com/openrewrite/rewrite-migrate-java/issues/250
+#  - org.openrewrite.java.migrate.util.JavaUtilAPIs
   - org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty
   - org.openrewrite.java.migrate.util.OptionalNotEmptyToIsPresent
   - org.openrewrite.github.SetupJavaUpgradeJavaVersion:


### PR DESCRIPTION
## What's changed?
Disable JavaUtilAPIs recipe in list of recipes for Java8toJava11

## What's your motivation?
Due to null safety issues reported in https://github.com/openrewrite/rewrite-migrate-java/issues/250