### PR TITLE
Fix errors for Arrays and inception bounds

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.migrate.lang.var;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.openrewrite.*;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -72,13 +71,22 @@ public class UseVarForGenericMethodInvocations extends Recipe {
 
             //if no type paramters are present and no arguments we assume the type is hard to determine a needs manual action
             boolean hasNoTypeParams = ((J.MethodInvocation) initializer).getTypeParameters() == null;
-            boolean argumentsEmpty = ((J.MethodInvocation) initializer).getArguments().stream().allMatch(p -> p instanceof J.Empty);
+            boolean argumentsEmpty = allArgumentsEmpty((J.MethodInvocation) initializer);
             if (hasNoTypeParams && argumentsEmpty) return vd;
 
             // mark imports for removal if unused
             if (vd.getType() instanceof JavaType.FullyQualified) maybeRemoveImport((JavaType.FullyQualified) vd.getType());
 
             return transformToVar(vd, new ArrayList<>(), new ArrayList<>());
+        }
+
+        private static boolean allArgumentsEmpty(J.MethodInvocation invocation){
+            for (Expression argument : invocation.getArguments()) {
+                if (!(argument instanceof J.Empty)) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         private J.VariableDeclarations transformToVar(J.VariableDeclarations vd, List<JavaType> leftTypes, List<JavaType> rightTypes) {
@@ -88,10 +96,10 @@ public class UseVarForGenericMethodInvocations extends Recipe {
             // if left is defined but not right, copy types to initializer
             if(rightTypes.isEmpty() && !leftTypes.isEmpty()) {
                 // we need to switch type infos from left to right here
-                List<Expression> typeArgument = leftTypes.stream()
-                        .map(t ->
-                                new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, ((JavaType.Class)t).getClassName(), t, null))
-                        .collect(Collectors.toList());
+                List<Expression> typeArgument = new ArrayList<>();
+                for (JavaType t : leftTypes) {
+                    typeArgument.add(new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, ((JavaType.Class) t).getClassName(), t, null));
+                }
                 J.ParameterizedType typedInitializerClazz = ((J.ParameterizedType) ((J.NewClass) initializer).getClazz()).withTypeParameters(typeArgument);
                 initializer = ((J.NewClass) initializer).withClazz(typedInitializerClazz);
             }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
@@ -76,9 +76,7 @@ public class UseVarForGenericsConstructors extends Recipe {
 
             // skip generics with type bounds, it's not yet implemented
             boolean genericHasBounds = leftTypes.stream()
-                    .filter(t -> t instanceof JavaType.GenericTypeVariable)
-                    .map(t -> (JavaType.GenericTypeVariable) t)
-                    .map(t -> !t.getBounds().isEmpty())
+                    .map(UseVarForGenericsConstructorsVisitor::hasBounds)
                     .reduce(false, Boolean::logicalOr);
             if (genericHasBounds) return vd;
 
@@ -86,6 +84,18 @@ public class UseVarForGenericsConstructors extends Recipe {
             if (vd.getType() instanceof JavaType.FullyQualified) maybeRemoveImport((JavaType.FullyQualified) vd.getType());
 
             return transformToVar(vd, leftTypes, rightTypes);
+        }
+
+        private static boolean hasBounds(JavaType type) {
+            if (type instanceof JavaType.Parameterized) {
+                return ((JavaType.Parameterized) type).getTypeParameters().stream()
+                        .map(UseVarForGenericsConstructorsVisitor::hasBounds)
+                        .reduce(false, Boolean::logicalOr);
+            }
+            if (type instanceof JavaType.GenericTypeVariable) {
+                return !((JavaType.GenericTypeVariable) type).getBounds().isEmpty();
+            }
+            return false;
         }
 
         /**

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -188,7 +188,36 @@ public class UseVarForGenericMethodInvocationsTest implements RewriteTest {
             );
         }
 
-
+        @Test
+        void withJDKFactoryMethodsAndBounds() {
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                package com.example.app;
+                                    
+                import java.util.List;
+                                    
+                class A {
+                  void m() {
+                      List<? extends String> lst = List.of("Test");
+                  }
+                }
+                ""","""
+                package com.example.app;
+                                    
+                import java.util.List;
+                                    
+                class A {
+                  void m() {
+                      var lst = List.of("Test");
+                  }
+                }
+                """),
+                10
+              )
+            );
+        }
 
         @Test
         void withOwnFactoryMethods() {

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
@@ -357,7 +357,6 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
             );
         }
 
-        //see https://app.moderne.io/results/CuzcK/details/eyJfX3R5cGVuYW1lIjoiR2l0SHViUmVwb3NpdG9yeSIsIm9yaWdpbiI6ImdpdGh1Yi5jb20iLCJwYXRoIjoic3ByaW5nLXByb2plY3RzL3NwcmluZy12YXVsdCIsImJyYW5jaCI6Im1haW4ifQ==?referrer=%2Fresults%2FCuzcK%3Ffilter%3DeyJpdGVtcyI6W3siZmllbGQiOiJzdGF0dXMiLCJvcGVyYXRvciI6Im5vdCIsImlkIjo0Nzc3MiwidmFsdWUiOiJGSU5JU0hFRCJ9XSwibG9naWNPcGVyYXRvciI6ImFuZCIsInF1aWNrRmlsdGVyVmFsdWVzIjpbXSwicXVpY2tGaWx0ZXJMb2dpY09wZXJhdG9yIjoiYW5kIn0%25253D
         @Test
         void arrayAsType() {
             //language=java

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
@@ -323,7 +323,7 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                   )
                 );
             }
-    }
+        }
 
         @Test
         void ifWelldefined() {
@@ -350,6 +350,63 @@ public class UseVarForGenericsConstructorsTest implements RewriteTest {
                     void m() {
                         var strs = new ArrayList<String>();
                     }
+                  }
+                  """),
+                10
+              )
+            );
+        }
+
+        //see https://app.moderne.io/results/CuzcK/details/eyJfX3R5cGVuYW1lIjoiR2l0SHViUmVwb3NpdG9yeSIsIm9yaWdpbiI6ImdpdGh1Yi5jb20iLCJwYXRoIjoic3ByaW5nLXByb2plY3RzL3NwcmluZy12YXVsdCIsImJyYW5jaCI6Im1haW4ifQ==?referrer=%2Fresults%2FCuzcK%3Ffilter%3DeyJpdGVtcyI6W3siZmllbGQiOiJzdGF0dXMiLCJvcGVyYXRvciI6Im5vdCIsImlkIjo0Nzc3MiwidmFsdWUiOiJGSU5JU0hFRCJ9XSwibG9naWNPcGVyYXRvciI6ImFuZCIsInF1aWNrRmlsdGVyVmFsdWVzIjpbXSwicXVpY2tGaWx0ZXJMb2dpY09wZXJhdG9yIjoiYW5kIn0%25253D
+        @Test
+        void arrayAsType() {
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                  package com.example.app;
+                              
+                  import java.util.List;
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                    void m() {
+                        List<char[]> strs = new ArrayList<>();
+                    }
+                  }
+                  ""","""
+                  package com.example.app;
+
+                  import java.util.ArrayList;
+                                    
+                  class A {
+                    void m() {
+                        var strs = new ArrayList<char[]>();
+                    }
+                  }
+                  """),
+                10
+              )
+            );
+        }
+
+        @Test
+        void twoParamsWithBounds() {
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                  package com.example.app;
+                              
+                  import java.util.Map;
+                  import java.util.LinkedHashMap;
+                                    
+                  class AbstractOAuth2Configurer {}
+                                    
+                  class A {
+                      void twoParams() {
+                          Map<Class<? extends AbstractOAuth2Configurer>, AbstractOAuth2Configurer> configurers = new LinkedHashMap<>();
+                      }
                   }
                   """),
                 10


### PR DESCRIPTION
## What's changed?
Fixed two additional edge cases in `UseVarForGenericsConstructors` found with run [moderne.io/results/CuzcK](https://app.moderne.io/results/CuzcK?filter=eyJpdGVtcyI6W3siZmllbGQiOiJzdGF0dXMiLCJvcGVyYXRvciI6Im5vdCIsImlkIjo0Nzc3MiwidmFsdWUiOiJGSU5JU0hFRCJ9XSwibG9naWNPcGVyYXRvciI6ImFuZCIsInF1aWNrRmlsdGVyVmFsdWVzIjpbXSwicXVpY2tGaWx0ZXJMb2dpY09wZXJhdG9yIjoiYW5kIn0%253D)

## What's your motivation?
Fix edgecases in UseVarForGenericsConstructors.

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?
It breaks moderne.io runs, so no.

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] ~I've updated the documentation (if applicable)~
