### PR TITLE
Add tests to reproduce exceptions in UseVarForGenericsConstructors

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -75,6 +75,9 @@ public class UseVarForGenericMethodInvocations extends Recipe {
             boolean argumentsEmpty = ((J.MethodInvocation) initializer).getArguments().stream().allMatch(p -> p instanceof J.Empty);
             if (hasNoTypeParams && argumentsEmpty) return vd;
 
+            // mark imports for removal if unused
+            if (vd.getType() instanceof JavaType.FullyQualified) maybeRemoveImport((JavaType.FullyQualified) vd.getType());
+
             return transformToVar(vd, new ArrayList<>(), new ArrayList<>());
         }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
@@ -80,6 +80,9 @@ public class UseVarForGenericsConstructors extends Recipe {
                     .reduce(false, Boolean::logicalOr);
             if (genericHasBounds) return vd;
 
+            // mark imports for removal if unused
+            if (vd.getType() instanceof JavaType.FullyQualified) maybeRemoveImport((JavaType.FullyQualified) vd.getType());
+
             return transformToVar(vd, leftTypes, rightTypes);
         }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
@@ -46,10 +46,10 @@ public class UseVarForGenericsConstructors extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new UsesJavaVersion<>(10),
-                new UseVarForGenericsConstructors.UseVarForGenericsVisitor());
+                new UseVarForGenericsConstructorsVisitor());
     }
 
-    static final class UseVarForGenericsVisitor extends JavaIsoVisitor<ExecutionContext> {
+    static final class UseVarForGenericsConstructorsVisitor extends JavaIsoVisitor<ExecutionContext> {
         private final JavaTemplate template = JavaTemplate.builder("var #{} = #{any()}")
                 .javaParser(JavaParser.fromJavaVersion()).build();
 
@@ -76,7 +76,7 @@ public class UseVarForGenericsConstructors extends Recipe {
         }
 
         /**
-         * Tries to extract the genric parameters from the expression,
+         * Tries to extract the generic parameters from the expression,
          * if the Initializer is no new class or not of a parameterized type, returns null to signale "no info".
          * if the initializer uses empty diamonds use an empty list to signale no type information
          * @param initializer to extract parameters from
@@ -101,9 +101,14 @@ public class UseVarForGenericsConstructors extends Recipe {
             return null;
         }
 
-        private List<JavaType> extractParameters(@Nullable JavaType.Variable variableType) {
-            if (variableType != null && variableType.getType() instanceof JavaType.Parameterized) {
-                return ((JavaType.Parameterized) variableType.getType()).getTypeParameters();
+        /**
+         * Try to extract the parameters from the variables type.
+         * @param variable to extract from
+         * @return may be empty list of type parameters
+         */
+        private List<JavaType> extractParameters(@Nullable JavaType.Variable variable) {
+            if (variable != null && variable.getType() instanceof JavaType.Parameterized) {
+                return ((JavaType.Parameterized) variable.getType()).getTypeParameters();
             } else {
                 return new ArrayList<>();
             }
@@ -113,14 +118,17 @@ public class UseVarForGenericsConstructors extends Recipe {
             Expression initializer = vd.getVariables().get(0).getInitializer();
             String simpleName = vd.getVariables().get(0).getSimpleName();
 
+
             // if left is defined but not right, copy types to initializer
             if(rightTypes.isEmpty() && !leftTypes.isEmpty()) {
                 // we need to switch type infos from left to right here
                 List<Expression> typeArgument = leftTypes.stream()
-                        .map(t ->
-                                new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, ((JavaType.Class)t).getClassName(), t, null))
+                        .map(UseVarForGenericsConstructorsVisitor::typeToExpression)
                         .collect(Collectors.toList());
-                J.ParameterizedType typedInitializerClazz = ((J.ParameterizedType) ((J.NewClass) initializer).getClazz()).withTypeParameters(typeArgument);
+
+                J.ParameterizedType typedInitializerClazz = ((J.ParameterizedType) ((J.NewClass) initializer)
+                        .getClazz())
+                        .withTypeParameters(typeArgument);
                 initializer = ((J.NewClass) initializer).withClazz(typedInitializerClazz);
             }
 
@@ -142,6 +150,48 @@ public class UseVarForGenericsConstructors extends Recipe {
             }
 
             return result;
+        }
+
+        /**
+         * recursively map a JavaType to an Expression with same semantics
+         * @param type to map
+         * @return semantically equal Expression
+         */
+        private static Expression typeToExpression(JavaType type) {
+            if (type instanceof JavaType.Class) { // easy just parse to identifier
+                String className = ((JavaType.Class) type).getClassName();
+                return new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, className, type, null);
+            }
+            if (type instanceof JavaType.GenericTypeVariable) {
+                String variableName = ((JavaType.GenericTypeVariable) type).getName();
+                J.Identifier identifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, variableName, null, null);
+
+                List<JavaType> bounds1 = ((JavaType.GenericTypeVariable) type).getBounds();
+                if (bounds1.isEmpty()) {
+                    return identifier;
+                } else {
+                    /*
+                    List<JRightPadded<TypeTree>> bounds = bounds1.stream()
+                            .map(b -> new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, , null, null))
+                            .map(JRightPadded::build)
+                            .collect(Collectors.toList());
+
+                    return new J.TypeParameter(Tree.randomId(), Space.EMPTY, Markers.EMPTY, new ArrayList<>(), identifier, JContainer.build(bounds));
+                     */
+                    throw new IllegalStateException("Generic type variables with bound are not supported, yet.");
+                }
+            }
+            if (type instanceof JavaType.Parameterized) { // recursively parse
+                List<JRightPadded<Expression>> typeParams = ((JavaType.Parameterized) type).getTypeParameters().stream()
+                        .map(UseVarForGenericsConstructorsVisitor::typeToExpression)
+                        .map(JRightPadded::build)
+                        .collect(Collectors.toList());
+
+                NameTree clazz = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, ((JavaType.Parameterized) type).getClassName(),null, null);
+                return new J.ParameterizedType(Tree.randomId(), Space.EMPTY, Markers.EMPTY, clazz, JContainer.build(typeParams), type);
+            }
+
+            throw new IllegalArgumentException(String.format("Unable to parse expression from JavaType %s", type));
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
@@ -72,6 +72,14 @@ public class UseVarForGenericsConstructors extends Recipe {
             List<JavaType> rightTypes = extractParameters(variable.getInitializer());
             if (rightTypes == null || (leftTypes.isEmpty() && rightTypes.isEmpty())) return vd;
 
+            // skip generics with type bounds, it's not yet implemented
+            boolean genericHasBounds = leftTypes.stream()
+                    .filter(t -> t instanceof JavaType.GenericTypeVariable)
+                    .map(t -> (JavaType.GenericTypeVariable) t)
+                    .map(t -> !t.getBounds().isEmpty())
+                    .reduce(false, Boolean::logicalOr);
+            if (genericHasBounds) return vd;
+
             return transformToVar(vd, leftTypes, rightTypes);
         }
 
@@ -164,7 +172,7 @@ public class UseVarForGenericsConstructors extends Recipe {
             }
             if (type instanceof JavaType.GenericTypeVariable) {
                 String variableName = ((JavaType.GenericTypeVariable) type).getName();
-                J.Identifier identifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, variableName, null, null);
+                J.Identifier identifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, variableName, type, null);
 
                 List<JavaType> bounds1 = ((JavaType.GenericTypeVariable) type).getBounds();
                 if (bounds1.isEmpty()) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.migrate.lang.var;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -27,7 +25,11 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeTree;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -72,6 +74,9 @@ public class UseVarForObject extends Recipe {
             boolean usesGenerics = DeclarationCheck.useGenerics(vd);
             boolean usesTernary = DeclarationCheck.initializedByTernary(vd);
             if (isPrimitive || usesGenerics || usesTernary) return vd;
+
+            // mark imports for removal if unused
+            if (vd.getType() instanceof JavaType.FullyQualified) maybeRemoveImport((JavaType.FullyQualified) vd.getType());
 
             return transformToVar(vd);
         }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitive.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitive.java
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.java.migrate.lang.var;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
+import static java.lang.String.format;
+
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -29,7 +29,8 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
-import static java.lang.String.format;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -78,6 +79,8 @@ public class UseVarForPrimitive extends Recipe {
             boolean isByteVariable = DeclarationCheck.declarationHasType(vd, BYTE_TYPE);
             boolean isShortVariable = DeclarationCheck.declarationHasType(vd, SHORT_TYPE);
             if (isNoPrimitive || isByteVariable || isShortVariable) return vd;
+
+            // no need to remove imports, because primitives are never imported
 
             return transformToVar(vd);
         }

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseVarKeywordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseVarKeywordTest.java
@@ -21,6 +21,7 @@ import static org.openrewrite.java.Assertions.version;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Example;
 import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -123,8 +124,6 @@ class UseVarKeywordTest implements RewriteTest {
               version(
                 java("""
                   package com.example.app;
-                        
-                  import java.util.Date;
                         
                   class A {
                     void m() {
@@ -390,6 +389,7 @@ class UseVarKeywordTest implements RewriteTest {
         @Nested
         class Applicable {
             @Test
+            @Example
             void forString() {
                 //language=java
                 rewriteRun(
@@ -713,6 +713,7 @@ class UseVarKeywordTest implements RewriteTest {
                     java("""
                   package com.example.app;
                                     
+                  import java.util.List;
                   import java.util.ArrayList;
                                     
                   class A {
@@ -756,7 +757,6 @@ class UseVarKeywordTest implements RewriteTest {
                           package com.example.app;
                           
                           import java.util.ArrayList;
-                          import java.util.List;
                           
                           class A {
                             void m() {
@@ -769,6 +769,7 @@ class UseVarKeywordTest implements RewriteTest {
                 );
             }
             @Test
+            @Example
             void withDiamondOperator() {
                 //language=java
                 rewriteRun(
@@ -785,9 +786,8 @@ class UseVarKeywordTest implements RewriteTest {
                     }
                   }
                   ""","""
-                  package com.example.app;
+                  package com.example.app;         
                   
-                  import java.util.List;                 
                   import java.util.ArrayList;
                                     
                   class A {

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -19,6 +19,7 @@ import static org.openrewrite.java.Assertions.*;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -38,10 +39,6 @@ public class UseVarForGenericMethodInvocationsTest implements RewriteTest {
               version(
                 java("""
                 package com.example.app;
-                                    
-                import java.util.Arrays;
-                import java.util.List;
-                import java.util.stream.Collectors;
                                     
                 class A {
                   static String myString(String ... values) {
@@ -160,6 +157,7 @@ public class UseVarForGenericMethodInvocationsTest implements RewriteTest {
     @Nested
     class Applicable {
         @Test
+        @DocumentExample
         void withJDKFactoryMethods() {
             //language=java
             rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
@@ -17,10 +17,8 @@ package org.openrewrite.java.migrate.lang.var;
 
 import static org.openrewrite.java.Assertions.*;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -33,6 +31,29 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
 
     @Nested
     class NotApplicable {
+
+        @Test
+        void boundedGenerics(){
+            // could be var lst = new ArrayList<? extends String>();
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                      package com.example.app;
+                                  
+                      import java.util.List;
+                      import java.util.ArrayList;
+                                        
+                      class A {
+                          void generic() {
+                              List<? extends String> lst = new ArrayList<>();
+                          }
+                      }
+                      """),
+                10
+              )
+            );
+        }
         @Test
         void forEmptyFactoryMethod() {
             //language=java
@@ -151,7 +172,6 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
         @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/257")
         class AdvancedGenerics {
             @Test
-            @Disabled("AST look wrong for OpenRewrite but its valid")
             void genericMethod() {
                 //language=java
                 rewriteRun(
@@ -185,7 +205,6 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
         }
 
         @Test
-        @Disabled("AST look wrong for OpenRewrite but its valid")
         void unboundedGenerics(){
             //language=java
             rewriteRun(
@@ -219,8 +238,8 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
         }
 
             @Test
-            @ExpectedToFail("Fails with IllegalStateException because not yet implemented")
             void boundedGenerics(){
+                // could be var lst = new ArrayList<? extends String>();
                 //language=java
                 rewriteRun(
                   version(
@@ -235,55 +254,44 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                           List<? extends String> lst = new ArrayList<>();
                       }
                   }
-                  ""","""
-                  package com.example.app;
-                              
-                  import java.util.List;
-                  import java.util.ArrayList;
-                                    
-                  class A {
-                      void generic() {
-                          var lst = new ArrayList<? extends String>();
-                      }
-                  }
                   """),
                     10
                   )
                 );
             }
 
-        @Test
-        void inceptionGenerics() {
-            //language=java
-            rewriteRun(
-              version(
-                java("""
-                  package com.example.app;
-                              
-                  import java.util.List;
-                  import java.util.ArrayList;
-                                    
-                  class A {
-                      void generic() {
-                          List<List<Object>> lst = new ArrayList<>();
+            @Test
+            void inceptionGenerics() {
+                //language=java
+                rewriteRun(
+                  version(
+                    java("""
+                      package com.example.app;
+                                  
+                      import java.util.List;
+                      import java.util.ArrayList;
+                                        
+                      class A {
+                          void generic() {
+                              List<List<Object>> lst = new ArrayList<>();
+                          }
                       }
-                  }
-                  """, """
-                  package com.example.app;
-                              
-                  import java.util.List;
-                  import java.util.ArrayList;
-                                    
-                  class A {
-                      void generic() {
-                          var lst = new ArrayList<List<Object>>();
+                      """, """
+                      package com.example.app;
+                                  
+                      import java.util.List;
+                      import java.util.ArrayList;
+                                        
+                      class A {
+                          void generic() {
+                              var lst = new ArrayList<List<Object>>();
+                          }
                       }
-                  }
-                  """),
-                10
-              )
-            );
-        }
+                      """),
+                    10
+                  )
+                );
+            }
 
             @Test
             void twoParams() {

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
@@ -17,8 +17,11 @@ package org.openrewrite.java.migrate.lang.var;
 
 import static org.openrewrite.java.Assertions.*;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -143,6 +146,179 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
 
     @Nested
     class Applicable {
+
+        @Nested
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/257")
+        class AdvancedGenerics {
+            @Test
+            @Disabled("AST look wrong for OpenRewrite but its valid")
+            void genericMethod() {
+                //language=java
+                rewriteRun(
+                  version(
+                    java("""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      static <T> void generic() {
+                          List<T> lst = new ArrayList<>();
+                      }
+                  }
+                  ""","""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      static <T> void generic() {
+                          var lst = new ArrayList<T>();
+                      }
+                  }
+                  """),
+                10
+              )
+            );
+        }
+
+        @Test
+        @Disabled("AST look wrong for OpenRewrite but its valid")
+        void unboundedGenerics(){
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      void generic() {
+                          List<?> lst = new ArrayList<>();
+                      }
+                  }
+                  ""","""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      void generic() {
+                          var lst = new ArrayList<?>();
+                      }
+                  }
+                  """),
+                10
+              )
+            );
+        }
+
+            @Test
+            @ExpectedToFail("Fails with IllegalStateException because not yet implemented")
+            void boundedGenerics(){
+                //language=java
+                rewriteRun(
+                  version(
+                    java("""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      void generic() {
+                          List<? extends String> lst = new ArrayList<>();
+                      }
+                  }
+                  ""","""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      void generic() {
+                          var lst = new ArrayList<? extends String>();
+                      }
+                  }
+                  """),
+                    10
+                  )
+                );
+            }
+
+        @Test
+        void inceptionGenerics() {
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      void generic() {
+                          List<List<Object>> lst = new ArrayList<>();
+                      }
+                  }
+                  """, """
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                      void generic() {
+                          var lst = new ArrayList<List<Object>>();
+                      }
+                  }
+                  """),
+                10
+              )
+            );
+        }
+
+            @Test
+            void twoParams() {
+                //language=java
+                rewriteRun(
+                  version(
+                    java("""
+                  package com.example.app;
+                              
+                  import java.util.Map;
+                  import java.util.HashMap;
+                                    
+                  class A {
+                      void twoParams() {
+                          Map<String, Object> map = new HashMap<>();
+                      }
+                  }
+                  """, """
+                  package com.example.app;
+                              
+                  import java.util.Map;
+                  import java.util.HashMap;
+                                    
+                  class A {
+                      void twoParams() {
+                          var map = new HashMap<String, Object>();
+                      }
+                  }
+                  """),
+                    10
+                  )
+                );
+            }
+    }
+
         @Test
         void ifWelldefined() {
             //language=java

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
@@ -19,6 +19,7 @@ import static org.openrewrite.java.Assertions.*;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Example;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -189,8 +190,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                   }
                   ""","""
                   package com.example.app;
-                              
-                  import java.util.List;
+
                   import java.util.ArrayList;
                                     
                   class A {
@@ -222,8 +222,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                   }
                   ""","""
                   package com.example.app;
-                              
-                  import java.util.List;
+                                                
                   import java.util.ArrayList;
                                     
                   class A {
@@ -278,7 +277,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                       }
                       """, """
                       package com.example.app;
-                                  
+
                       import java.util.List;
                       import java.util.ArrayList;
                                         
@@ -311,8 +310,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                   }
                   """, """
                   package com.example.app;
-                              
-                  import java.util.Map;
+
                   import java.util.HashMap;
                                     
                   class A {
@@ -345,8 +343,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                   }
                   ""","""
                   package com.example.app;
-                  
-                  import java.util.List;
+
                   import java.util.ArrayList;
                                     
                   class A {
@@ -361,6 +358,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
         }
 
         @Test
+        @Example
         void withTypeParameterInDefinitionOnly() {
             //language=java
             rewriteRun(
@@ -378,8 +376,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                   }
                   ""","""
                   package com.example.app;
-                                    
-                  import java.util.List;
+
                   import java.util.ArrayList;
                                     
                   class A {

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
@@ -85,6 +85,7 @@ class UseVarForObjectsTest extends VarBaseTest {
         }
 
         @Test
+        @DocumentExample
         void withModifier() {
             //language=java
             rewriteRun(


### PR DESCRIPTION
## What's changed?
UseVarForGenericsConstructors failed for some edge cases. They are documented by #257 and are fixed in this PR.

## What's your motivation?
Close #257 

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?
No, would lead to broken recipes.

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] ~~I've updated the documentation (if applicable)~~
