### PR TITLE
doc: correct java17 recipe name, add info on the java21 recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ of the platform. This changed in June 2018 when a new, six-month release cadence
 The new model allows features to be released within any six-month window allowing features to be incrementally
 introduced when they are ready. Additionally, there are Java LTS (Long term support) releases on which there exists
 enterprise support offered through several vendors that provide builds of the JVM, compiler, and standard libraries. The
-current LTS versions of the Java platform (Java 8, 11, and 17) are the most common versions in use within the Java
+current LTS versions of the Java platform (Java 8, 11, 17, and 21) are the most common versions in use within the Java
 ecosystem.
 
 # Java EE/Jakarta EE
@@ -102,7 +102,7 @@ migrate applications that were previously running on Java 8 through 10. This rec
 ## Java 17 Migrations
 
 OpenRewrite provides a set of recipes that will help developers migrate to Java 17 when their existing application
-workloads are on Java 11 through 16. The composite recipe `org.openrewrite.java.migrate.UpgradeJava17` will cover the
+workloads are on Java 11 through 16. The composite recipe `org.openrewrite.java.migrate.UpgradeToJava17` will cover the
 following themes:
 
 - Any deprecated APIs in the earlier versions of Java that have a well-defined migration path will be automatically
@@ -112,6 +112,15 @@ following themes:
   application or a third-party library attempts to access an API that has not been publicly exported via the module
   system. This recipe will upgrade well-known, third-party libraries if they provide a version that is compliant with
   the Java module system.
+
+## Java 21 Migrations
+
+OpenRewrite provides a set of recipes that will help developers migrate to Java 21 when their existing application
+workloads are on Java 11 through 20. The composite recipe `org.openrewrite.java.migrate.UpgradeToJava21` will cover the
+following themes:
+
+- everything covered by the Java 17 Migration
+- initial support for the migration to Sequenced collections
 
 ## Illegal Reflective Access<a name="IllegalReflectiveAccess"></a>
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
I corrected the Java 17 recipe name, and added the Java 21 one.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
To improve the quality of the documentation.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
