### PR TITLE
Plexus FileUtils refaster template recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
     implementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
 
+    implementation("commons-io:commons-io:2.+")
+    implementation("org.codehaus.plexus:plexus-utils:3.+")
+
     runtimeOnly("org.openrewrite:rewrite-java-8")
     runtimeOnly("org.openrewrite:rewrite-java-11")
     runtimeOnly("org.openrewrite:rewrite-java-17")
@@ -47,7 +50,6 @@ dependencies {
 
     testImplementation("commons-codec:commons-codec:1.+")
     testImplementation("org.apache.commons:commons-lang3:3.+")
-    testImplementation("org.codehaus.plexus:plexus-utils:3.+")
     testImplementation("org.apache.maven.shared:maven-shared-utils:3.+")
 
     testRuntimeOnly("commons-io:commons-io:2.+")

--- a/src/main/.gitignore
+++ b/src/main/.gitignore
@@ -1,1 +1,1 @@
-generated/
+generated

--- a/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
@@ -24,17 +24,7 @@ import java.io.IOException;
 
 class PlexusFileUtils {
 
-    static class DeleteDirectoryString {
-        @BeforeTemplate
-        void before(String dir) throws IOException {
-            FileUtils.deleteDirectory(dir);
-        }
-
-        @AfterTemplate
-        void after(String dir) throws IOException {
-            org.apache.commons.io.FileUtils.deleteDirectory(new File(dir));
-        }
-    }
+    // https://github.com/codehaus-plexus/plexus-utils/blob/master/src/main/java/org/codehaus/plexus/util/StringUtils.java
 
     static class DeleteDirectoryFile {
         @BeforeTemplate
@@ -48,6 +38,18 @@ class PlexusFileUtils {
         }
     }
 
+    static class DeleteDirectoryString {
+        @BeforeTemplate
+        void before(String dir) throws IOException {
+            FileUtils.deleteDirectory(dir);
+        }
+
+        @AfterTemplate
+        void after(String dir) throws IOException {
+            org.apache.commons.io.FileUtils.deleteDirectory(new File(dir));
+        }
+    }
+
     static class FileExistsString {
         @BeforeTemplate
         boolean before(String fileName) throws IOException {
@@ -57,6 +59,18 @@ class PlexusFileUtils {
         @AfterTemplate
         boolean after(String fileName) throws IOException {
             return new File(fileName).exists();
+        }
+    }
+
+    static class GetFile {
+        @BeforeTemplate
+        File before(String fileName) throws IOException {
+            return FileUtils.getFile(fileName);
+        }
+
+        @AfterTemplate
+        File after(String fileName) throws IOException {
+            return new File(fileName);
         }
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
@@ -47,4 +47,16 @@ class PlexusFileUtils {
         }
     }
 
+    static class FileExistsString {
+        @BeforeTemplate
+        boolean before(String fileName) throws IOException {
+            return org.codehaus.plexus.util.FileUtils.fileExists(fileName);
+        }
+
+        @AfterTemplate
+        boolean after(String fileName) throws IOException {
+            return new File(fileName).exists();
+        }
+    }
+
 }

--- a/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.plexus;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+import java.io.File;
+import java.io.IOException;
+
+class PlexusFileUtils {
+
+    static class DeleteDirectoryString {
+        @BeforeTemplate
+        void before(String dir) throws IOException {
+            org.codehaus.plexus.util.FileUtils.deleteDirectory(dir);
+        }
+
+        @AfterTemplate
+        void after(String dir) throws IOException {
+            org.apache.commons.io.FileUtils.deleteDirectory(new File(dir));
+        }
+    }
+
+    static class DeleteDirectoryFile {
+        @BeforeTemplate
+        void before(File dir) throws IOException {
+            org.codehaus.plexus.util.FileUtils.deleteDirectory(dir);
+        }
+
+        @AfterTemplate
+        void after(File dir) throws IOException {
+            org.apache.commons.io.FileUtils.deleteDirectory(dir);
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/plexus/PlexusFileUtils.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.plexus;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +27,7 @@ class PlexusFileUtils {
     static class DeleteDirectoryString {
         @BeforeTemplate
         void before(String dir) throws IOException {
-            org.codehaus.plexus.util.FileUtils.deleteDirectory(dir);
+            FileUtils.deleteDirectory(dir);
         }
 
         @AfterTemplate
@@ -38,7 +39,7 @@ class PlexusFileUtils {
     static class DeleteDirectoryFile {
         @BeforeTemplate
         void before(File dir) throws IOException {
-            org.codehaus.plexus.util.FileUtils.deleteDirectory(dir);
+            FileUtils.deleteDirectory(dir);
         }
 
         @AfterTemplate
@@ -50,7 +51,7 @@ class PlexusFileUtils {
     static class FileExistsString {
         @BeforeTemplate
         boolean before(String fileName) throws IOException {
-            return org.codehaus.plexus.util.FileUtils.fileExists(fileName);
+            return FileUtils.fileExists(fileName);
         }
 
         @AfterTemplate

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.plexus;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class PlexusFileUtilsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpath("commons-io", "plexus-utils"))
+          .recipe(new PlexusFileUtilsRecipes());
+    }
+
+    @Test
+    void uberTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.File;
+              import java.io.IOException;
+              import org.codehaus.plexus.util.FileUtils;
+              class Test {
+                  void test() throws IOException {
+                      File file = new File("test");
+                      FileUtils.deleteDirectory("test");
+                      org.codehaus.plexus.util.FileUtils.deleteDirectory("test");
+                      org.codehaus.plexus.util.FileUtils.deleteDirectory(file);
+                  }
+              }
+              """,
+            """
+              import java.io.File;
+              import java.io.IOException;
+              import org.apache.commons.io.FileUtils;
+              class Test {
+                  void test() throws IOException {
+                      File file = new File("test");
+                      FileUtils.deleteDirectory("test");
+                      org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
+                      org.apache.commons.io.FileUtils.deleteDirectory(test);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -32,45 +32,31 @@ class PlexusFileUtilsTest implements RewriteTest {
     }
 
     @Test
-    void deleteDirectory() {
+    void deleteDirectoryFullyQualified() {
         rewriteRun(
-          spec -> spec.recipes(
-            new PlexusFileUtilsRecipes.DeleteDirectoryFileRecipe(),
-            new PlexusFileUtilsRecipes.DeleteDirectoryStringRecipe()
-          ),
           //language=java
           java(
             """
               import java.io.File;
-              import java.io.IOException;
-              import org.codehaus.plexus.util.FileUtils;
+                            
               class Test {
-                  void test() throws IOException {
-                      FileUtils.deleteDirectory("test");
+                  void test() throws Exception {
                       org.codehaus.plexus.util.FileUtils.deleteDirectory("test");
-
                       File file = new File("test");
-                      FileUtils.deleteDirectory(file);
                       org.codehaus.plexus.util.FileUtils.deleteDirectory(file);
-
-                      FileUtils.dirname("/foo/bar"); // Unused
                   }
               }
               """,
             """
-              import java.io.File;
-              import java.io.IOException;
               import org.apache.commons.io.FileUtils;
+                            
+              import java.io.File;
+                            
               class Test {
-                  void test() throws IOException {
+                  void test() throws Exception {
                       FileUtils.deleteDirectory(new File("test"));
-                      org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
-
                       File file = new File("test");
                       FileUtils.deleteDirectory(file);
-                      org.apache.commons.io.FileUtils.deleteDirectory(file);
-
-                      FileUtils.dirname("/foo/bar"); // Unused
                   }
               }
               """
@@ -79,32 +65,67 @@ class PlexusFileUtilsTest implements RewriteTest {
     }
 
     @Test
-    void deleteDirectoryMinimal() {
+    void deleteDirectorySimpleImport() {
         rewriteRun(
-          spec -> spec.recipes(
-            new PlexusFileUtilsRecipes.DeleteDirectoryStringRecipe()
-          ),
           //language=java
           java(
             """
+              import org.codehaus.plexus.util.FileUtils;
+                            
               import java.io.File;
-              import java.io.IOException;
+                            
               class Test {
-                  void test() throws IOException {
-                      org.codehaus.plexus.util.FileUtils.deleteDirectory("test");
+                  void test() throws Exception {
+                      FileUtils.deleteDirectory("test");
                   }
               }
               """,
             """
+              import org.apache.commons.io.FileUtils;
+                            
               import java.io.File;
-              import java.io.IOException;
+                            
               class Test {
-                  void test() throws IOException {
-                      org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
+                  void test() throws Exception {
+                      FileUtils.deleteDirectory(new File("test"));
                   }
               }
               """
           )
         );
     }
+
+    @Test
+    void deleteDirectoryRetainedImport() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.codehaus.plexus.util.FileUtils;
+                            
+              import java.io.File;
+                            
+              class Test {
+                  void test() throws Exception {
+                      FileUtils.deleteDirectory("test");
+                      FileUtils.dirname("/foo/bar");
+                  }
+              }
+              """,
+            """
+              import org.codehaus.plexus.util.FileUtils;
+                            
+              import java.io.File;
+                            
+              class Test {
+                  void test() throws Exception {
+                      org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
+                      FileUtils.dirname("/foo/bar");
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.migrate.plexus;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaParser;
@@ -70,8 +69,6 @@ class PlexusFileUtilsTest implements RewriteTest {
         }
 
         @Test
-        @Disabled("Fails to clear out imports")
-            // FIXME clear out imports
         void deleteDirectorySimpleImport() {
             rewriteRun(
               //language=java

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -58,7 +58,7 @@ class PlexusFileUtilsTest implements RewriteTest {
                       File file = new File("test");
                       FileUtils.deleteDirectory("test");
                       org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
-                      org.apache.commons.io.FileUtils.deleteDirectory(test);
+                      org.apache.commons.io.FileUtils.deleteDirectory(file);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -32,8 +32,12 @@ class PlexusFileUtilsTest implements RewriteTest {
     }
 
     @Test
-    void uberTest() {
+    void deleteDirectory() {
         rewriteRun(
+          spec -> spec.recipes(
+            new PlexusFileUtilsRecipes.DeleteDirectoryFileRecipe(),
+            new PlexusFileUtilsRecipes.DeleteDirectoryStringRecipe()
+          ),
           //language=java
           java(
             """
@@ -46,6 +50,7 @@ class PlexusFileUtilsTest implements RewriteTest {
                       FileUtils.deleteDirectory("test");
                       org.codehaus.plexus.util.FileUtils.deleteDirectory("test");
                       org.codehaus.plexus.util.FileUtils.deleteDirectory(file);
+                      FileUtils.dirname("/foo/bar"); // Unused
                   }
               }
               """,
@@ -59,6 +64,7 @@ class PlexusFileUtilsTest implements RewriteTest {
                       FileUtils.deleteDirectory("test");
                       org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
                       org.apache.commons.io.FileUtils.deleteDirectory(file);
+                      FileUtils.dirname("/foo/bar"); // Unused
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -162,4 +162,36 @@ class PlexusFileUtilsTest implements RewriteTest {
             );
         }
     }
+
+    @Nested
+    class GetFile {
+        @Test
+        void getFile() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.codehaus.plexus.util.FileUtils;
+                                    
+                  import java.io.File;
+                      
+                  class Test {
+                      File test(String fileName) throws Exception {
+                          return FileUtils.getFile(fileName);
+                      }
+                  }
+                  """,
+                """
+                  import java.io.File;
+                      
+                  class Test {
+                      File test(String fileName) throws Exception {
+                          return new File(fileName);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -46,10 +46,13 @@ class PlexusFileUtilsTest implements RewriteTest {
               import org.codehaus.plexus.util.FileUtils;
               class Test {
                   void test() throws IOException {
-                      File file = new File("test");
                       FileUtils.deleteDirectory("test");
                       org.codehaus.plexus.util.FileUtils.deleteDirectory("test");
+
+                      File file = new File("test");
+                      FileUtils.deleteDirectory(file);
                       org.codehaus.plexus.util.FileUtils.deleteDirectory(file);
+
                       FileUtils.dirname("/foo/bar"); // Unused
                   }
               }
@@ -60,10 +63,13 @@ class PlexusFileUtilsTest implements RewriteTest {
               import org.apache.commons.io.FileUtils;
               class Test {
                   void test() throws IOException {
-                      File file = new File("test");
-                      FileUtils.deleteDirectory("test");
+                      FileUtils.deleteDirectory(new File("test"));
                       org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
+
+                      File file = new File("test");
+                      FileUtils.deleteDirectory(file);
                       org.apache.commons.io.FileUtils.deleteDirectory(file);
+
                       FileUtils.dirname("/foo/bar"); // Unused
                   }
               }
@@ -94,7 +100,7 @@ class PlexusFileUtilsTest implements RewriteTest {
               import java.io.IOException;
               class Test {
                   void test() throws IOException {
-                      org.apache.commons.io.FileUtils.deleteDirectory("test");
+                      org.apache.commons.io.FileUtils.deleteDirectory(new File("test"));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/plexus/PlexusFileUtilsTest.java
@@ -71,4 +71,34 @@ class PlexusFileUtilsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void deleteDirectoryMinimal() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new PlexusFileUtilsRecipes.DeleteDirectoryStringRecipe()
+          ),
+          //language=java
+          java(
+            """
+              import java.io.File;
+              import java.io.IOException;
+              class Test {
+                  void test() throws IOException {
+                      org.codehaus.plexus.util.FileUtils.deleteDirectory("test");
+                  }
+              }
+              """,
+            """
+              import java.io.File;
+              import java.io.IOException;
+              class Test {
+                  void test() throws IOException {
+                      org.apache.commons.io.FileUtils.deleteDirectory("test");
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Added recipes to convert from Plexus FileUtils to either JDK or Apache Commons IO FileUtils.

## What's your motivation?
Standardizing on a single implementation aids later migration to JDK internals, or at least reduces the number of dependencies.

## Anything in particular you'd like reviewers to focus on?
Matchers fail to match 🤔 

## Anyone you would like to review specifically?
@knutwannheden 

## Any additional context
https://issues.apache.org/jira/browse/MNG-6825
Assumes https://github.com/openrewrite/rewrite-templating/pull/17 gets merged