### PR TITLE
Do not partially use text blocks

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -75,12 +75,6 @@ public class UseTextBlocks extends Recipe {
         return Duration.ofMinutes(3);
     }
 
-    private static boolean allLiterals(Expression exp) {
-        return isRegularStringLiteral(exp) || exp instanceof J.Binary
-                && ((J.Binary) exp).getOperator() == J.Binary.Type.Addition
-                && allLiterals(((J.Binary) exp).getLeft()) && allLiterals(((J.Binary) exp).getRight());
-    }
-
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new HasJavaVersion("17", true), new JavaVisitor<ExecutionContext>() {
@@ -179,6 +173,12 @@ public class UseTextBlocks extends Recipe {
                         String.format("\"\"\"%s\"\"\"", content), null, JavaType.Primitive.String);
             }
         });
+    }
+
+    private static boolean allLiterals(Expression exp) {
+        return isRegularStringLiteral(exp) || exp instanceof J.Binary
+                && ((J.Binary) exp).getOperator() == J.Binary.Type.Addition
+                && allLiterals(((J.Binary) exp).getLeft()) && allLiterals(((J.Binary) exp).getRight());
     }
 
     private static boolean flatAdditiveStringLiterals(Expression expression,

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -75,16 +75,10 @@ public class UseTextBlocks extends Recipe {
         return Duration.ofMinutes(3);
     }
 
-    private static boolean allLiterals(Expression left, Expression right) {
-        boolean leftAll = isRegularStringLiteral(left) || left instanceof J.Binary
-                && ((J.Binary) left).getOperator() == J.Binary.Type.Addition
-                && allLiterals(((J.Binary) left).getLeft(), ((J.Binary) left).getRight());
-        if (!leftAll) {
-            return false;
-        }
-        return isRegularStringLiteral(right) || right instanceof J.Binary
-                && ((J.Binary) right).getOperator() == J.Binary.Type.Addition
-                && allLiterals(((J.Binary) right).getLeft(), ((J.Binary) right).getRight());
+    private static boolean allLiterals(Expression exp) {
+        return isRegularStringLiteral(exp) || exp instanceof J.Binary
+                && ((J.Binary) exp).getOperator() == J.Binary.Type.Addition
+                && allLiterals(((J.Binary) exp).getLeft()) && allLiterals(((J.Binary) exp).getRight());
     }
 
     @Override
@@ -97,7 +91,7 @@ public class UseTextBlocks extends Recipe {
                 StringBuilder contentSb = new StringBuilder();
                 StringBuilder concatenationSb = new StringBuilder();
 
-                boolean allLiterals = allLiterals(binary.getLeft(), binary.getRight());
+                boolean allLiterals = allLiterals(binary);
                 if (!allLiterals) {
                     return binary; // Not super.visitBinary(binary, ctx) because we don't want to visit the children
                 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -70,40 +70,6 @@ class UseTextBlocksTest implements RewriteTest {
     }
 
     @Test
-    void preserveTrailingWhiteSpaces() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                      String query = "SELECT * FROM    \\n" +
-                          "my_table    \\n" +
-                          "WHERE something = 1; ";
-              }
-              """,
-            """
-              class Test {
-                      String query = \"""
-                          SELECT * FROM   \\s
-                          my_table   \\s
-                          WHERE something = 1; \\
-                          \""";
-              }
-              """
-          )
-        );
-    }
-
-    private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with, int tabSize) {
-        return spec -> spec.parser(JavaParser.fromJavaVersion().styles(singletonList(
-          new NamedStyles(
-            randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is x", emptySet(),
-            singletonList(with.apply(buildTabsAndIndents(tabSize)))
-          )
-        )));
-    }
-
-    @Test
     void indentsAlignment() {
         rewriteRun(
           //language=java
@@ -357,6 +323,15 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
+    private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with, int tabSize) {
+        return spec -> spec.parser(JavaParser.fromJavaVersion().styles(singletonList(
+          new NamedStyles(
+            randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is x", emptySet(),
+            singletonList(with.apply(buildTabsAndIndents(tabSize)))
+          )
+        )));
+    }
+
     @Test
     void preserveTrailingWhiteSpaces2() {
         rewriteRun(
@@ -376,6 +351,31 @@ class UseTextBlocksTest implements RewriteTest {
                                  green\\s
                                  blue \\s
                                  ""\";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveTrailingWhiteSpaces() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                      String query = "SELECT * FROM    \\n" +
+                          "my_table    \\n" +
+                          "WHERE something = 1; ";
+              }
+              """,
+            """
+              class Test {
+                      String query = \"""
+                          SELECT * FROM   \\s
+                          my_table   \\s
+                          WHERE something = 1; \\
+                          \""";
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -70,6 +70,56 @@ class UseTextBlocksTest implements RewriteTest {
     }
 
     @Test
+    void preserveTrailingWhiteSpaces() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                      String query = "SELECT * FROM    \\n" +
+                          "my_table    \\n" +
+                          "WHERE something = 1; ";
+              }
+              """,
+            """
+              class Test {
+                      String query = \"""
+                          SELECT * FROM   \\s
+                          my_table   \\s
+                          WHERE something = 1; \\
+                          \""";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveTrailingWhiteSpaces2() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String color = "red   \\n" +
+                                 "green \\n" +
+                                 "blue  \\n";
+              }
+              """,
+            """
+              class Test {
+                  String color = \"""
+                                 red  \\s
+                                 green\\s
+                                 blue \\s
+                                 ""\";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void indentsAlignment() {
         rewriteRun(
           //language=java
@@ -330,56 +380,6 @@ class UseTextBlocksTest implements RewriteTest {
             singletonList(with.apply(buildTabsAndIndents(tabSize)))
           )
         )));
-    }
-
-    @Test
-    void preserveTrailingWhiteSpaces2() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  String color = "red   \\n" +
-                                 "green \\n" +
-                                 "blue  \\n";
-              }
-              """,
-            """
-              class Test {
-                  String color = \"""
-                                 red  \\s
-                                 green\\s
-                                 blue \\s
-                                 ""\";
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void preserveTrailingWhiteSpaces() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                      String query = "SELECT * FROM    \\n" +
-                          "my_table    \\n" +
-                          "WHERE something = 1; ";
-              }
-              """,
-            """
-              class Test {
-                      String query = \"""
-                          SELECT * FROM   \\s
-                          my_table   \\s
-                          WHERE something = 1; \\
-                          \""";
-              }
-              """
-          )
-        );
     }
 
     private static TabsAndIndentsStyle buildTabsAndIndents(int tabSize) {

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.style.TabsAndIndentsStyle;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
@@ -31,7 +32,8 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
 
 class UseTextBlocksTest implements RewriteTest {
 
@@ -92,28 +94,13 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
-    @Test
-    void preserveTrailingWhiteSpaces2() {
-        rewriteRun(
-          java(
-            """
-              class Test {
-                  String color = "red   \\n" +
-                                 "green \\n" +
-                                 "blue  \\n";
-              }
-              """,
-            """
-              class Test {
-                  String color = \"""
-                                 red  \\s
-                                 green\\s
-                                 blue \\s
-                                 ""\";
-              }
-              """
+    private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with, int tabSize) {
+        return spec -> spec.parser(JavaParser.fromJavaVersion().styles(singletonList(
+          new NamedStyles(
+            randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is x", emptySet(),
+            singletonList(with.apply(buildTabsAndIndents(tabSize)))
           )
-        );
+        )));
     }
 
     @Test
@@ -370,13 +357,29 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
-    private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with, int tabSize) {
-        return spec -> spec.parser(JavaParser.fromJavaVersion().styles(singletonList(
-            new NamedStyles(
-              randomId(), "TabsOnlyFile", "TabsOnlyFile", "tabSize is x", emptySet(),
-              singletonList(with.apply(buildTabsAndIndents(tabSize)))
-            )
-          )));
+    @Test
+    void preserveTrailingWhiteSpaces2() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String color = "red   \\n" +
+                                 "green \\n" +
+                                 "blue  \\n";
+              }
+              """,
+            """
+              class Test {
+                  String color = \"""
+                                 red  \\s
+                                 green\\s
+                                 blue \\s
+                                 ""\";
+              }
+              """
+          )
+        );
     }
 
     private static TabsAndIndentsStyle buildTabsAndIndents(int tabSize) {
@@ -500,6 +503,7 @@ class UseTextBlocksTest implements RewriteTest {
     @Test
     void newlineAtBeginningOfLines() {
         rewriteRun(
+          //language=java
           java(
             """
               class A {
@@ -541,6 +545,7 @@ class UseTextBlocksTest implements RewriteTest {
     @Test
     void consecutiveNewLines() {
         rewriteRun(
+          //language=java
           java(
             """
               class Test {
@@ -693,6 +698,7 @@ class UseTextBlocksTest implements RewriteTest {
     @Test
     void eightQuotes() {
         rewriteRun(
+          //language=java
           java(
             """
               class Test {
@@ -758,10 +764,12 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
-    void grouping() {
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/260")
+        //@Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/261")
+    void doNotPartiallyReplaceWithTextBlocks() {
         rewriteRun(
+          //language=java
           java(
             """
               public class Test {
@@ -779,23 +787,30 @@ class UseTextBlocksTest implements RewriteTest {
                           "AFTER the variable. ";
                   }
               }
-              """,
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/261")
+    void doNotPartiallyReplaceWithTextBlocksWithIntLiteral() {
+        rewriteRun(
+          //language=java
+          java(
             """
               public class Test {
                   public void method() {
-                      int variable = 1;
                       String stringWithVariableInIt =
-                          \"""
-                          This \\
-                          is  \\
-                          text \\
-                          BEFORE the variable \\
-                          \"""
-                          This \\
-                          is \\
-                          text \\
-                          AFTER the variable. \\
-                          \""";
+                          "This " +
+                          "is  " +
+                          "text " +
+                          "BEFORE the variable " +
+                          1 +
+                          "This " +
+                          "is  " +
+                          "text " +
+                          "AFTER the variable. ";
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
No longer, for the time being, concatenate text blocks unless they are fully composed of string literals.

## What's your motivation?
Before we would end up with partial conversions when SQL statements for instance used variables in the concatenation, which resulted in less than ideal text blocks. While we wait for a proper fix in #261 this

Fixes #260

## Have you considered any alternatives or workarounds?
A separate check seemed easier than squeezing this into `flatAdditiveStringLiterals`, especially if we revisit this with #261 

## Any additional context
- #260 
- #261 