### PR TITLE
feat: no guava - java 21 version (Math.clamp)

### DIFF
--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -77,6 +77,20 @@ recipeList:
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNullElse
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.guava.NoGuavaJava21
+displayName: Prefer the Java 21 standard library instead of Guava
+description: >
+  Guava filled in important gaps in the Java standard library and still does. But at least some of Guava's API surface
+  area is covered by the Java standard library now, and some projects may be able to remove Guava altogether if they
+  migrate to standard library for these functions.
+tags:
+  - guava
+  - java21
+recipeList:
+  - org.openrewrite.java.migrate.guava.NoGuavaJava11
+  - org.openrewrite.java.migrate.guava.PreferMathClamp
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.guava.PreferJavaNioCharsetStandardCharsets
 displayName: Prefer `java.nio.charset.StandardCharsets`
 description: Prefer `java.nio.charset.StandardCharsets` instead of using `com.google.common.base.Charsets`.
@@ -453,4 +467,32 @@ recipeList:
       newMethodName: multiplyExact
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: com.google.common.math.IntMath multiplyExact(..)
+      fullyQualifiedTargetTypeName: java.lang.Math
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.guava.PreferMathClamp
+displayName: Prefer `Math#clamp`
+description: Prefer `java.lang.Math#clamp` instead of using `com.google.common.primitives.*#constrainToRange`.
+tags:
+  - guava
+  - java21
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.google.common.primitives.Doubles constrainToRange(..)
+      newMethodName: clamp
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: com.google.common.primitives.Doubles clamp(..)
+      fullyQualifiedTargetTypeName: java.lang.Math
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.google.common.primitives.Floats constrainToRange(..)
+      newMethodName: clamp
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: com.google.common.primitives.Floats clamp(..)
+      fullyQualifiedTargetTypeName: java.lang.Math
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.google.common.primitives.Longs constrainToRange(..)
+      newMethodName: clamp
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: com.google.common.primitives.Longs clamp(..)
       fullyQualifiedTargetTypeName: java.lang.Math

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaJava21Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaJava21Test.java
@@ -47,15 +47,15 @@ class NoGuavaJava21Test implements RewriteTest {
                 import com.google.common.primitives.Doubles;
   
                 class Test {
-                    public void testMethod() {
-                        Doubles.constrainToRange(20D, 10D, 100D);
+                    public double testMethod() {
+                        return Doubles.constrainToRange(20D, 10D, 100D);
                     }
                 }
                 """,
               """ 
                 class Test {
-                    public void testMethod() {
-                        Math.clamp(20D, 10D, 100D);
+                    public double testMethod() {
+                        return Math.clamp(20D, 10D, 100D);
                     }
                 }
                 """
@@ -74,15 +74,15 @@ class NoGuavaJava21Test implements RewriteTest {
                 import com.google.common.primitives.Longs;
   
                 class Test {
-                    public void testMethod() {
-                        Longs.constrainToRange(20L, 10L, 100L);
+                    public long testMethod() {
+                        return Longs.constrainToRange(20L, 10L, 100L);
                     }
                 }
                 """,
               """ 
                 class Test {
-                    public void testMethod() {
-                        Math.clamp(20L, 10L, 100L);
+                    public long testMethod() {
+                        return Math.clamp(20L, 10L, 100L);
                     }
                 }
                 """
@@ -101,15 +101,15 @@ class NoGuavaJava21Test implements RewriteTest {
                 import com.google.common.primitives.Floats;
   
                 class Test {
-                    public void testMethod() {
-                        Floats.constrainToRange(20F, 10F, 100F);
+                    public float testMethod() {
+                        return Floats.constrainToRange(20F, 10F, 100F);
                     }
                 }
                 """,
               """ 
                 class Test {
-                    public void testMethod() {
-                        Math.clamp(20F, 10F, 100F);
+                    public float testMethod() {
+                        return Math.clamp(20F, 10F, 100F);
                     }
                 }
                 """

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaJava21Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaJava21Test.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+class NoGuavaJava21Test implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(
+            Environment.builder()
+              .scanRuntimeClasspath("org.openrewrite.java.migrate.guava")
+              .build()
+              .activateRecipes("org.openrewrite.java.migrate.guava.NoGuavaJava21")
+          )
+          .parser(JavaParser.fromJavaVersion().classpath("guava"));
+    }
+
+    @Test
+    void preferMathClampForDouble() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """   
+                import com.google.common.primitives.Doubles;
+  
+                class Test {
+                    public void testMethod() {
+                        Doubles.constrainToRange(20D, 10D, 100D);
+                    }
+                }
+                """,
+              """ 
+                class Test {
+                    public void testMethod() {
+                        Math.clamp(20D, 10D, 100D);
+                    }
+                }
+                """
+            ),
+            21)
+        );
+    }
+
+    @Test
+    void preferMathClampForLongs() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """   
+                import com.google.common.primitives.Longs;
+  
+                class Test {
+                    public void testMethod() {
+                        Longs.constrainToRange(20L, 10L, 100L);
+                    }
+                }
+                """,
+              """ 
+                class Test {
+                    public void testMethod() {
+                        Math.clamp(20L, 10L, 100L);
+                    }
+                }
+                """
+            ),
+            21)
+        );
+    }
+
+    @Test
+    void preferMathClampForFloats() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """   
+                import com.google.common.primitives.Floats;
+  
+                class Test {
+                    public void testMethod() {
+                        Floats.constrainToRange(20F, 10F, 100F);
+                    }
+                }
+                """,
+              """ 
+                class Test {
+                    public void testMethod() {
+                        Math.clamp(20F, 10F, 100F);
+                    }
+                }
+                """
+            ),
+            21)
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Introduces a new `No guava - Java 21` recipe which extends the `No Guava - Java 11` recipe, and also contains a new recipe which replaces the `Guava - constrainToRange` with the new Java 21 `clamp` method.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
To help people make use of core Java features.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
