### PR TITLE
Set Maven compiler plugin Java version when using default groupId

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/maven/UseMavenCompilerPluginReleaseConfiguration.java
+++ b/src/main/java/org/openrewrite/java/migrate/maven/UseMavenCompilerPluginReleaseConfiguration.java
@@ -65,8 +65,8 @@ public class UseMavenCompilerPluginReleaseConfiguration extends Recipe {
                 }
                 Optional<Xml.Tag> maybeCompilerPlugin = t.getChildren().stream()
                         .filter(plugin -> "plugin".equals(plugin.getName())
-                                && "org.apache.maven.plugins".equals(plugin.getChildValue("groupId").orElse(null))
-                                && "maven-compiler-plugin".equals(plugin.getChildValue("artifactId").orElse(null)))
+                                          && "org.apache.maven.plugins".equals(plugin.getChildValue("groupId").orElse("org.apache.maven.plugins"))
+                                          && "maven-compiler-plugin".equals(plugin.getChildValue("artifactId").orElse(null)))
                         .findAny();
                 Optional<Xml.Tag> maybeCompilerPluginConfig = maybeCompilerPlugin
                         .flatMap(it -> it.getChild("configuration"));

--- a/src/test/java/org/openrewrite/java/migrate/maven/UseMavenCompilerPluginReleaseConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/maven/UseMavenCompilerPluginReleaseConfigurationTest.java
@@ -212,7 +212,6 @@ class UseMavenCompilerPluginReleaseConfigurationTest implements RewriteTest {
               <build>
                 <plugins>
                   <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
                     <configuration>
@@ -240,7 +239,6 @@ class UseMavenCompilerPluginReleaseConfigurationTest implements RewriteTest {
               <build>
                 <plugins>
                   <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
                     <configuration>


### PR DESCRIPTION
## What's changed?
Use a fallback value for groupId that matches the default value, rather than mismatching.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite/issues/3562