### PR TITLE
adjusting MaybeAddJakartaServletApi to be a `ScanningRecipe` so that …

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/jakarta/MaybeAddJakartaServletApiTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/MaybeAddJakartaServletApiTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.jakarta;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class MaybeAddJakartaServletApiTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MaybeAddJakartaServletApi())
+          .parser(JavaParser.fromJavaVersion()
+            .dependsOn("package javax.servlet;\npublic class Filter {}"));
+    }
+
+    @Test
+    void hasSpringBootStarterWeb() {
+        rewriteRun(
+          mavenProject("my-project",
+            srcMainJava(java("""
+              import javax.servlet.Filter;
+              class A {
+                  Filter foo = null;
+              }
+              """)),
+            pomXml("""
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                    <version>2.7.0</version>
+                  </dependency>
+                </dependencies>
+
+              </project>
+              """)
+          )
+        );
+    }
+
+    @Test
+    void doesNotHaveSpringBootStarterWeb() {
+        rewriteRun(
+          mavenProject("my-project",
+            srcMainJava(java("""
+              import javax.servlet.Filter;
+              class A {
+                  Filter foo = null;
+              }
+              """)),
+            pomXml("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+    
+                  <dependencies>
+                  </dependencies>
+    
+                </project>
+                """,
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+
+                  <dependencies>
+                    <dependency>
+                      <groupId>jakarta.servlet</groupId>
+                      <artifactId>jakarta.servlet-api</artifactId>
+                      <version>6.0.0</version>
+                    </dependency>
+                  </dependencies>
+
+                </project>
+                """)
+          )
+        );
+    }
+}


### PR DESCRIPTION
…it can correctly apply its precondition to the `AddDependency` recipe

## What's your motivation?
closes #254

## Any additional context
Thinking about the introduction of ScanningRecipes, this is an example of a recipe which "wants" to be a non-scanning recipe but is trying to call a ScanningRecipe, and therefore itself becomes a ScanningRecipe

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ auto-formatter on affected files
- ~~[ ] I've updated the documentation (if applicable)~~
