### PR TITLE
Support trimmed arguments in IsNotEmptyToJdk

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/IsNotEmptyToJdkTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/IsNotEmptyToJdkTest.java
@@ -55,6 +55,31 @@ class IsNotEmptyToJdkTest implements RewriteTest {
             """));
     }
 
+    @Test
+    void trim() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.apache.commons.lang3.StringUtils;
+
+              class A {
+                  boolean test(String first) {
+                      boolean a = StringUtils.isEmpty(first.trim());
+                      boolean b = !StringUtils.isEmpty(first.trim());
+                  }
+              }
+              """,
+            """
+              class A {
+                  boolean test(String first) {
+                      boolean a = first.trim().isEmpty();
+                      boolean b = !first.trim().isEmpty();
+                  }
+              }
+              """));
+    }
+
     @ParameterizedTest
     @CsvSource(delimiter = '#', textBlock = """
       org.apache.commons.lang3.StringUtils # StringUtils.isEmpty(first) # first == null || first.isEmpty()

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/IsNotEmptyToJdkTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/IsNotEmptyToJdkTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.migrate.apache.commons.lang;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -55,13 +56,18 @@ class IsNotEmptyToJdkTest implements RewriteTest {
             """));
     }
 
-    @Test
-    void trim() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "org.apache.commons.lang3.StringUtils",
+      "org.apache.maven.shared.utils.StringUtils",
+      "org.codehaus.plexus.util.StringUtils"
+    })
+    void trim(String import_) {
         // language=java
         rewriteRun(
           java(
             """
-              import org.apache.commons.lang3.StringUtils;
+              import %s;
 
               class A {
                   boolean test(String first) {
@@ -75,7 +81,7 @@ class IsNotEmptyToJdkTest implements RewriteTest {
                       return "foo";
                   }
               }
-              """,
+              """.formatted(import_),
             """
               class A {
                   boolean test(String first) {

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/IsNotEmptyToJdkTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/IsNotEmptyToJdkTest.java
@@ -67,6 +67,12 @@ class IsNotEmptyToJdkTest implements RewriteTest {
                   boolean test(String first) {
                       boolean a = StringUtils.isEmpty(first.trim());
                       boolean b = !StringUtils.isEmpty(first.trim());
+                      boolean c = StringUtils.isNotEmpty(first.trim());
+                      boolean d = !StringUtils.isNotEmpty(first.trim()); // yeah, this is weird, but not worth cleaning up
+                      boolean e = StringUtils.isEmpty(foo().trim());
+                  }
+                  String foo() {
+                      return "foo";
                   }
               }
               """,
@@ -75,6 +81,12 @@ class IsNotEmptyToJdkTest implements RewriteTest {
                   boolean test(String first) {
                       boolean a = first.trim().isEmpty();
                       boolean b = !first.trim().isEmpty();
+                      boolean c = !first.trim().isEmpty();
+                      boolean d = !!first.trim().isEmpty(); // yeah, this is weird, but not worth cleaning up
+                      boolean e = foo().trim().isEmpty();
+                  }
+                  String foo() {
+                      return "foo";
                   }
               }
               """));


### PR DESCRIPTION
## What's changed?
Rewrite `StringUtils isEmpty(String)` when argument is a method invocation of `String trim()`.

## What's your motivation?
maven-scm frequently [uses patterns such as](https://github.com/apache/maven-scm/blob/600c347c5ee01139f32473dd2db2ab57d34fbf1f/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/tag/HgTagCommand.java#L67)
```java
if (tag == null || StringUtils.isEmpty(tag.trim())) {
    throw new ScmException("tag must be specified");
}
```
These are fairly easy to cover and migrate still, without needed a null safe replacement.