### PR TITLE
Convert Lombok `@Value` classes to Java records

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -56,12 +56,13 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
 
     private static boolean isRelevantClass(J.ClassDeclaration classDeclaration) {
         return classDeclaration.getType() != null
-               && !isRecord(classDeclaration)
-               && hasOnlyLombokValueAnnotation(classDeclaration)
-               && !hasGenericTypeParameter(classDeclaration)
-               && !hasExplicitMethods(classDeclaration)
-               && !hasExplicitConstructor(classDeclaration)
-               && !hasMemberVariableAnnotations(classDeclaration);
+                && !isRecord(classDeclaration)
+                && hasOnlyLombokValueAnnotation(classDeclaration)
+                && !hasGenericTypeParameter(classDeclaration)
+                && !hasExplicitMethods(classDeclaration)
+                && !hasExplicitConstructor(classDeclaration)
+                && !hasMemberVariableAnnotations(classDeclaration)
+                && !hasStaticMembers(classDeclaration);
     }
 
     @Override
@@ -305,6 +306,14 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
                 .map(J.MethodDeclaration::getMethodType)
                 .filter(Objects::nonNull)
                 .anyMatch(JavaType.Method::isConstructor);
+    }
+
+    private static boolean hasStaticMembers(J.ClassDeclaration classDeclaration) {
+        return findAllClassFields(classDeclaration)
+                .map(J.VariableDeclarations::getModifiers)
+                .flatMap(List::stream)
+                .map(J.Modifier::getType)
+                .anyMatch(J.Modifier.Type.Static::equals);
     }
 
     private static boolean hasMemberVariableAnnotations(J.ClassDeclaration classDeclaration) {

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -87,13 +87,13 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
         return Preconditions.check(check, new ScannerVisitor(acc));
     }
 
-    public String getDisplayName() {
-        return "Convert `@lombok.Value` class to Record";
-    }
-
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Map<String, Set<String>> recordTypesToMembers) {
         return new LombokValueToRecord.LombokValueToRecordVisitor(useExactToString, recordTypesToMembers);
+    }
+
+    public String getDisplayName() {
+        return "Convert `@lombok.Value` class to Record";
     }
 
     private static class LombokValueToRecordVisitor extends JavaIsoVisitor<ExecutionContext> {

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.lombok;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -1,0 +1,163 @@
+package org.openrewrite.java.migrate.lombok;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.RemoveAnnotationVisitor;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class LombokValueToRecord extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Convert Value class to Record";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Convert Lombok Value annotated classes to standard java record classes in java 11 or higher.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("lombok");
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(5);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        final TreeVisitor<?, ExecutionContext> check = Preconditions.and(
+                new UsesJavaVersion<>(17)
+        );
+
+        return Preconditions.check(check, new LombokValueToRecord.LombokValueToRecordVisitor());
+    }
+
+    private static class LombokValueToRecordVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(final J.ClassDeclaration cd, final ExecutionContext ctx) {
+            J.ClassDeclaration classDeclaration = super.visitClassDeclaration(cd, ctx);
+
+            if (isRecord(classDeclaration)
+                    || hasExplicitConstructor(classDeclaration)
+                    || !hasOnlyLombokValueAnnotation(classDeclaration)
+            ) {
+                return classDeclaration;
+            }
+
+            final List<J.VariableDeclarations> memberVariables = findAllClassFields(classDeclaration);
+            if (hasMemberVariableAssignments(memberVariables)) {
+                return classDeclaration;
+            }
+
+            final List<Statement> bodyStatements = new ArrayList<>(classDeclaration.getBody().getStatements());
+            bodyStatements.removeAll(memberVariables);
+
+            classDeclaration = removeValueAnnotation(classDeclaration, ctx);
+            classDeclaration = classDeclaration
+                    .withKind(J.ClassDeclaration.Kind.Type.Record)
+                    .withType(buildRecordType(classDeclaration))
+                    .withBody(classDeclaration.getBody()
+                            .withStatements(bodyStatements)
+                    )
+                    .withPrimaryConstructor(mapToConstructorArguments(memberVariables));
+
+            return maybeAutoFormat(cd, classDeclaration, ctx);
+        }
+
+        private static JavaType.Class buildRecordType(final J.ClassDeclaration cd) {
+            requireNonNull(cd.getType(), "Class type must not be null");
+            final String className = requireNonNull(cd.getType().getFullyQualifiedName(),
+                    "Fully qualified name of class must not be null");
+
+            return JavaType.ShallowClass.build(className)
+                    .withKind(JavaType.FullyQualified.Kind.Record);
+        }
+
+        private static boolean isRecord(final J.ClassDeclaration classDeclaration) {
+            return J.ClassDeclaration.Kind.Type.Record.equals(classDeclaration.getKind());
+        }
+
+        private static boolean hasExplicitConstructor(final J.ClassDeclaration classDeclaration) {
+            return classDeclaration.getPrimaryConstructor() != null || classDeclaration
+                    .getBody()
+                    .getStatements()
+                    .stream()
+                    .filter(J.MethodDeclaration.class::isInstance)
+                    .map(J.MethodDeclaration.class::cast)
+                    .map(J.MethodDeclaration::getMethodType)
+                    .filter(Objects::nonNull)
+                    .anyMatch(JavaType.Method::isConstructor);
+        }
+
+        private static List<Statement> mapToConstructorArguments(
+                final List<J.VariableDeclarations> memberVariables
+        ) {
+            return memberVariables
+                    .stream()
+                    .map(it -> it
+                            .withModifiers(Collections.emptyList())
+                            .withVariables(it.getVariables())
+                    )
+                    .map(Statement.class::cast)
+                    .collect(Collectors.toList());
+        }
+
+        private J.ClassDeclaration removeValueAnnotation(final J.ClassDeclaration cd, final ExecutionContext ctx) {
+            maybeRemoveImport("lombok.Value");
+
+            return new RemoveAnnotationVisitor(
+                    new AnnotationMatcher("@lombok.Value")
+            ).visitClassDeclaration(cd, ctx);
+        }
+
+        private static List<J.VariableDeclarations> findAllClassFields(final J.ClassDeclaration cd) {
+            return new ArrayList<>(cd.getBody().getStatements())
+                    .stream()
+                    .filter(J.VariableDeclarations.class::isInstance)
+                    .map(J.VariableDeclarations.class::cast)
+                    .collect(Collectors.toList());
+        }
+
+        private static boolean hasMemberVariableAssignments(final List<J.VariableDeclarations> memberVariables) {
+            return memberVariables
+                    .stream()
+                    .map(J.VariableDeclarations::getVariables)
+                    .flatMap(List::stream)
+                    .map(J.VariableDeclarations.NamedVariable::getInitializer)
+                    .anyMatch(J.Literal.class::isInstance);
+        }
+
+        private static final Pattern LOMBOK_ANNOTATION_PATTERN = Pattern.compile("^lombok.*");
+
+        private static boolean hasOnlyLombokValueAnnotation(final J.ClassDeclaration cd) {
+            return cd.getAllAnnotations()
+                    .stream()
+                    .filter(annotation -> TypeUtils.isAssignableTo(LOMBOK_ANNOTATION_PATTERN, annotation.getType()))
+                    .map(J.Annotation::getSimpleName)
+                    .allMatch("Value"::equals);
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -25,8 +25,8 @@ import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.RemoveAnnotationVisitor;
-import org.openrewrite.java.search.MaybeUsesImport;
 import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 
 import java.util.*;
@@ -81,7 +81,7 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
     public TreeVisitor<?, ExecutionContext> getScanner(Map<String, Set<String>> acc) {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(
                 new UsesJavaVersion<>(17),
-                new MaybeUsesImport<>(LOMBOK_VALUE_IMPORT)
+                new UsesType<>(LOMBOK_VALUE_IMPORT, false)
         );
 
         return Preconditions.check(check, new JavaIsoVisitor<ExecutionContext>() {

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -148,7 +148,7 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
                     .map(J.VariableDeclarations::getVariables)
                     .flatMap(List::stream)
                     .map(J.VariableDeclarations.NamedVariable::getInitializer)
-                    .anyMatch(J.Literal.class::isInstance);
+                    .anyMatch(Objects::nonNull);
         }
     }
 
@@ -177,12 +177,6 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
         public LombokValueToRecordVisitor(boolean useExactToString, Map<String, Set<String>> recordTypeToMembers) {
             this.useExactToString = useExactToString;
             this.recordTypeToMembers = recordTypeToMembers;
-        }
-
-        @Override
-        public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
-            // TODO Add type to record constructor
-            return super.visitNewClass(newClass, executionContext);
         }
 
         @Override

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -18,12 +18,7 @@ package org.openrewrite.java.migrate.lombok;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Preconditions;
-import org.openrewrite.ScanningRecipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -36,13 +31,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,7 +46,8 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
 
     @Option(displayName = "Add a `toString()` implementation matching Lombok",
             description = "When set the `toString` format from Lombok is used in the migrated record.")
-    boolean useExactToString;
+    @Nullable
+    Boolean useExactToString;
 
     public String getDisplayName() {
         return "Convert `@lombok.Value` class to Record";
@@ -165,10 +155,10 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
         private static final String TO_STRING_MEMBER_DELIMITER = "\", \" +\n";
         private static final String STANDARD_GETTER_PREFIX = "get";
 
-        private final boolean useExactToString;
+        private final Boolean useExactToString;
         private final Map<String, Set<String>> recordTypeToMembers;
 
-        public LombokValueToRecordVisitor(boolean useExactToString, Map<String, Set<String>> recordTypeToMembers) {
+        public LombokValueToRecordVisitor(Boolean useExactToString, Map<String, Set<String>> recordTypeToMembers) {
             this.useExactToString = useExactToString;
             this.recordTypeToMembers = recordTypeToMembers;
         }
@@ -284,7 +274,7 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
                     )
                     .withPrimaryConstructor(mapToConstructorArguments(memberVariables));
 
-            if (useExactToString) {
+            if (useExactToString != null && useExactToString) {
                 classDeclaration = addExactToStringMethod(classDeclaration, memberVariables);
             }
 

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -19,32 +19,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.RemoveAnnotationVisitor;
 import org.openrewrite.java.search.UsesJavaVersion;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Statement;
-import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.java.tree.*;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -56,7 +40,7 @@ import static java.util.Objects.requireNonNull;
 public class LombokValueToRecord extends Recipe {
 
     @Option(displayName = "useExactToString",
-            description = "When set the toString format from Lombok is used in the migrated record.")
+            description = "When set the `toString` format from Lombok is used in the migrated record.")
     boolean useExactToString;
 
     @JsonCreator
@@ -66,22 +50,17 @@ public class LombokValueToRecord extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Convert Value class to Record";
+        return "Convert `@lombok.Value` class to Record";
     }
 
     @Override
     public String getDescription() {
-        return "Convert Lombok Value annotated classes to standard Java Record classes in Java 17 or higher.";
+        return "Convert Lombok `@Value` annotated classes to standard Java Records.";
     }
 
     @Override
     public Set<String> getTags() {
         return Collections.singleton("lombok");
-    }
-
-    @Override
-    public Duration getEstimatedEffortPerOccurrence() {
-        return Duration.ofMinutes(5);
     }
 
     @Override
@@ -226,12 +205,12 @@ public class LombokValueToRecord extends Recipe {
         }
 
         private static boolean isRelevantClass(final J.ClassDeclaration classDeclaration) {
-            return !isRecord(classDeclaration)
+            return classDeclaration.getType() != null
+                    && !isRecord(classDeclaration)
                     && hasOnlyLombokValueAnnotation(classDeclaration)
                     && !hasGenericTypeParameter(classDeclaration)
                     && !hasExplicitMethods(classDeclaration)
-                    && !hasExplicitConstructor(classDeclaration)
-                    && classDeclaration.getType() != null;
+                    && !hasExplicitConstructor(classDeclaration);
         }
 
         private static String memberVariablesToString(final Set<String> memberVariables) {

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -45,7 +45,8 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
     private static final AnnotationMatcher LOMBOK_VALUE_MATCHER = new AnnotationMatcher("@lombok.Value");
 
     @Option(displayName = "Add a `toString()` implementation matching Lombok",
-            description = "When set the `toString` format from Lombok is used in the migrated record.")
+            description = "When set the `toString` format from Lombok is used in the migrated record.",
+            required = false)
     @Nullable
     Boolean useExactToString;
 

--- a/src/main/resources/META-INF/rewrite/lombok.yml
+++ b/src/main/resources/META-INF/rewrite/lombok.yml
@@ -42,3 +42,4 @@ recipeList:
       oldFullyQualifiedTypeName: lombok.experimental.val
       newFullyQualifiedTypeName: lombok.val
   - org.openrewrite.java.migrate.lombok.LombokValToFinalVar
+  - org.openrewrite.java.migrate.lombok.LombokValueToRecord

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.lombok;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -41,7 +41,7 @@ public class LombokValueToRecordTest implements RewriteTest {
             java(
               """
                 import lombok.Value;
-                
+                                
                 @Value
                 public class Test {
                     String field1;

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -29,7 +29,12 @@ class LombokValueToRecordTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new LombokValueToRecord(false))
           .allSources(s -> s.markers(javaVersion(17)))
-          .parser(JavaParser.fromJavaVersion().classpath("lombok"));
+          .parser(JavaParser.fromJavaVersion()
+            .classpath(
+              "lombok",
+              "jackson-core"
+            )
+          );
     }
 
     @Test
@@ -142,6 +147,26 @@ class LombokValueToRecordTest implements RewriteTest {
                  public A() {
                      this.test = "test";
                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void classWithFieldAnnotationsIsUnchanged() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.fasterxml.jackson.annotation.JsonProperty;
+              import lombok.Value;
+                              
+              @Value
+              public class A {
+                            
+                 @JsonProperty
+                 String test;
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -1,0 +1,125 @@
+package org.openrewrite.java.migrate.lombok;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+public class LombokValueToRecordTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new LombokValueToRecord())
+          .parser(JavaParser.fromJavaVersion().classpath("lombok"));
+    }
+
+    @Test
+    void convertOnlyValueAnnotatedClassWithoutDefaultValuesToRecord() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import lombok.Value;
+                
+                @Value
+                public class A {
+                   String test;
+                }
+                """,
+              """
+                public record A(
+                   String test) {
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
+
+    @Test
+    void classWithExplicitConstructorIsUnchanged() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import lombok.Value;
+                
+                @Value
+                public class A {
+                   String test;
+                   
+                   public A() {
+                       this.test = "test";
+                   }
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
+
+    @Test
+    void nonJava17ClassIsUnchanged() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import lombok.Value;
+                
+                @Value
+                public class A {
+                   String test;
+                }
+                """
+            ),
+            11
+          )
+        );
+    }
+
+    @Test
+    void classWithMultipleLombokAnnotationsIsUnchanged() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import lombok.Value;
+                import lombok.experimental.Accessors;
+                
+                @Value
+                @Accessors(fluent = true)
+                public class A {
+                    String test;
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
+
+    @Test
+    void existingRecordsAreUnchanged() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                public record A(String test) {
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -28,8 +28,44 @@ public class LombokValueToRecordTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new LombokValueToRecord())
+        spec.recipe(new LombokValueToRecord(false))
           .parser(JavaParser.fromJavaVersion().classpath("lombok"));
+    }
+
+    @Test
+    void valueAnnotatedClassWithUseExactOptionKeepsLombokToString() {
+        //language=java
+        rewriteRun(
+          s -> s.recipe(new LombokValueToRecord(true)),
+          version(
+            java(
+              """
+                import lombok.Value;
+                
+                @Value
+                public class Test {
+                    String field1;
+                    
+                    String field2;
+                }
+                """,
+              """
+                public record Test(
+                    String field1,
+                    
+                    String field2) {
+                    @Override
+                    public String toString() {
+                        return "Test(" +
+                                "field1=" + field1 + ", " +
+                                "field2=" + field2 +
+                                ")";
+                    }
+                }
+                """),
+            17
+          )
+        );
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.lombok;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -72,6 +73,7 @@ class LombokValueToRecordTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/141")
     void convertOnlyValueAnnotatedClassWithoutDefaultValuesToRecord() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.migrate.lombok;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -132,134 +133,155 @@ class LombokValueToRecordTest implements RewriteTest {
         );
     }
 
-    @Test
-    void classWithExplicitConstructorIsUnchanged() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import lombok.Value;
-                              
-              @Value
-              public class A {
-                 String test;
-                 
-                 public A() {
-                     this.test = "test";
-                 }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void classWithFieldAnnotationsIsUnchanged() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import com.fasterxml.jackson.annotation.JsonProperty;
-              import lombok.Value;
-                              
-              @Value
-              public class A {
-                            
-                 @JsonProperty
-                 String test;
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void classWithExplicitMethodsIsUnchanged() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import lombok.Value;
-                              
-              @Value
-              public class A {
-                 String test;
-                 
-                 public String getTest() {
-                     return test;
-                 }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void genericClassIsUnchanged() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import lombok.Value;
-                              
-              @Value
-              public class A<T extends Object> {
-                 T test;
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void nonJava17ClassIsUnchanged() {
-        //language=java
-        rewriteRun(
-          version(
-            java(
-              """
-                import lombok.Value;
-                                
-                @Value
-                public class A {
-                   String test;
-                }
+    @Nested
+    class Unchanged {
+        @Test
+        void classWithExplicitConstructor() {
+            //language=java
+            rewriteRun(
+              java(
                 """
-            ),
-            11
-          )
-        );
-    }
+                  import lombok.Value;
+                                  
+                  @Value
+                  public class A {
+                     String test;
+                     
+                     public A() {
+                         this.test = "test";
+                     }
+                  }
+                  """
+              )
+            );
+        }
 
-    @Test
-    void classWithMultipleLombokAnnotationsIsUnchanged() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import lombok.Value;
-              import lombok.experimental.Accessors;
-                              
-              @Value
-              @Accessors(fluent = true)
-              public class A {
-                  String test;
-              }
-              """
-          )
-        );
-    }
+        @Test
+        void classWithFieldAnnotations() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.annotation.JsonProperty;
+                  import lombok.Value;
+                                  
+                  @Value
+                  public class A {
+                                
+                     @JsonProperty
+                     String test;
+                  }
+                  """
+              )
+            );
+        }
 
-    @Test
-    void existingRecordsAreUnchanged() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              public record A(String test) {
-              }
-              """
-          )
-        );
+        @Test
+        void classWithExplicitMethods() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import lombok.Value;
+                                  
+                  @Value
+                  public class A {
+                     String test;
+                     
+                     public String getTest() {
+                         return test;
+                     }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void genericClass() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import lombok.Value;
+                                  
+                  @Value
+                  public class A<T extends Object> {
+                     T test;
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void nonJava17Class() {
+            //language=java
+            rewriteRun(
+              version(
+                java(
+                  """
+                    import lombok.Value;
+                                    
+                    @Value
+                    public class A {
+                       String test;
+                    }
+                    """
+                ),
+                11
+              )
+            );
+        }
+
+        @Test
+        void classWithMultipleLombokAnnotations() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import lombok.Value;
+                  import lombok.experimental.Accessors;
+                                  
+                  @Value
+                  @Accessors(fluent = true)
+                  public class A {
+                      String test;
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void existingRecordsAreUnchanged() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  public record A(String test) {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void classWithStaticField() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import lombok.Value;
+                                  
+                  @Value
+                  public class A {
+                      static String disqualifyingField;
+                      String test;
+                  }
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?
Adds a recipe for converting lombok value annotated classes to java records.

## What's your motivation?
I am working on a case study to evaluate the effort and benefit of automated refactorings.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
