### PR TITLE
Add PreferJavaUtilObjectsRequireNonNullElse recipe for Java 11

### DIFF
--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -63,6 +63,20 @@ recipeList:
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.guava.NoGuavaJava11
+displayName: Prefer the Java 11 standard library instead of Guava
+description: >
+  Guava filled in important gaps in the Java standard library and still does. But at least some of Guava's API surface
+  area is covered by the Java standard library now, and some projects may be able to remove Guava altogether if they
+  migrate to standard library for these functions.
+tags:
+  - guava
+  - java11
+recipeList:
+  - org.openrewrite.java.migrate.guava.NoGuava
+  - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNullElse
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.guava.PreferJavaNioCharsetStandardCharsets
 displayName: Prefer `java.nio.charset.StandardCharsets`
 description: Prefer `java.nio.charset.StandardCharsets` instead of using `com.google.common.base.Charsets`.

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -191,6 +191,22 @@ recipeList:
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNullElse
+displayName: Prefer `java.util.Objects#requireNonNullElse`
+description: Prefer `java.util.Objects#requireNonNullElse` instead of using `com.google.common.base.MoreObjects#firstNonNull`.
+tags:
+  - guava
+  - java11
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.google.common.base.MoreObjects firstNonNull(..)
+      newMethodName: requireNonNullElse
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: com.google.common.base.MoreObjects requireNonNullElse(..)
+      fullyQualifiedTargetTypeName: java.util.Objects
+
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsUnmodifiableNavigableMap
 displayName: Prefer `java.util.Collections#unmodifiableNavigableMap`
 description: Prefer `java.util.Collections#unmodifiableNavigableMap` instead of using `com.google.common.collect.Maps#unmodifiableNavigableMap`.

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
@@ -108,4 +108,30 @@ class PreferJavaUtilObjectsTest implements RewriteTest {
           """));
     }
 
+    @Test
+    void moreObjectsFirstNonNullToObjectsRequireNonNullElse() {
+        //language=java
+        rewriteRun((spec) -> {spec.recipes(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite.java.migrate.guava")
+            .build()
+            .activateRecipes("org.openrewrite.java.migrate.guava.NoGuavaJava11"));
+            },
+          java("""
+          import com.google.common.base.MoreObjects;
+
+          class A {
+              Object foo(Object obj) {
+                  return MoreObjects.firstNonNull(obj, "default");
+              }
+          }
+          """, """
+          import java.util.Objects;
+
+          class A {
+              Object foo(Object obj) {
+                  return Objects.requireNonNullElse(obj, "default");
+              }
+          }
+          """));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This adds `PreferJavaUtilObjectsRequireNonNullElse`, a `ChangeMethodName`/`ChangeMethodTargetToStatic` combination to convert Guava's `MoreObjects.firstNonNull` to the Java 9 equivalent of `Objects.requireNonNullElse`.

## What's your motivation?
I'm aiming to extend the set of Guava calls that are replaced by direct equivalents, and get that included in a bulk recipe.

## Anything in particular you'd like reviewers to focus on?
This method only shows up in Java 9. I've taken the approach of adding a new `NoGuavaJava11` recipe, in the style of the `UpgradeToJavaX` recipes, so this doesn't break Java 8 projects, or require users to nominate the individual recipe directly.

The method is generic; I found that it didn't match with `"firstNonNull(Object, Object)"`, so I'm using `".."`.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
As I need this recipe, my alternative is to keep it in a local ruleset.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover ~both~ positive ~and negative~ cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
