### PR TITLE
Fix/no guava immutable recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
@@ -31,7 +31,7 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public abstract class AbstractNoGuavaImmutableOf extends Recipe {
+abstract class AbstractNoGuavaImmutableOf extends Recipe {
 
     private final String guavaType;
     private final String javaType;

--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
@@ -33,23 +33,25 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractNoGuavaImmutableOf extends Recipe {
 
-    private transient final MethodMatcher IMMUTABLE_MATCHER = new MethodMatcher(getGuavaType()+" of(..)");
+    private transient final MethodMatcher IMMUTABLE_MATCHER = new MethodMatcher(getGuavaType() + " of(..)");
 
     abstract String getGuavaType();
+
     abstract String getJavaType();
+
     private String getShortType(String fullyQualifiedType) {
         return fullyQualifiedType.substring(getJavaType().lastIndexOf(".") + 1);
     }
 
     @Override
     public String getDisplayName() {
-        return "Prefer `"+getShortType(getJavaType())+".of(..)` in Java 9 or higher";
+        return "Prefer `" + getShortType(getJavaType()) + ".of(..)` in Java 9 or higher";
     }
 
     @Override
     public String getDescription() {
         String name = getGuavaType().substring(getGuavaType().lastIndexOf("."));
-        return "Replaces `"+getShortType(getGuavaType())+".of(..)` if the returned type is immediately down-cast.";
+        return "Replaces `" + getShortType(getGuavaType()) + ".of(..)` if the returned type is immediately down-cast.";
     }
 
     @Override
@@ -98,7 +100,7 @@ public abstract class AbstractNoGuavaImmutableOf extends Recipe {
                             })
                             .filter(Objects::nonNull)
                             .map(type -> "#{any(" + type.getFullyQualifiedName() + ")}")
-                            .collect(Collectors.joining(",", getShortType(getJavaType())+".of(", ")"));
+                            .collect(Collectors.joining(",", getShortType(getJavaType()) + ".of(", ")"));
 
                     return JavaTemplate.builder(template)
                             .contextSensitive()

--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public abstract class AbstractNoGuavaImmutableOf extends Recipe {
+
+    private transient final MethodMatcher IMMUTABLE_MATCHER = new MethodMatcher(getGuavaType()+" of(..)");
+
+    abstract String getGuavaType();
+    abstract String getJavaType();
+    private String getShortType(String fullyQualifiedType) {
+        return fullyQualifiedType.substring(getJavaType().lastIndexOf(".") + 1);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Prefer `"+getShortType(getJavaType())+".of(..)` in Java 9 or higher";
+    }
+
+    @Override
+    public String getDescription() {
+        String name = getGuavaType().substring(getGuavaType().lastIndexOf("."));
+        return "Replaces `"+getShortType(getGuavaType())+".of(..)` if the returned type is immediately down-cast.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(10);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
+                new UsesType<>(getGuavaType(), false));
+        return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (IMMUTABLE_MATCHER.matches(method) && isParentTypeDownCast()) {
+                    maybeRemoveImport(getGuavaType());
+                    maybeAddImport(getJavaType());
+
+                    String template = method.getArguments().stream()
+                            .map(arg -> {
+                                if (arg.getType() instanceof JavaType.Primitive) {
+                                    String type = "";
+                                    if (JavaType.Primitive.Boolean == arg.getType()) {
+                                        type = "Boolean";
+                                    } else if (JavaType.Primitive.Byte == arg.getType()) {
+                                        type = "Byte";
+                                    } else if (JavaType.Primitive.Char == arg.getType()) {
+                                        type = "Character";
+                                    } else if (JavaType.Primitive.Double == arg.getType()) {
+                                        type = "Double";
+                                    } else if (JavaType.Primitive.Float == arg.getType()) {
+                                        type = "Float";
+                                    } else if (JavaType.Primitive.Int == arg.getType()) {
+                                        type = "Integer";
+                                    } else if (JavaType.Primitive.Long == arg.getType()) {
+                                        type = "Long";
+                                    } else if (JavaType.Primitive.Short == arg.getType()) {
+                                        type = "Short";
+                                    } else if (JavaType.Primitive.String == arg.getType()) {
+                                        type = "String";
+                                    }
+                                    return TypeUtils.asFullyQualified(JavaType.buildType("java.lang." + type));
+                                } else {
+                                    return TypeUtils.asFullyQualified(arg.getType());
+                                }
+                            })
+                            .filter(Objects::nonNull)
+                            .map(type -> "#{any(" + type.getFullyQualifiedName() + ")}")
+                            .collect(Collectors.joining(",", getShortType(getJavaType())+".of(", ")"));
+
+                    return JavaTemplate.builder(template)
+                            .contextSensitive()
+                            .imports(getJavaType())
+                            .build()
+                            .apply(getCursor(),
+                                    method.getCoordinates().replace(),
+                                    method.getArguments().get(0) instanceof J.Empty ? new Object[]{} : method.getArguments().toArray());
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+
+            private boolean isParentTypeDownCast() {
+                J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
+                boolean isParentTypeDownCast = false;
+                if (parent instanceof J.VariableDeclarations.NamedVariable) {
+                    isParentTypeDownCast = isParentTypeMatched(((J.VariableDeclarations.NamedVariable) parent).getType());
+                } else if (parent instanceof J.Assignment) {
+                    J.Assignment a = (J.Assignment) parent;
+                    if (a.getVariable() instanceof J.Identifier && ((J.Identifier) a.getVariable()).getFieldType() != null) {
+                        isParentTypeDownCast = isParentTypeMatched(((J.Identifier) a.getVariable()).getFieldType().getType());
+                    } else if (a.getVariable() instanceof J.FieldAccess) {
+                        isParentTypeDownCast = isParentTypeMatched(a.getVariable().getType());
+                    }
+                } else if (parent instanceof J.Return) {
+                    // Does not currently support returns in lambda expressions.
+                    J j = getCursor().dropParentUntil(is -> is instanceof J.MethodDeclaration || is instanceof J.CompilationUnit).getValue();
+                    if (j instanceof J.MethodDeclaration) {
+                        TypeTree returnType = ((J.MethodDeclaration) j).getReturnTypeExpression();
+                        if (returnType != null) {
+                            isParentTypeDownCast = isParentTypeMatched(returnType.getType());
+                        }
+                    }
+                } else if (parent instanceof J.MethodInvocation) {
+                    J.MethodInvocation m = (J.MethodInvocation) parent;
+                    if (m.getMethodType() != null) {
+                        int index = 0;
+                        for (Expression argument : m.getArguments()) {
+                            if (IMMUTABLE_MATCHER.matches(argument)) {
+                                break;
+                            }
+                            index++;
+                        }
+                        isParentTypeDownCast = isParentTypeMatched(m.getMethodType().getParameterTypes().get(index));
+                    }
+                } else if (parent instanceof J.NewClass) {
+                    J.NewClass c = (J.NewClass) parent;
+                    int index = 0;
+                    if (c.getConstructorType() != null) {
+                        for (Expression argument : c.getArguments()) {
+                            if (IMMUTABLE_MATCHER.matches(argument)) {
+                                break;
+                            }
+                            index++;
+                        }
+                        if (c.getConstructorType() != null) {
+                            isParentTypeDownCast = isParentTypeMatched(c.getConstructorType().getParameterTypes().get(index));
+                        }
+                    }
+                } else if (parent instanceof J.NewArray) {
+                    J.NewArray a = (J.NewArray) parent;
+                    JavaType arrayType = a.getType();
+                    while (arrayType instanceof JavaType.Array) {
+                        arrayType = ((JavaType.Array) arrayType).getElemType();
+                    }
+
+                    isParentTypeDownCast = isParentTypeMatched(arrayType);
+                }
+                return isParentTypeDownCast;
+            }
+
+            private boolean isParentTypeMatched(@Nullable JavaType type) {
+                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
+                return TypeUtils.isOfClassType(fq, getJavaType())
+                        || TypeUtils.isOfClassType(fq, "java.lang.Object");
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
@@ -20,6 +20,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
@@ -31,149 +32,17 @@ import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class NoGuavaImmutableListOf extends Recipe {
-    private static final MethodMatcher IMMUTABLE_LIST_MATCHER = new MethodMatcher("com.google.common.collect.ImmutableList of(..)");
+public class NoGuavaImmutableListOf extends AbstractNoGuavaImmutableOf {
 
     @Override
-    public String getDisplayName() {
-        return "Prefer `List.of(..)` in Java 9 or higher";
+    String getGuavaType() {
+        return "com.google.common.collect.ImmutableList";
     }
 
     @Override
-    public String getDescription() {
-        return "Replaces `ImmutableList.of(..)` if the returned type is immediately down-cast.";
+    String getJavaType() {
+        return "java.util.List";
     }
 
-    @Override
-    public Set<String> getTags() {
-        return new HashSet<>(Arrays.asList("RSPEC-4738", "guava"));
-    }
-
-    @Override
-    public Duration getEstimatedEffortPerOccurrence() {
-        return Duration.ofMinutes(10);
-    }
-
-    // Code is shared between `NoGuavaImmutableMapOf`, `NoGuavaImmutableListOf`, and `NoGuavaImmutableSetOf`.
-    // Updates to either may apply to each of the recipes.
-    @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesType<>("com.google.common.collect.ImmutableList", false));
-        return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
-            @Override
-            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                if (IMMUTABLE_LIST_MATCHER.matches(method) && isParentTypeDownCast()) {
-                    maybeRemoveImport("com.google.common.collect.ImmutableList");
-                    maybeAddImport("java.util.List");
-
-                    String template = method.getArguments().stream()
-                            .map(arg -> {
-                                if (arg.getType() instanceof JavaType.Primitive) {
-                                    String type = "";
-                                    if (JavaType.Primitive.Boolean == arg.getType()) {
-                                        type = "Boolean";
-                                    } else if (JavaType.Primitive.Byte == arg.getType()) {
-                                        type = "Byte";
-                                    } else if (JavaType.Primitive.Char == arg.getType()) {
-                                        type = "Character";
-                                    } else if (JavaType.Primitive.Double == arg.getType()) {
-                                        type = "Double";
-                                    } else if (JavaType.Primitive.Float == arg.getType()) {
-                                        type = "Float";
-                                    } else if (JavaType.Primitive.Int == arg.getType()) {
-                                        type = "Integer";
-                                    } else if (JavaType.Primitive.Long == arg.getType()) {
-                                        type = "Long";
-                                    } else if (JavaType.Primitive.Short == arg.getType()) {
-                                        type = "Short";
-                                    } else if (JavaType.Primitive.String == arg.getType()) {
-                                        type = "String";
-                                    }
-                                    return TypeUtils.asFullyQualified(JavaType.buildType("java.lang." + type));
-                                } else {
-                                    return TypeUtils.asFullyQualified(arg.getType());
-                                }
-                            })
-                            .filter(Objects::nonNull)
-                            .map(type -> "#{any(" + type.getFullyQualifiedName() + ")}")
-                            .collect(Collectors.joining(",", "List.of(", ")"));
-
-                    return JavaTemplate.builder(template)
-                            .contextSensitive()
-                            .imports("java.util.List")
-                            .build()
-                            .apply(getCursor(),
-                                    method.getCoordinates().replace(),
-                                    method.getArguments().get(0) instanceof J.Empty ? new Object[]{} : method.getArguments().toArray());
-                }
-                return super.visitMethodInvocation(method, ctx);
-            }
-
-            private boolean isParentTypeDownCast() {
-                J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
-                boolean isParentTypeDownCast = false;
-                if (parent instanceof J.VariableDeclarations.NamedVariable) {
-                    isParentTypeDownCast = isParentTypeMatched(((J.VariableDeclarations.NamedVariable) parent).getType());
-                } else if (parent instanceof J.Assignment) {
-                    J.Assignment a = (J.Assignment) parent;
-                    if (a.getVariable() instanceof J.Identifier && ((J.Identifier) a.getVariable()).getFieldType() != null) {
-                        isParentTypeDownCast = isParentTypeMatched(((J.Identifier) a.getVariable()).getFieldType().getType());
-                    } else if (a.getVariable() instanceof J.FieldAccess) {
-                        isParentTypeDownCast = isParentTypeMatched(a.getVariable().getType());
-                    }
-                } else if (parent instanceof J.Return) {
-                    // Does not currently support returns in lambda expressions.
-                    J j = getCursor().dropParentUntil(is -> is instanceof J.MethodDeclaration || is instanceof J.CompilationUnit).getValue();
-                    if (j instanceof J.MethodDeclaration) {
-                        TypeTree returnType = ((J.MethodDeclaration) j).getReturnTypeExpression();
-                        if (returnType != null) {
-                            isParentTypeDownCast = isParentTypeMatched(returnType.getType());
-                        }
-                    }
-                } else if (parent instanceof J.MethodInvocation) {
-                    J.MethodInvocation m = (J.MethodInvocation) parent;
-                    int index = 0;
-                    for (Expression argument : m.getArguments()) {
-                        if (IMMUTABLE_LIST_MATCHER.matches(argument)) {
-                            break;
-                        }
-                        index++;
-                    }
-                    if (m.getMethodType() != null) {
-                        isParentTypeDownCast = isParentTypeMatched(m.getMethodType().getParameterTypes().get(index));
-                    }
-                } else if (parent instanceof J.NewClass) {
-                    J.NewClass c = (J.NewClass) parent;
-                    int index = 0;
-                    if (c.getConstructorType() != null && c.getArguments() != null) {
-                        for (Expression argument : c.getArguments()) {
-                            if (IMMUTABLE_LIST_MATCHER.matches(argument)) {
-                                break;
-                            }
-                            index++;
-                        }
-                        if (c.getConstructorType() != null) {
-                            isParentTypeDownCast = isParentTypeMatched(c.getConstructorType().getParameterTypes().get(index));
-                        }
-                    }
-                } else if (parent instanceof J.NewArray) {
-                    J.NewArray a = (J.NewArray) parent;
-                    JavaType arrayType = a.getType();
-                    while (arrayType instanceof JavaType.Array) {
-                        arrayType = ((JavaType.Array) arrayType).getElemType();
-                    }
-
-                    isParentTypeDownCast = isParentTypeMatched(arrayType);
-                }
-                return isParentTypeDownCast;
-            }
-
-            private boolean isParentTypeMatched(@Nullable JavaType type) {
-                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
-                return TypeUtils.isOfClassType(fq, "java.util.List") || TypeUtils.isOfType(fq, JavaType.ShallowClass.build("java.lang.Object"));
-            }
-        });
-    }
 }
 

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
@@ -16,16 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 public class NoGuavaImmutableListOf extends AbstractNoGuavaImmutableOf {
-
-    @Override
-    String getGuavaType() {
-        return "com.google.common.collect.ImmutableList";
+    NoGuavaImmutableListOf(){
+        super("com.google.common.collect.ImmutableList", "java.util.List");
     }
-
-    @Override
-    String getJavaType() {
-        return "java.util.List";
-    }
-
 }
-

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
@@ -16,7 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 public class NoGuavaImmutableListOf extends AbstractNoGuavaImmutableOf {
-    NoGuavaImmutableListOf(){
+    public NoGuavaImmutableListOf(){
         super("com.google.common.collect.ImmutableList", "java.util.List");
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOf.java
@@ -15,23 +15,6 @@
  */
 package org.openrewrite.java.migrate.guava;
 
-import org.openrewrite.Preconditions;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.search.UsesJavaVersion;
-import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.*;
-
-import java.time.Duration;
-import java.util.*;
-import java.util.stream.Collectors;
-
 public class NoGuavaImmutableListOf extends AbstractNoGuavaImmutableOf {
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
@@ -16,7 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 public class NoGuavaImmutableMapOf extends AbstractNoGuavaImmutableOf {
-    NoGuavaImmutableMapOf(){
+    public NoGuavaImmutableMapOf(){
         super("com.google.common.collect.ImmutableMap", "java.util.Map");
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
@@ -15,23 +15,6 @@
  */
 package org.openrewrite.java.migrate.guava;
 
-import com.google.common.collect.ImmutableMap;
-import org.openrewrite.Preconditions;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.search.UsesJavaVersion;
-import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.*;
-
-import java.time.Duration;
-import java.util.*;
-import java.util.stream.Collectors;
-
 public class NoGuavaImmutableMapOf extends AbstractNoGuavaImmutableOf {
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
@@ -16,16 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 public class NoGuavaImmutableMapOf extends AbstractNoGuavaImmutableOf {
-
-    @Override
-    String getGuavaType() {
-        return "com.google.common.collect.ImmutableMap";
+    NoGuavaImmutableMapOf(){
+        super("com.google.common.collect.ImmutableMap", "java.util.Map");
     }
-
-    @Override
-    String getJavaType() {
-        return "java.util.Map";
-    }
-
 }
-

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOf.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.migrate.guava;
 
+import com.google.common.collect.ImmutableMap;
 import org.openrewrite.Preconditions;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
@@ -31,154 +32,17 @@ import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class NoGuavaImmutableMapOf extends Recipe {
-    private static final MethodMatcher IMMUTABLE_MAP_MATCHER = new MethodMatcher("com.google.common.collect.ImmutableMap of(..)");
+public class NoGuavaImmutableMapOf extends AbstractNoGuavaImmutableOf {
 
     @Override
-    public String getDisplayName() {
-        return "Prefer `Map.of(..)` in Java 9 or higher";
+    String getGuavaType() {
+        return "com.google.common.collect.ImmutableMap";
     }
 
     @Override
-    public String getDescription() {
-        return "Replaces `ImmutableMap.of(..)` if the returned type is immediately down-cast.";
+    String getJavaType() {
+        return "java.util.Map";
     }
 
-    @Override
-    public Set<String> getTags() {
-        return new HashSet<>(Arrays.asList("RSPEC-4738", "guava"));
-    }
-
-    @Override
-    public Duration getEstimatedEffortPerOccurrence() {
-        return Duration.ofMinutes(10);
-    }
-
-    // Code is shared between `NoGuavaImmutableMapOf`, `NoGuavaImmutableListOf`, and `NoGuavaImmutableSetOf`.
-    // Updates to either may apply to each of the recipes.
-    @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesType<>("com.google.common.collect.ImmutableMap", false));
-        return Preconditions.check(check, new JavaIsoVisitor<ExecutionContext>() {
-
-            @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                method = super.visitMethodInvocation(method, ctx);
-                if (IMMUTABLE_MAP_MATCHER.matches(method) && isParentTypeDownCast()) {
-                    maybeRemoveImport("com.google.common.collect.ImmutableMap");
-                    maybeAddImport("java.util.Map");
-
-                    String template = method.getArguments().stream()
-                            .map(arg -> {
-                                if (arg.getType() instanceof JavaType.Primitive) {
-                                    String type = "";
-                                    if (JavaType.Primitive.Boolean == arg.getType()) {
-                                        type = "Boolean";
-                                    } else if (JavaType.Primitive.Byte == arg.getType()) {
-                                        type = "Byte";
-                                    } else if (JavaType.Primitive.Char == arg.getType()) {
-                                        type = "Character";
-                                    } else if (JavaType.Primitive.Double == arg.getType()) {
-                                        type = "Double";
-                                    } else if (JavaType.Primitive.Float == arg.getType()) {
-                                        type = "Float";
-                                    } else if (JavaType.Primitive.Int == arg.getType()) {
-                                        type = "Integer";
-                                    } else if (JavaType.Primitive.Long == arg.getType()) {
-                                        type = "Long";
-                                    } else if (JavaType.Primitive.Short == arg.getType()) {
-                                        type = "Short";
-                                    } else if (JavaType.Primitive.String == arg.getType()) {
-                                        type = "String";
-                                    }
-                                    return TypeUtils.asFullyQualified(JavaType.buildType("java.lang." + type));
-                                } else {
-                                    return TypeUtils.asFullyQualified(arg.getType());
-                                }
-                            })
-                            .filter(Objects::nonNull)
-                            .map(type -> "#{any(" + type.getFullyQualifiedName() + ")}")
-                            .collect(Collectors.joining(",", "Map.of(", ")"));
-
-                    return JavaTemplate.builder(template)
-                            .contextSensitive()
-                            .imports("java.util.Map")
-                            .build()
-                            .apply(
-                                    updateCursor(method),
-                                    method.getCoordinates().replace(),
-                                    method.getArguments().get(0) instanceof J.Empty ? new Object[]{} : method.getArguments().toArray());
-                }
-                return method;
-            }
-
-            private boolean isParentTypeDownCast() {
-                J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
-                boolean isParentTypeDownCast = false;
-                if (parent instanceof J.VariableDeclarations.NamedVariable) {
-                    isParentTypeDownCast = isParentTypeMatched(((J.VariableDeclarations.NamedVariable) parent).getType());
-                } else if (parent instanceof J.Assignment) {
-                    J.Assignment a = (J.Assignment) parent;
-                    if (a.getVariable() instanceof J.Identifier && ((J.Identifier) a.getVariable()).getFieldType() != null) {
-                        isParentTypeDownCast = isParentTypeMatched(((J.Identifier) a.getVariable()).getFieldType().getType());
-                    } else if (a.getVariable() instanceof J.FieldAccess) {
-                        isParentTypeDownCast = isParentTypeMatched(a.getVariable().getType());
-                    }
-                } else if (parent instanceof J.Return) {
-                    // Does not currently support returns in lambda expressions.
-                    J j = getCursor().dropParentUntil(is -> is instanceof J.MethodDeclaration || is instanceof J.CompilationUnit).getValue();
-                    if (j instanceof J.MethodDeclaration) {
-                        TypeTree returnType = ((J.MethodDeclaration) j).getReturnTypeExpression();
-                        if (returnType != null) {
-                            isParentTypeDownCast = isParentTypeMatched(returnType.getType());
-                        }
-                    }
-                } else if (parent instanceof J.MethodInvocation) {
-                    J.MethodInvocation m = (J.MethodInvocation) parent;
-                    int index = 0;
-                    for (Expression argument : m.getArguments()) {
-                        if (IMMUTABLE_MAP_MATCHER.matches(argument)) {
-                            break;
-                        }
-                        index++;
-                    }
-                    if (m.getMethodType() != null) {
-                        isParentTypeDownCast = isParentTypeMatched(m.getMethodType().getParameterTypes().get(index));
-                    }
-                } else if (parent instanceof J.NewClass) {
-                    J.NewClass c = (J.NewClass) parent;
-                    int index = 0;
-                    if (c.getConstructorType() != null) {
-                        for (Expression argument : c.getArguments()) {
-                            if (IMMUTABLE_MAP_MATCHER.matches(argument)) {
-                                break;
-                            }
-                            index++;
-                        }
-                        if (c.getConstructorType() != null) {
-                            isParentTypeDownCast = isParentTypeMatched(c.getConstructorType().getParameterTypes().get(index));
-                        }
-                    }
-                } else if (parent instanceof J.NewArray) {
-                    J.NewArray a = (J.NewArray) parent;
-                    JavaType arrayType = a.getType();
-                    while (arrayType instanceof JavaType.Array) {
-                        arrayType = ((JavaType.Array) arrayType).getElemType();
-                    }
-
-                    isParentTypeDownCast = isParentTypeMatched(arrayType);
-                }
-                return isParentTypeDownCast;
-            }
-
-            private boolean isParentTypeMatched(@Nullable JavaType type) {
-                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
-                return TypeUtils.isOfClassType(fq, "java.util.Map")
-                       || TypeUtils.isOfClassType(fq, "java.lang.Object")
-                       || TypeUtils.isOfClassType(fq, "com.google.common.collect.ImmutableMap");
-            }
-        });
-    }
 }
 

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
@@ -16,16 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 public class NoGuavaImmutableSetOf extends AbstractNoGuavaImmutableOf {
-
-    @Override
-    String getGuavaType() {
-        return "com.google.common.collect.ImmutableSet";
+    NoGuavaImmutableSetOf() {
+        super("com.google.common.collect.ImmutableSet", "java.util.Set");
     }
-
-    @Override
-    String getJavaType() {
-        return "java.util.Set";
-    }
-
 }
-

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
@@ -16,7 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 public class NoGuavaImmutableSetOf extends AbstractNoGuavaImmutableOf {
-    NoGuavaImmutableSetOf() {
+    public NoGuavaImmutableSetOf() {
         super("com.google.common.collect.ImmutableSet", "java.util.Set");
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
@@ -15,22 +15,6 @@
  */
 package org.openrewrite.java.migrate.guava;
 
-import org.openrewrite.Preconditions;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.search.UsesJavaVersion;
-import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.*;
-
-import java.time.Duration;
-import java.util.*;
-import java.util.stream.Collectors;
-
 public class NoGuavaImmutableSetOf extends AbstractNoGuavaImmutableOf {
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOf.java
@@ -31,156 +31,17 @@ import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class NoGuavaImmutableSetOf extends Recipe {
-    private static final MethodMatcher IMMUTABLE_SET_MATCHER = new MethodMatcher("com.google.common.collect.ImmutableSet of(..)");
+public class NoGuavaImmutableSetOf extends AbstractNoGuavaImmutableOf {
 
     @Override
-    public String getDisplayName() {
-        //language=markdown
-        return "Prefer `Set.of(..)` in Java 9 or higher";
+    String getGuavaType() {
+        return "com.google.common.collect.ImmutableSet";
     }
 
     @Override
-    public String getDescription() {
-        //language=markdown
-        return "Replaces `ImmutableSet.of(..)` if the returned type is immediately down-cast.\n" +
-               "  Java 9 introduced `List#of(..)`, `Map#of(..)`, `Set#of(..)` which is similar to `ImmutableList#of(..)`, " +
-               "`ImmutableMap#of(..)`, `ImmutableSet#of(..)`, but has a subtle difference.\n" +
-               "  As per the Java 9 documentation, [`Set.of` provides an unspecified iteration order on the set of " +
-               "elements and is subject to change](https://docs.oracle.com/javase/9/docs/api/java/util/Set.html), whereas " +
-               "[Guava `ImmutableSet` preserves the order from construction time](https://github.com/google/guava/wiki/ImmutableCollectionsExplained#how).\n" +
-               "  This is worth pointing out in case your usage calls for iteration order being important.";
+    String getJavaType() {
+        return "java.util.Set";
     }
 
-    @Override
-    public Set<String> getTags() {
-        return new HashSet<>(Arrays.asList("RSPEC-4738", "guava"));
-    }
-
-    @Override
-    public Duration getEstimatedEffortPerOccurrence() {
-        return Duration.ofMinutes(10);
-    }
-
-    // Code is shared between `NoGuavaImmutableMapOf`, `NoGuavaImmutableListOf`, and `NoGuavaImmutableSetOf`.
-    // Updates to either may apply to each of the recipes.
-    @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesType<>("com.google.common.collect.ImmutableSet", false)), new JavaVisitor<ExecutionContext>() {
-            @Override
-            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                if (IMMUTABLE_SET_MATCHER.matches(method) && isParentTypeDownCast()) {
-                    maybeRemoveImport("com.google.common.collect.ImmutableSet");
-                    maybeAddImport("java.util.Set");
-
-                    String template = method.getArguments().stream()
-                            .map(arg -> {
-                                if (arg.getType() instanceof JavaType.Primitive) {
-                                    String type = "";
-                                    if (JavaType.Primitive.Boolean == arg.getType()) {
-                                        type = "Boolean";
-                                    } else if (JavaType.Primitive.Byte == arg.getType()) {
-                                        type = "Byte";
-                                    } else if (JavaType.Primitive.Char == arg.getType()) {
-                                        type = "Character";
-                                    } else if (JavaType.Primitive.Double == arg.getType()) {
-                                        type = "Double";
-                                    } else if (JavaType.Primitive.Float == arg.getType()) {
-                                        type = "Float";
-                                    } else if (JavaType.Primitive.Int == arg.getType()) {
-                                        type = "Integer";
-                                    } else if (JavaType.Primitive.Long == arg.getType()) {
-                                        type = "Long";
-                                    } else if (JavaType.Primitive.Short == arg.getType()) {
-                                        type = "Short";
-                                    } else if (JavaType.Primitive.String == arg.getType()) {
-                                        type = "String";
-                                    }
-                                    return TypeUtils.asFullyQualified(JavaType.buildType("java.lang." + type));
-                                } else {
-                                    return TypeUtils.asFullyQualified(arg.getType());
-                                }
-                            })
-                            .filter(Objects::nonNull)
-                            .map(type -> "#{any(" + type.getFullyQualifiedName() + ")}")
-                            .collect(Collectors.joining(",", "Set.of(", ")"));
-
-                    return JavaTemplate.builder(template)
-                            .contextSensitive()
-                            .imports("java.util.Set")
-                            .build()
-                            .apply(getCursor(),
-                                    method.getCoordinates().replace(),
-                                    method.getArguments().get(0) instanceof J.Empty ? new Object[]{} : method.getArguments().toArray());
-                }
-                return super.visitMethodInvocation(method, ctx);
-            }
-
-            private boolean isParentTypeDownCast() {
-                J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
-                boolean isParentTypeDownCast = false;
-                if (parent instanceof J.VariableDeclarations.NamedVariable) {
-                    isParentTypeDownCast = isParentTypeMatched(((J.VariableDeclarations.NamedVariable) parent).getType());
-                } else if (parent instanceof J.Assignment) {
-                    J.Assignment a = (J.Assignment) parent;
-                    if (a.getVariable() instanceof J.Identifier && ((J.Identifier) a.getVariable()).getFieldType() != null) {
-                        isParentTypeDownCast = isParentTypeMatched(((J.Identifier) a.getVariable()).getFieldType().getType());
-                    } else if (a.getVariable() instanceof J.FieldAccess) {
-                        isParentTypeDownCast = isParentTypeMatched(a.getVariable().getType());
-                    }
-                } else if (parent instanceof J.Return) {
-                    // Does not currently support returns in lambda expressions.
-                    J j = getCursor().dropParentUntil(is -> is instanceof J.MethodDeclaration || is instanceof J.CompilationUnit).getValue();
-                    if (j instanceof J.MethodDeclaration) {
-                        TypeTree returnType = ((J.MethodDeclaration) j).getReturnTypeExpression();
-                        if (returnType != null) {
-                            isParentTypeDownCast = isParentTypeMatched(returnType.getType());
-                        }
-                    }
-                } else if (parent instanceof J.MethodInvocation) {
-                    J.MethodInvocation m = (J.MethodInvocation) parent;
-                    int index = 0;
-                    for (Expression argument : m.getArguments()) {
-                        if (IMMUTABLE_SET_MATCHER.matches(argument)) {
-                            break;
-                        }
-                        index++;
-                    }
-                    if (m.getMethodType() != null) {
-                        isParentTypeDownCast = isParentTypeMatched(m.getMethodType().getParameterTypes().get(index));
-                    }
-                } else if (parent instanceof J.NewClass) {
-                    J.NewClass c = (J.NewClass) parent;
-                    int index = 0;
-                    if (c.getConstructorType() != null && c.getArguments() != null) {
-                        for (Expression argument : c.getArguments()) {
-                            if (IMMUTABLE_SET_MATCHER.matches(argument)) {
-                                break;
-                            }
-                            index++;
-                        }
-                        if (c.getConstructorType() != null) {
-                            isParentTypeDownCast = isParentTypeMatched(c.getConstructorType().getParameterTypes().get(index));
-                        }
-                    }
-                } else if (parent instanceof J.NewArray) {
-                    J.NewArray a = (J.NewArray) parent;
-                    JavaType arrayType = a.getType();
-                    while (arrayType instanceof JavaType.Array) {
-                        arrayType = ((JavaType.Array) arrayType).getElemType();
-                    }
-
-                    isParentTypeDownCast = isParentTypeMatched(arrayType);
-                }
-                return isParentTypeDownCast;
-            }
-
-            private boolean isParentTypeMatched(@Nullable JavaType type) {
-                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
-                return TypeUtils.isOfClassType(fq, "java.util.Set") || TypeUtils.isOfType(fq, JavaType.ShallowClass.build("java.lang.Object"));
-            }
-        });
-    }
 }
 

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOfTest.java
@@ -444,4 +444,45 @@ class NoGuavaImmutableListOfTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotChangeNestedLists() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+                import java.util.List;
+                                
+                class A {
+                    Object o = List.of(ImmutableList.of(1, 2), ImmutableList.of(2, 3));
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotchangeAssignToImmutableList() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+                                
+                class Test {
+                    ImmutableList<String> l = ImmutableList.of();
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapOfTest.java
@@ -478,29 +478,44 @@ class NoGuavaImmutableMapOfTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/205")
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
     @Test
-    void nestedMaps() {
+    void doNotChangeNestedMaps() {
         //language=java
         rewriteRun(
           version(
             java(
               """
                 import com.google.common.collect.ImmutableMap;
-                                
-                class A {
-                    Object o = ImmutableMap.of(1, ImmutableMap.of(2, 3));
-                }
-                """,
-              """
                 import java.util.Map;
                                 
                 class A {
-                    Object o = Map.of(1, Map.of(2, 3));
+                    Object o = Map.of(1, ImmutableMap.of(2, 3));
                 }
                 """
             ),
             11
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotchangeAssignToImmutableMap() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Map;
+                import com.google.common.collect.ImmutableMap;
+                                
+                class Test {
+                    ImmutableMap<String, String> m = ImmutableMap.of();
+                }
+                """
+            ),
+            9
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetOfTest.java
@@ -443,4 +443,45 @@ class NoGuavaImmutableSetOfTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotChangeNestedSets() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+                import java.util.Set;
+                                
+                class A {
+                    Object o = Set.of(ImmutableSet.of(1, 2));
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotchangeAssignToImmutableSet() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+                                
+                class Test {
+                    ImmutableSetp<String> m = ImmutableSet.of();
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
First, we removed a previous change that allowed Map.of to be assigned to ImmutableMap (this was done to allow nested maps), but was causing uncompilable code.

Added some tests to validate that we do not produce changes in those scenarios for all three collections (List, Set, Map).

Also, since all three recipes (List, Set, Map), have the same duplicated code that needs to be synched, and already had slightly different versions, I've decided to extract it in a parent class, to avoid future inconsistence problems like it was happening right now

## What's your motivation?
Fixes #256 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
