### PR TITLE
Migrate `javax.annotation.Nullable` to `jakarta.annotation.Nullable`

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -144,6 +144,9 @@ recipeList:
       oldFullyQualifiedTypeName: javax.annotation.ManagedBean
       newFullyQualifiedTypeName: jakarta.annotation.ManagedBean
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.annotation.Nullable
+      newFullyQualifiedTypeName: jakarta.annotation.Nullable
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.PostConstruct
       newFullyQualifiedTypeName: jakarta.annotation.PostConstruct
   - org.openrewrite.java.ChangeType:

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -144,6 +144,9 @@ recipeList:
       oldFullyQualifiedTypeName: javax.annotation.ManagedBean
       newFullyQualifiedTypeName: jakarta.annotation.ManagedBean
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.annotation.Nonnull
+      newFullyQualifiedTypeName: jakarta.annotation.Nonnull
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Nullable
       newFullyQualifiedTypeName: jakarta.annotation.Nullable
   - org.openrewrite.java.ChangeType:


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Introduced support for migrating `javax.annotation.Nullable` to `jakarta.annotation.Nullable`.

## What's your motivation?

When running this recipe on our internal codebase at Picnic we noticed that the `javax.annotation.Nullable` annotation is not being migrated to `jakarta.annotation.Nullable`. After some investigation it was clear that this annotation was simply missing from [this recipe](https://github.com/rickie/rewrite-migrate-java/blob/main/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml#L131-L160). 

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context

To test this change, I used the `./gradlew publishToMavenLocal` command and ran the recipe locally. With this change it does work and I get the following diff (random example):

```diff
+import jakarta.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
```
