### PR TITLE
Add refaster templates for writeStringToFile overloads

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtils.java
@@ -74,8 +74,8 @@ public class ApacheCommonsFileUtils {
         }
 
         @AfterTemplate
-        void after(File a, String data) throws Exception {
-            Files.write(a.toPath(), data.getBytes(), StandardOpenOption.APPEND);
+        void after(File a, String data, boolean append) throws Exception {
+            Files.write(a.toPath(), data.getBytes(), append ? StandardOpenOption.APPEND : null);
         }
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtils.java
@@ -20,8 +20,13 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collections;
 
+@SuppressWarnings("deprecation")
 public class ApacheCommonsFileUtils {
     private static class GetFile {
         @BeforeTemplate
@@ -61,5 +66,70 @@ public class ApacheCommonsFileUtils {
         }
     }
 
+    // file, string, boolean
+    private static class WriteStringToFileOverloadOne {
+        @BeforeTemplate
+        void before(File a, String data, boolean append) throws Exception {
+            FileUtils.writeStringToFile(a, data, append);
+        }
+
+        @AfterTemplate
+        void after(File a, String data) throws Exception {
+            Files.write(a.toPath(), data.getBytes(), StandardOpenOption.APPEND);
+        }
+    }
+
+    // file, string, charset
+    @SuppressWarnings("depcr")
+    private static class WriteStringToFileOverloadTwo {
+        @BeforeTemplate
+        void before(File a, String data, Charset cs) throws Exception {
+            FileUtils.writeStringToFile(a, data, cs);
+        }
+
+        @AfterTemplate
+        void after(File a, String data, Charset cs) throws Exception {
+            Files.write(a.toPath(), Collections.singletonList(data), cs);
+        }
+    }
+
+    // file, string, charset, boolean
+    private static class WriteStringToFileOverloadThree {
+        @BeforeTemplate
+        void before(File a, String data, Charset cs, boolean append) throws Exception {
+            FileUtils.writeStringToFile(a, data, cs, append);
+        }
+
+        @AfterTemplate
+        void after(File a, String data, Charset cs, boolean append) throws Exception {
+            Files.write(a.toPath(), Collections.singletonList(data), cs, append ? StandardOpenOption.APPEND : null);
+        }
+    }
+
+    // file, string, string
+    private static class WriteStringToFileOverloadFour {
+        @BeforeTemplate
+        void before(File a, String data, String charsetName) throws Exception {
+            FileUtils.writeStringToFile(a, data, charsetName);
+        }
+
+        @AfterTemplate
+        void after(File a, String data, String charsetName) throws Exception {
+            Files.write(a.toPath(), Collections.singletonList(data), Charset.forName(charsetName));
+        }
+    }
+
+    // file, string, string, boolean
+    private static class WriteStringToFileOverloadFive {
+        @BeforeTemplate
+        void before(File a, String data, String charsetName, boolean append) throws Exception {
+            FileUtils.writeStringToFile(a, data, charsetName, append);
+        }
+
+        @AfterTemplate
+        void after(File a, String data, String charsetName, boolean append) throws Exception {
+            Files.write(a.toPath(), Collections.singletonList(data), Charset.forName(charsetName), append ? StandardOpenOption.APPEND : null);
+        }
+    }
 
 }

--- a/src/test/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtilsTest.java
@@ -88,6 +88,12 @@ class ApacheCommonsFileUtilsTest implements RewriteTest {
                       FileUtils.writeByteArrayToFile(fileA, bytes);
                       FileUtils.writeLines(fileA, collection);
                       FileUtils.writeStringToFile(fileA, s);
+                      
+                      FileUtils.writeStringToFile(fileA, s, bool);
+                      FileUtils.writeStringToFile(fileA, s, cs);
+                      FileUtils.writeStringToFile(fileA, s, cs, bool);
+                      FileUtils.writeStringToFile(fileA, s, str);
+                      FileUtils.writeStringToFile(fileA, s, str, bool);
                   }
               }
               """,
@@ -99,6 +105,7 @@ class ApacheCommonsFileUtilsTest implements RewriteTest {
               import java.net.URL;
               import java.nio.charset.Charset;
               import java.nio.file.Files;
+              import java.nio.file.StandardOpenOption;
               import java.util.Collection;
               import java.util.Collections;
               import java.util.List;
@@ -144,6 +151,12 @@ class ApacheCommonsFileUtilsTest implements RewriteTest {
                       FileUtils.writeByteArrayToFile(fileA, bytes);
                       FileUtils.writeLines(fileA, collection);
                       Files.write(fileA.toPath(), s.getBytes());
+                      
+                      Files.write(fileA.toPath(), s.getBytes(), bool ? StandardOpenOption.APPEND : null);
+                      Files.write(fileA.toPath(), Collections.singletonList(s), cs);
+                      Files.write(fileA.toPath(), Collections.singletonList(s), cs, bool ? StandardOpenOption.APPEND : null);
+                      Files.write(fileA.toPath(), Collections.singletonList(s), Charset.forName(str));
+                      Files.write(fileA.toPath(), Collections.singletonList(s), Charset.forName(str), bool ? StandardOpenOption.APPEND : null);
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
This PR adds refaster templates for writeStringToFile overloads.

## What's your motivation?
[This comment from an earlier PR](https://github.com/openrewrite/rewrite-migrate-java/pull/278#pullrequestreview-1627584184)

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
