### PR TITLE
Replace `StringUtils` methods with JDK templates

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.apache.commons.lang;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
@@ -1,0 +1,67 @@
+package org.openrewrite.java.migrate.apache.commons.lang;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class StringUtilsMethodToJdkTemplate extends Recipe {
+
+    @Option(displayName = "Method",
+            description = "The Apache Commons Lang `StringUtils` method to convert to a JDK equivalent.",
+            example = "org.apache.commons.lang3.StringUtils isBlank(java.lang.String)")
+    String methodPattern;
+
+    @Option(displayName = "JDK template",
+            description = "The JDK method to convert to.",
+            example = "#{any(String)}.isBlank()")
+    String jdkTemplate;
+
+    @Option(displayName = "Imports",
+            description = "The imports to add to the compilation unit.",
+            example = "java.util.Objects",
+            required = false)
+    String[] imports;
+
+    @Override
+    public String getDisplayName() {
+        return "Convert Apache Commons Lang `StringUtils` method to JDK equivalent";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Convert Apache Commons Lang `StringUtils` method to JDK equivalent.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesMethod<>(methodPattern), new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, executionContext);
+                if (new MethodMatcher(methodPattern).matches(method)) {
+                    String[] imports = StringUtilsMethodToJdkTemplate.this.imports == null ?
+                            new String[0] : StringUtilsMethodToJdkTemplate.this.imports;
+                    for (String imp : imports) {
+                        maybeAddImport(imp);
+                    }
+                    maybeRemoveImport(methodPattern.split(" ")[0]);
+                    return JavaTemplate.builder(jdkTemplate)
+                            .imports(imports)
+                            .build()
+                            .apply(updateCursor(mi),
+                                    mi.getCoordinates().replace(),
+                                    ListUtils.map(mi.getArguments(), a -> a instanceof J.Empty ? null : a).toArray());
+                }
+                return mi;
+            }
+        });
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.apache.commons.lang;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
@@ -1,0 +1,41 @@
+package org.openrewrite.java.migrate.apache.commons.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("commons-lang3"));
+    }
+
+    @Test
+    void defaultStringObjectsToString() {
+        rewriteRun(
+          spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
+            "org.apache.commons.lang3.StringUtils defaultString(java.lang.String)",
+            "Objects.toString(#{any()})",
+            new String[]{"java.util.Objects"})),
+          //language=java
+          java("""
+            import org.apache.commons.lang3.StringUtils;
+            
+            class Test {
+               String s = StringUtils.defaultString("foo");
+            }
+            """, """
+            import java.util.Objects;
+            
+            class Test {
+               String s = Objects.toString("foo");
+            }
+            """)
+        );
+    }
+
+}


### PR DESCRIPTION
## What's changed?
Add a configurable recipe that replaces methodPatterns with a JavaTemplate.

## What's your motivation?
Fixes #267

## Anything in particular you'd like reviewers to focus on?
Would we really want to offer the JavaTemplate string as yaml input?
Any risk of yaml configuration issues?
Is this already generic enough to support a variety of use cases?
How would we want to handle non-Apache Commons StringUtils classes?

## Have you considered any alternatives or workarounds?
A dedicated recipe per replacement, but that quickly adds up to a lot of recipes.

## Any additional context
We have a ton of such replacements to do for Apache Maven; this makes that trivial for easy cases.

## TODO
- [ ] Add yaml file
- [ ] Test using yaml file
- [ ] Add additional quick replacements
- [ ] Add an incubating annotation to discourage wider use