### PR TITLE
fix: added emptyList for annotations akin to the adaption made to cor…

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
+import static java.util.Collections.emptyList;
+
 public class UseVarForGenericMethodInvocations extends Recipe {
     @Override
     public String getDisplayName() {
@@ -98,7 +100,7 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 // we need to switch type infos from left to right here
                 List<Expression> typeArgument = new ArrayList<>();
                 for (JavaType t : leftTypes) {
-                    typeArgument.add(new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, ((JavaType.Class) t).getClassName(), t, null));
+                    typeArgument.add(new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY,  emptyList(), ((JavaType.Class) t).getClassName(), t, null));
                 }
                 J.ParameterizedType typedInitializerClazz = ((J.ParameterizedType) ((J.NewClass) initializer).getClazz()).withTypeParameters(typeArgument);
                 initializer = ((J.NewClass) initializer).withClazz(typedInitializerClazz);

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
@@ -30,6 +30,8 @@ import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
+import static java.util.Collections.emptyList;
+
 public class UseVarForGenericsConstructors extends Recipe {
     @Override
     public String getDisplayName() {
@@ -197,7 +199,7 @@ public class UseVarForGenericsConstructors extends Recipe {
             }
             if (type instanceof JavaType.Class) {
                 String className = ((JavaType.Class) type).getClassName();
-                return new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, className, type, null);
+                return new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY,  emptyList(), className, type, null);
             }
             if (type instanceof JavaType.Array){
                 int dimensions = StringUtils.countOccurrences(type.toString(), "[]");
@@ -207,7 +209,7 @@ public class UseVarForGenericsConstructors extends Recipe {
             }
             if (type instanceof JavaType.GenericTypeVariable) {
                 String variableName = ((JavaType.GenericTypeVariable) type).getName();
-                J.Identifier identifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, variableName, type, null);
+                J.Identifier identifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), variableName, type, null);
 
                 List<JavaType> bounds1 = ((JavaType.GenericTypeVariable) type).getBounds();
                 if (bounds1.isEmpty()) {
@@ -232,7 +234,7 @@ public class UseVarForGenericsConstructors extends Recipe {
                     typeParamsExpression.add(JRightPadded.build(typeToExpression(curType)));
                 }
 
-                NameTree clazz = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, ((JavaType.Parameterized) type).getClassName(),null, null);
+                NameTree clazz = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), ((JavaType.Parameterized) type).getClassName(),null, null);
                 return new J.ParameterizedType(Tree.randomId(), Space.EMPTY, Markers.EMPTY, clazz, JContainer.build(typeParamsExpression), type);
             }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added the emptyList() to J.Field akin to the changes made to core after commit #df5478b8592d90bba65923878b08ae0a412fdbc9

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Working build

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
No

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
