### PR TITLE
Add recipe descriptors to ApacheCommonsStringUtils

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/io/ApacheCommonsFileUtils.java
@@ -18,11 +18,15 @@ package org.openrewrite.java.migrate.apache.commons.io;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import org.apache.commons.io.FileUtils;
+import org.openrewrite.java.template.RecipeDescriptor;
 
 import java.io.File;
 import java.nio.file.Files;
 
 public class ApacheCommonsFileUtils {
+    @RecipeDescriptor(
+            name = "Replace `FileUtils.getFile(String...)` with JDK internals",
+            description = "Replace Apache Commons `FileUtils.getFile(String... name)` with JDK internals.")
     private static class GetFile {
         @BeforeTemplate
         File before(String name) {
@@ -48,6 +52,9 @@ public class ApacheCommonsFileUtils {
 //        }
 //    }
 
+    @RecipeDescriptor(
+            name = "Replace `FileUtils.writeStringToFile(File, String)` with JDK internals",
+            description = "Replace Apache Commons `FileUtils.writeStringToFile(File file, String data)` with JDK internals.")
     @SuppressWarnings("deprecation")
     private static class WriteStringToFile {
         @BeforeTemplate
@@ -60,6 +67,4 @@ public class ApacheCommonsFileUtils {
             Files.write(a.toPath(), s.getBytes());
         }
     }
-
-
 }

--- a/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtils.java
@@ -19,12 +19,16 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import org.apache.commons.lang3.StringUtils;
 import org.openrewrite.java.template.Matches;
+import org.openrewrite.java.template.RecipeDescriptor;
 
 import java.util.Objects;
 
 @SuppressWarnings("ALL")
 public class ApacheCommonsStringUtils {
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.abbreviate(String, int)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.abbreviate(String str, int maxWidth)` with JDK internals.")
     private static class Abbreviate {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s1,
@@ -38,6 +42,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.capitalize(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.capitalize(String str)` with JDK internals.")
     @SuppressWarnings("ConstantValue")
     private static class Capitalize {
         @BeforeTemplate
@@ -106,6 +113,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.defaultString(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.defaultString(String str)` with JDK internals.")
     private static class DefaultString {
         @BeforeTemplate
         String before(String s) {
@@ -118,6 +128,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.defaultString(String, String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.defaultString(String str, String nullDefault)` with JDK internals.")
     private static class DefaultStringFallback {
         @BeforeTemplate
         String before(String s, String nullDefault) {
@@ -130,6 +143,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.deleteWhitespace(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.deleteWhitespace(String str)` with JDK internals.")
     private static class DeleteWhitespace {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s) {
@@ -155,6 +171,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.equalsIgnoreCase(CharSequence, CharSequence)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.equalsIgnoreCase(CharSequence cs1, CharSequence cs2)` with JDK internals.")
     private static class EqualsIgnoreCase {
         @BeforeTemplate
         boolean before(@Matches(RepeatableArgumentMatcher.class) String s,
@@ -168,6 +187,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.equals(CharSequence, CharSequence)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.equals(CharSequence cs1, CharSequence cs2)` with JDK internals.")
     private static class Equals {
         @BeforeTemplate
         boolean before(String s, String other) {
@@ -326,6 +348,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.lowerCase(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.lowerCase(String str)` with JDK internals.")
     private static class Lowercase {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s) {
@@ -377,6 +402,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.removeEnd(String, String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.removeEnd(String str, String remove)` with JDK internals.")
     private static class RemoveEnd {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s,
@@ -416,6 +444,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.replace(String, String, String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.replace(String text, String searchString, String replacement)` with JDK internals.")
     private static class Replace {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s,
@@ -430,6 +461,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.reverse(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.reverse(String str)` with JDK internals.")
     private static class Reverse {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s) {
@@ -455,6 +489,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.split(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.split(String str)` with JDK internals.")
     private static class Split {
         @BeforeTemplate
         String[] before(@Matches(RepeatableArgumentMatcher.class) String s) {
@@ -493,6 +530,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.strip(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.strip(String str)` with JDK internals.")
     private static class Strip {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s) {
@@ -586,6 +626,9 @@ public class ApacheCommonsStringUtils {
     //    }
     //}
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.trimToEmpty(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.trimToEmpty(String str)` with JDK internals.")
     @SuppressWarnings("ConstantValue")
     private static class TrimToEmpty {
         @BeforeTemplate
@@ -599,6 +642,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.trimToNull(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.trimToNull(String str)` with JDK internals.")
     @SuppressWarnings("ConstantValue")
     private static class TrimToNull {
         @BeforeTemplate
@@ -612,6 +658,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.trim(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.trim(String str)` with JDK internals.")
     private static class Trim {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s) {
@@ -624,6 +673,9 @@ public class ApacheCommonsStringUtils {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `StringUtils.upperCase(String)` with JDK internals",
+            description = "Replace Apache Commons `StringUtils.upperCase(String str)` with JDK internals.")
     private static class Uppercase {
         @BeforeTemplate
         String before(@Matches(RepeatableArgumentMatcher.class) String s) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/StringRules.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringRules.java
@@ -17,9 +17,13 @@ package org.openrewrite.java.migrate.lang;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
 
 public class StringRules {
-
+    @RecipeDescriptor(
+            name = "Replace redundant `String` method calls with self",
+            description = "Replace redundant `substring(..)` and `toString()` method calls with the `String` self."
+    )
     @SuppressWarnings("StringOperationCanBeSimplified")
     static class RedundantCall {
         @BeforeTemplate
@@ -43,6 +47,9 @@ public class StringRules {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `String.indexOf(String, 0)` with `String.indexOf(String)`",
+            description = "Replace `String.indexOf(String str, int fromIndex)` with `String.indexOf(String)`.")
     @SuppressWarnings("StringOperationCanBeSimplified")
     static class IndexOfString {
         @BeforeTemplate
@@ -56,6 +63,9 @@ public class StringRules {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace `String.indexOf(char, 0)` with `String.indexOf(char)`",
+            description = "Replace `String.indexOf(char ch, int fromIndex)` with `String.indexOf(char)`.")
     @SuppressWarnings("StringOperationCanBeSimplified")
     static class IndexOfChar {
         @BeforeTemplate
@@ -69,6 +79,9 @@ public class StringRules {
         }
     }
 
+    @RecipeDescriptor(
+            name = "Replace lower and upper case `String` comparisons with `String.equalsIgnoreCase(String)`",
+            description = "Replace `String` equality comparisons involving `.toLowerCase()` or `.toUpperCase()` with `String.equalsIgnoreCase(String anotherString)`.")
     @SuppressWarnings("StringOperationCanBeSimplified")
     static class UseEqualsIgnoreCase {
         @BeforeTemplate

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseStringIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseStringIsEmpty.java
@@ -17,11 +17,31 @@ package org.openrewrite.java.migrate.lang;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
 
+@RecipeDescriptor(
+        name = "Replace `0 < s.length()` with `!s.isEmpty()`",
+        description = "Replace `0 < s.length()` and `s.length() != 0` with `!s.isEmpty()`."
+)
 public class UseStringIsEmpty {
     @BeforeTemplate
-    boolean before(String s) {
+    boolean beforeGreaterThan(String s) {
         return s.length() > 0;
+    }
+
+    @BeforeTemplate
+    boolean beforeLessThan(String s) {
+        return 0 < s.length();
+    }
+
+    @BeforeTemplate
+    boolean beforeNotZero(String s) {
+        return 0 != s.length();
+    }
+
+    @BeforeTemplate
+    boolean beforeNotZeroEither(String s) {
+        return s.length() != 0;
     }
 
     @AfterTemplate

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseStringIsEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseStringIsEmptyTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class UseStringIsEmptyTest implements RewriteTest {
+class UseStringIsEmptyTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -33,11 +33,15 @@ public class UseStringIsEmptyTest implements RewriteTest {
     @Test
     void lengthGreaterZero() {
         rewriteRun(
+          //language=java
           java(
             """
               class Test {
                   void m(String s) {
                       boolean b = s.length() > 0;
+                      boolean c = 0 < s.length();
+                      boolean d = 0 != s.length();
+                      boolean e = s.length() != 0;
                   }
               }
               """,
@@ -45,6 +49,9 @@ public class UseStringIsEmptyTest implements RewriteTest {
               class Test {
                   void m(String s) {
                       boolean b = !s.isEmpty();
+                      boolean c = !s.isEmpty();
+                      boolean d = !s.isEmpty();
+                      boolean e = !s.isEmpty();
                   }
               }
               """


### PR DESCRIPTION
## What's your motivation?
Better documentation once these show up in the docs & platform.

## Have you considered any alternatives or workarounds?
- I think in the past we used the before and after snippets to show document examples.
That might help to (also) do that to document what these recipes actually replace with.
- We could also take the detected method (or complete lambda) in the before template and use that to generate the description (only). That would need special handling for recipes with multiple before templates.