### PR TITLE
Completes LogRecord.getLongThreadID recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnType.java
+++ b/src/main/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnType.java
@@ -1,7 +1,20 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;

--- a/src/main/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnType.java
+++ b/src/main/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnType.java
@@ -1,0 +1,107 @@
+package org.openrewrite.java.migrate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.java.*;
+import org.openrewrite.marker.Markers;
+
+import static java.util.Collections.emptyList;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChangeMethodInvocationReturnType extends Recipe {
+
+    @Option(displayName = "Method pattern",
+            description = "A method pattern that is used to find matching method declarations/invocations.",
+            example = "org.mockito.Matchers anyVararg()")
+    String methodPattern;
+
+    @Option(displayName = "New method invocation return type",
+            description = "The return return type of method invocation.",
+            example = "long")
+    String newReturnType;
+
+    @Override
+    public String getDisplayName() {
+        return "Change method invocation return type";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Changes the return type of a method invocation.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        JavaIsoVisitor<ExecutionContext> condition = new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                return super.visit(tree, ctx);
+            }
+        };
+
+        return new JavaIsoVisitor<ExecutionContext>() {
+            private final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, false);
+
+            private boolean methodUpdated;
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                JavaType.Method type = m.getMethodType();
+                if (methodMatcher.matches(method) && type != null && !type.getReturnType().toString().equals(newReturnType)) {
+                    type = type.withReturnType(JavaType.buildType(newReturnType));
+                    m = m.withMethodType(type);
+                    methodUpdated = true;
+                }
+                return m;
+            }
+
+           @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+               methodUpdated = false;
+                JavaType.FullyQualified typeAsClass = multiVariable.getTypeAsFullyQualified();
+                J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
+
+                if (methodUpdated) {
+                    JavaType newType = JavaType.buildType(newReturnType);
+                    JavaType.FullyQualified newFieldType = TypeUtils.asFullyQualified(newType);
+
+                    maybeAddImport(newFieldType);
+                    maybeRemoveImport(typeAsClass);
+
+                    mv = mv.withTypeExpression(mv.getTypeExpression() == null ?
+                            null :
+                            new J.Identifier(mv.getTypeExpression().getId(),
+                                    mv.getTypeExpression().getPrefix(),
+                                    Markers.EMPTY,
+                                    emptyList(),
+                                    newReturnType,
+                                    newType,
+                                    null
+                            )
+                    );
+
+                    mv = mv.withVariables(ListUtils.map(mv.getVariables(), var -> {
+                        JavaType.FullyQualified varType = TypeUtils.asFullyQualified(var.getType());
+                        if (varType != null && !varType.equals(newType)) {
+                            return var.withType(newType).withName(var.getName().withType(newType));
+                        }
+                        return var;
+                    }));
+                }
+
+                return mv;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -80,10 +80,12 @@ description: Avoid using the deprecated methods in `java.util.logging.LogRecord`
 tags:
   - java17
 recipeList:
-  # Disabled for now, as the new methods returns a long instead of an int, which causes compilation errors
-  #- org.openrewrite.java.ChangeMethodName:
-  #    methodPattern: java.util.logging.LogRecord getThreadID()
-  #    newMethodName: getLongThreadID
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.LogRecord getThreadID()
+      newMethodName: getLongThreadID
+  - org.openrewrite.java.migrate.ChangeMethodInvocationReturnType:
+      methodPattern: java.util.logging.LogRecord getLongThreadID()
+      newReturnType: long
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: java.util.logging.LogRecord setThreadID(int)
       newMethodName: setLongThreadID

--- a/src/test/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnTypeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnTypeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnTypeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnTypeTest.java
@@ -1,0 +1,67 @@
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ChangeMethodInvocationReturnTypeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ChangeMethodInvocationReturnType("java.lang.Integer parseInt(String)", "long"));
+    }
+
+    @Test
+    @DocumentExample
+    void replaceVariableAssignment() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      int one = Integer.parseInt("1");
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      long one = Integer.parseInt("1");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldOnlyChangeTargetMethodAssignments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      int zero = Integer.valueOf("0");
+                      int one = Integer.parseInt("1");
+                      int two = Integer.valueOf("2");
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      int zero = Integer.valueOf("0");
+                      long one = Integer.parseInt("1");
+                      int two = Integer.valueOf("2");
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava17Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava17Test.java
@@ -21,6 +21,7 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.java.ChangeMethodName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.*;
@@ -271,6 +272,7 @@ class UpgradeToJava17Test implements RewriteTest {
                                 
                 class Foo {
                     void bar(LogRecord record) {
+                        int threadID = record.getThreadID();
                         record.setThreadID(1);
                     }
                 }
@@ -280,6 +282,7 @@ class UpgradeToJava17Test implements RewriteTest {
                                 
                 class Foo {
                     void bar(LogRecord record) {
+                        long threadID = record.getLongThreadID();
                         record.setLongThreadID(1);
                     }
                 }

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava17Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava17Test.java
@@ -21,7 +21,6 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.java.ChangeMethodName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.*;


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The pull requests introduces a ChangeMethodInvocationReturnType recipe to handle the final part of the `org.openrewrite.java.migrate.DeprecatedLogRecordThreadID` recipe.
<img width="1435" alt="Screenshot 2023-09-13 at 5 16 35 PM" src="https://github.com/openrewrite/rewrite-migrate-java/assets/48495887/aad6a623-3f5b-48c9-8216-d6d566bc5c82">

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @joanvr 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
