### PR TITLE
Replace `StringUtils` Methods with JDK Templates

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.apache.commons.lang;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplate.java
@@ -1,0 +1,67 @@
+package org.openrewrite.java.migrate.apache.commons.lang;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class StringUtilsMethodToJdkTemplate extends Recipe {
+
+    @Option(displayName = "Method",
+            description = "The Apache Commons Lang `StringUtils` method to convert to a JDK equivalent.",
+            example = "org.apache.commons.lang3.StringUtils isBlank(java.lang.String)")
+    String methodPattern;
+
+    @Option(displayName = "JDK template",
+            description = "The JDK method to convert to.",
+            example = "#{any(String)}.isBlank()")
+    String jdkTemplate;
+
+    @Option(displayName = "Imports",
+            description = "The imports to add to the compilation unit.",
+            example = "java.util.Objects",
+            required = false)
+    String[] imports;
+
+    @Override
+    public String getDisplayName() {
+        return "Convert Apache Commons Lang `StringUtils` method to JDK equivalent";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Convert Apache Commons Lang `StringUtils` method to JDK equivalent.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesMethod<>(methodPattern), new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, executionContext);
+                if (new MethodMatcher(methodPattern).matches(method)) {
+                    String[] imports = StringUtilsMethodToJdkTemplate.this.imports == null ?
+                            new String[0] : StringUtilsMethodToJdkTemplate.this.imports;
+                    for (String imp : imports) {
+                        maybeAddImport(imp);
+                    }
+                    maybeRemoveImport(methodPattern.split(" ")[0]);
+                    return JavaTemplate.builder(jdkTemplate)
+                            .imports(imports)
+                            .build()
+                            .apply(updateCursor(mi),
+                                    mi.getCoordinates().replace(),
+                                    ListUtils.map(mi.getArguments(), a -> a instanceof J.Empty ? null : a).toArray());
+                }
+                return mi;
+            }
+        });
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
@@ -36,17 +36,18 @@ class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
           spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
             "org.apache.commons.lang3.StringUtils defaultString(java.lang.String)",
             "Objects.toString(#{any()})",
-            new String[]{"java.util.Objects"})),
+            new String[]{"java.util.Objects"},
+            null)),
           //language=java
           java("""
             import org.apache.commons.lang3.StringUtils;
-            
+
             class Test {
                String s = StringUtils.defaultString("foo");
             }
             """, """
             import java.util.Objects;
-            
+
             class Test {
                String s = Objects.toString("foo");
             }
@@ -60,13 +61,14 @@ class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
           spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
             "org.apache.commons.lang3.StringUtils isBlank(java.lang.CharSequence)",
             "#{any()}.isBlank()",
+            null,
             null
           )),
           //language=java
           java(
             """
               import org.apache.commons.lang3.StringUtils;
-              
+
               class Test {
                   void method() {
                       boolean b = StringUtils.isBlank("hello world");
@@ -90,13 +92,14 @@ class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
           spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
             "org.apache.commons.lang3.StringUtils split(java.lang.String, java.lang.String)",
             "#{any()}.split(#{any()})",
+            null,
             null
           )),
           //language=java
           java(
             """
               import org.apache.commons.lang3.StringUtils;
-              
+
               class Test {
                   void method() {
                       String[] split = StringUtils.split("hello, world", ", ");
@@ -120,13 +123,14 @@ class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
           spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
             "org.apache.commons.lang3.StringUtils replace(java.lang.String, java.lang.String, java.lang.String)",
             "#{any()}.replaceAll(#{any()}, #{any()})",
+            null,
             null
           )),
           //language=java
           java(
             """
               import org.apache.commons.lang3.StringUtils;
-              
+
               class Test {
                   void method() {
                       String rep = StringUtils.replace("hello world", "world", "rewrite");
@@ -150,13 +154,14 @@ class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
           spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
             "org.apache.commons.lang3.StringUtils chop(java.lang.String)",
             "#{any()}.substring(0, #{any()}.length() - 1)",
-            null
+            null,
+            new Integer[]{0, 0}
           )),
           //language=java
           java(
             """
               import org.apache.commons.lang3.StringUtils;
-              
+
               class Test {
                   void method() {
                       String chop = StringUtils.chop("hello world");
@@ -180,7 +185,8 @@ class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
           spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
             "org.apache.commons.lang3.StringUtils repeat(java.lang.String, int)",
             "new String(new char[#{any(int)}]).replace(\"\0\", #{any(java.lang.String)})",
-            null
+            null,
+            new Integer[]{1, 0}
           )),
           //language=java
           java(
@@ -209,14 +215,15 @@ class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
             "org.apache.commons.lang3.StringUtils stripEnd(java.lang.String, java.lang.String)",
-            "(#{any()}.endsWith(#{any()}) ? #{any()}.substring(0, #{any()}.lastIndexOf(#{any()}) : #{any()})",
-            null
+            "(#{any()}.endsWith(#{any()}) ? #{any()}.substring(0, #{any()}.lastIndexOf(#{any()})) : #{any()})",
+            null,
+            new Integer[]{0, 1, 0, 0, 1, 0}
           )),
           //language=java
           java(
             """
               import org.apache.commons.lang3.StringUtils;
-              
+    
               class Test {
                   void method() {
                       String x = StringUtils.stripEnd("hello world", "ld");

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.apache.commons.lang;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/StringUtilsMethodToJdkTemplateTest.java
@@ -1,0 +1,41 @@
+package org.openrewrite.java.migrate.apache.commons.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class StringUtilsMethodToJdkTemplateTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("commons-lang3"));
+    }
+
+    @Test
+    void defaultStringObjectsToString() {
+        rewriteRun(
+          spec -> spec.recipe(new StringUtilsMethodToJdkTemplate(
+            "org.apache.commons.lang3.StringUtils defaultString(java.lang.String)",
+            "Objects.toString(#{any()})",
+            new String[]{"java.util.Objects"})),
+          //language=java
+          java("""
+            import org.apache.commons.lang3.StringUtils;
+            
+            class Test {
+               String s = StringUtils.defaultString("foo");
+            }
+            """, """
+            import java.util.Objects;
+            
+            class Test {
+               String s = Objects.toString("foo");
+            }
+            """)
+        );
+    }
+
+}


### PR DESCRIPTION
## What's changed?
This PR introduces some new tests that should cover all edge cases in the list of `StringUtils` methods to migrate as well as changes to make those tests pass. 

## What's your motivation?
[#267](https://github.com/openrewrite/rewrite-migrate-java/issues/267)

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
