### PR TITLE
Disable some ApacheCommonsStringUtils recipes after seeing results

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtils.java
@@ -20,8 +20,6 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;
-import java.util.regex.Pattern;
-import java.util.stream.IntStream;
 
 @SuppressWarnings("ALL")
 public class ApacheCommonsStringUtils {
@@ -142,17 +140,18 @@ public class ApacheCommonsStringUtils {
         }
     }
 
-    private static class EndsWithIgnoreCase {
-        @BeforeTemplate
-        boolean before(String s, String suffix) {
-            return StringUtils.endsWithIgnoreCase(s, suffix);
-        }
-
-        @AfterTemplate
-        boolean after(String s, String suffix) {
-            return (s == null && suffix == null || s != null && suffix != null && s.regionMatches(true, s.length() - suffix.length(), suffix, 0, suffix.length()));
-        }
-    }
+    // NOTE: unlikely to go over well due to added complexity
+    //private static class EndsWithIgnoreCase {
+    //    @BeforeTemplate
+    //    boolean before(String s, String suffix) {
+    //        return StringUtils.endsWithIgnoreCase(s, suffix);
+    //    }
+    //
+    //    @AfterTemplate
+    //    boolean after(String s, String suffix) {
+    //        return (s == null && suffix == null || s != null && suffix != null && s.regionMatches(true, s.length() - suffix.length(), suffix, 0, suffix.length()));
+    //    }
+    //}
 
     private static class EqualsIgnoreCase {
         @BeforeTemplate
@@ -178,20 +177,23 @@ public class ApacheCommonsStringUtils {
         }
     }
 
-    private static class IndexOfAny {
-        @BeforeTemplate
-        int before(String s, String searchChars) {
-            return StringUtils.indexOfAny(s, searchChars);
-        }
-
-        @AfterTemplate
-        int after(String s, String searchChars) {
-            return IntStream.range(0, searchChars.length())
-                    .filter(i -> s.indexOf(searchChars.charAt(i)) >= 0)
-                    .min()
-                    .orElse(-1);
-        }
-    }
+    // NOTE: unlikely to go over well due to added complexity
+    //private static class IndexOfAny {
+    //    @BeforeTemplate
+    //    int before(String s, String searchChars) {
+    //        return StringUtils.indexOfAny(s, searchChars);
+    //    }
+    //
+    //    @AfterTemplate
+    //    int after(String s, String searchChars) {
+    //        return searchChars == null || searchChars.isEmpty() ? -1 :
+    //                IntStream.range(0, searchChars.length())
+    //                        .map(searchChars::charAt)
+    //                        .map(s::indexOf)
+    //                        .min()
+    //                        .orElse(-1);
+    //    }
+    //}
 
     // NOTE: not sure if accurate replacement
     //private static class IsAlphanumericSpace {
@@ -394,17 +396,18 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
-    private static class ReplaceOnce {
-        @BeforeTemplate
-        String before(String s, String search, String replacement) {
-            return StringUtils.replaceOnce(s, search, replacement);
-        }
-
-        @AfterTemplate
-        String after(String s, String search, String replacement) {
-            return (s == null || s.isEmpty() || search == null || search.isEmpty() || replacement == null ? s : s.replaceFirst(Pattern.quote(search), replacement));
-        }
-    }
+    // NOTE: requires dedicated recipe to clean up `Pattern.quote(",")`
+    //private static class ReplaceOnce {
+    //    @BeforeTemplate
+    //    String before(String s, String search, String replacement) {
+    //        return StringUtils.replaceOnce(s, search, replacement);
+    //    }
+    //
+    //    @AfterTemplate
+    //    String after(String s, String search, String replacement) {
+    //        return (s == null || s.isEmpty() || search == null || search.isEmpty() || replacement == null ? s : s.replaceFirst(Pattern.quote(search), replacement));
+    //    }
+    //}
 
     private static class Replace {
         @BeforeTemplate
@@ -455,17 +458,18 @@ public class ApacheCommonsStringUtils {
         }
     }
 
-    private static class SplitSeparator {
-        @BeforeTemplate
-        String[] before(String s, String arg) {
-            return StringUtils.split(s, arg);
-        }
-
-        @AfterTemplate
-        String[] after(String s, String arg) {
-            return (s == null ? null : s.split(Pattern.quote(arg)));
-        }
-    }
+    // NOTE: requires dedicated recipe to clean up `Pattern.quote(",")`
+    //private static class SplitSeparator {
+    //    @BeforeTemplate
+    //    String[] before(String s, String arg) {
+    //        return StringUtils.split(s, arg);
+    //    }
+    //
+    //    @AfterTemplate
+    //    String[] after(String s, String arg) {
+    //        return (s == null ? null : s.split(Pattern.quote(arg)));
+    //    }
+    //}
 
     // NOTE: different semantics in handling max=0 to discard trailing empty strings
     //private static class SplitSeparatorMax {

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtilsTest.java
@@ -69,13 +69,13 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
                       string = StringUtils.defaultString(in, "nil");
                       string = StringUtils.deleteWhitespace(in);
 
-                      bool = StringUtils.endsWithIgnoreCase(in, "suffix");
+                      //bool = StringUtils.endsWithIgnoreCase(in, "suffix");
                       bool = StringUtils.equalsIgnoreCase(in, "other");
                       bool = StringUtils.equals(in, "other");
                       bool = StringUtils.equals(cs, "other");
                       bool = StringUtils.equals(cs, cs);
 
-                      integer = StringUtils.indexOfAny(in, "search");
+                      //integer = StringUtils.indexOfAny(in, "search");
 
                       bool = StringUtils.isAlphanumericSpace(in);
                       bool = StringUtils.isAlphanumeric(in);
@@ -98,7 +98,7 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
                       string = StringUtils.repeat(in, 4);
                       string = StringUtils.repeat(in, ",", 4);
                       string = StringUtils.replace(in, "search", "replacement");
-                      string = StringUtils.replaceOnce(in, "search", "replacement");
+                      //string = StringUtils.replaceOnce(in, "search", "replacement");
                       string = StringUtils.reverse(in);
                       string = StringUtils.right(in, 5);
                       string = StringUtils.rightPad(in, 5);
@@ -106,7 +106,7 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
                       string = StringUtils.rightPad(in, 5, " ");
 
                       array = StringUtils.split(in);
-                      array = StringUtils.split(in, "*");
+                      //array = StringUtils.split(in, "*");
                       bool = StringUtils.startsWith(in, "prefix");
                       bool = StringUtils.startsWithAny(in, "prefix");
                       bool = StringUtils.startsWithIgnoreCase(in, "prefix");
@@ -162,13 +162,13 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
                       string = Objects.toString(in, "nil");
                       string = in == null ? null : in.replaceAll("\\s+", "");
 
-                      bool = in != null && in.regionMatches(true, in.length() - "suffix".length(), "suffix", 0, "suffix".length());
+                      //bool = StringUtils.endsWithIgnoreCase(in, "suffix");
                       bool = in != null && in.equalsIgnoreCase("other");
                       bool = Objects.equals(in, "other");
                       bool = StringUtils.equals(cs, "other");
                       bool = StringUtils.equals(cs, cs);
 
-                      integer = IntStream.range(0, "search".length()).filter(i -> in.indexOf("search".charAt(i)) >= 0).min().orElse(-1);
+                      //integer = StringUtils.indexOfAny(in, "search");
 
                       bool = StringUtils.isAlphanumericSpace(in);
                       bool = in != null && !in.isEmpty() && in.chars().allMatch(Character::isLetterOrDigit);
@@ -191,7 +191,7 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
                       string = StringUtils.repeat(in, 4);
                       string = StringUtils.repeat(in, ",", 4);
                       string = in == null || in.isEmpty() ? in : in.replace("search", "replacement");
-                      string = in == null || in.isEmpty() ? in : in.replaceFirst(Pattern.quote("search"), "replacement");
+                      //string = StringUtils.replaceOnce(in, "search", "replacement");
                       string = in == null ? null : new StringBuilder(in).reverse().toString();
                       string = StringUtils.right(in, 5);
                       string = StringUtils.rightPad(in, 5);
@@ -199,7 +199,7 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
                       string = StringUtils.rightPad(in, 5, " ");
 
                       array = in == null ? null : in.split("\\s+");
-                      array = in == null ? null : in.split(Pattern.quote("*"));
+                      //array = StringUtils.split(in, "*");
                       bool = StringUtils.startsWith(in, "prefix");
                       bool = StringUtils.startsWithAny(in, "prefix");
                       bool = StringUtils.startsWithIgnoreCase(in, "prefix");

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtilsTest.java
@@ -25,7 +25,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-@SuppressWarnings({"UnnecessaryCallToStringValueOf", "ConstantValue", "UnusedAssignment", "DataFlowIssue", "StringOperationCanBeSimplified"})
+@SuppressWarnings({"Deprecation", "UnusedAssignment", "DataFlowIssue", "StringOperationCanBeSimplified"})
 class ApacheCommonsStringUtilsTest implements RewriteTest {
 
     @Override
@@ -133,8 +133,6 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
               import org.apache.commons.lang3.StringUtils;
 
               import java.util.Objects;
-              import java.util.regex.Pattern;
-              import java.util.stream.IntStream;
 
               class Foo {
                   void bar(String in, CharSequence cs) {


### PR DESCRIPTION
At scale we don't want to add a `Pattern.compile(",")` for split, or `IntStream`, after seeing results on Apache Maven.