### PR TITLE
Upgrade Lombok for Java 11

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -41,6 +41,7 @@ recipeList:
   - org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs
   - org.openrewrite.java.migrate.lang.JavaLangAPIs
   - org.openrewrite.java.migrate.logging.JavaLoggingAPIs
+  - org.openrewrite.java.migrate.lombok.UpdateLombokToJava11
   - org.openrewrite.java.migrate.net.JavaNetAPIs
   - org.openrewrite.java.migrate.sql.JavaSqlAPIs
   - org.openrewrite.java.migrate.javax.JavaxLangModelUtil

--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -30,7 +30,6 @@ recipeList:
   - org.openrewrite.java.migrate.Java8toJava11
   - org.openrewrite.java.migrate.JavaVersion17
   - org.openrewrite.java.migrate.lang.StringFormatted
-  - org.openrewrite.java.migrate.lombok.UpdateLombokToJava17
   - org.openrewrite.github.SetupJavaUpgradeJavaVersion
   - org.openrewrite.staticanalysis.InstanceOfPatternMatch
   - org.openrewrite.java.migrate.lang.UseTextBlocks

--- a/src/main/resources/META-INF/rewrite/lombok.yml
+++ b/src/main/resources/META-INF/rewrite/lombok.yml
@@ -15,9 +15,9 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.lombok.UpdateLombokToJava17
-displayName: Migrate Lombok to a Java 17 compatible version
-description: Update Lombok dependency to a version that is compatible with Java 17 and migrate experimental Lombok types that have been promoted.
+name: org.openrewrite.java.migrate.lombok.UpdateLombokToJava11
+displayName: Migrate Lombok to a Java 11 compatible version
+description: Update Lombok dependency to a version that is compatible with Java 11 and migrate experimental Lombok types that have been promoted.
 tags:
   - java17
   - lombok

--- a/src/test/java/org/openrewrite/java/migrate/lombok/UpdateLombokToJava11Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/UpdateLombokToJava11Test.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.java.Assertions.java;
 
-public class UpdateLombokToJava17Test implements RewriteTest {
+class UpdateLombokToJava11Test implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -37,7 +37,7 @@ public class UpdateLombokToJava17Test implements RewriteTest {
             Environment.builder()
               .scanRuntimeClasspath("org.openrewrite.java.migrate.lombok")
               .build()
-              .activateRecipes("org.openrewrite.java.migrate.lombok.UpdateLombokToJava17")
+              .activateRecipes("org.openrewrite.java.migrate.lombok.UpdateLombokToJava11")
           )
           .parser(
             //language=java
@@ -71,7 +71,7 @@ public class UpdateLombokToJava17Test implements RewriteTest {
 
     @SuppressWarnings({"DeprecatedLombok", "deprecation", "Lombok", "RedundantModifiersValueLombok"})
     @Test
-    void upgradeLombokToJava17() {
+    void updateLombokToJava11() {
         rewriteRun(
           pomXml(
             //language=xml


### PR DESCRIPTION
## What's changed?
Moved Lombok upgrade from Java 17 to Java 11.

## What's your motivation?
Java 11 looks to require Lombok v1.18.4+ (October 30th, 2018) as per https://projectlombok.org/changelog
We failed to upgrade that for Java versions below 17.

## Any additional context
As reported on StackOverflow: https://stackoverflow.com/questions/76703460/openrewrite-recipe-dont-do-anything?noredirect=1#comment135315498_76703460
