### PR TITLE
Add recipes to migrate boxed primitive constructors deprecated in Java 9

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/MigrateDeprecatedBoxedPrimitiveConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/MigrateDeprecatedBoxedPrimitiveConstructors.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+/**
+ * Handles the migration of the deprecated constructors of primitive wrappers
+ * highlighted <a href="https://docs.oracle.com/javase/9/docs/api/deprecated-list.html#constructor">here</a>.
+ */
+@SuppressWarnings("removal")
+public class MigrateDeprecatedBoxedPrimitiveConstructors {
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Boolean(boolean)` constructor invocations",
+        description = "Replace deprecated `Boolean(boolean)` constructor invocations with `Boolean.valueOf(boolean)`."
+    )
+    public static class BooleanConstructor {
+        @BeforeTemplate
+        public Boolean booleanConstructor(boolean value) {
+            return new Boolean(value);
+        }
+
+        @AfterTemplate
+        public Boolean valueOf(boolean value) {
+            return Boolean.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Boolean(String)` constructor invocations",
+        description = "Replace deprecated `Boolean(String)` constructor invocations with `Boolean.valueOf(String)`."
+    )
+    public static class BooleanStringConstructor {
+        @BeforeTemplate
+        public Boolean stringConstructor(String value) {
+            return new Boolean(value);
+        }
+
+        @AfterTemplate
+        public Boolean valueOf(String value) {
+            return Boolean.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Byte(byte)` constructor invocations",
+        description = "Replace deprecated `Byte(byte)` constructor invocations with `Byte.valueOf(byte)`."
+    )
+    public static class ByteConstructor {
+        @BeforeTemplate
+        public Byte byteConstructor(byte value) {
+            return new Byte(value);
+        }
+
+        @AfterTemplate
+        public Byte valueOf(byte value) {
+            return Byte.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Byte(String)` constructor invocations",
+        description = "Replace deprecated `Byte(String)` constructor invocations with `Byte.valueOf(String)`."
+    )
+    public static class ByteStringConstructor {
+        @BeforeTemplate
+        public Byte stringConstructor(String value) {
+            return new Byte(value);
+        }
+
+        @AfterTemplate
+        public Byte valueOf(String value) {
+            return Byte.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Character(char)` constructor invocations",
+        description = "Replace deprecated `Character(char)` constructor invocations with `Character.valueOf(char)`."
+    )
+    public static class CharacterConstructor {
+        @BeforeTemplate
+        public Character charConstructor(char value) {
+            return new Character(value);
+        }
+
+        @AfterTemplate
+        public Character valueOf(char value) {
+            return Character.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Double(double)` constructor invocations",
+        description = "Replace deprecated `Double(double)` constructor invocations with `Double.valueOf(double)`."
+    )
+    public static class DoubleConstructor {
+        @BeforeTemplate
+        public Double doubleConstructor(double value) {
+            return new Double(value);
+        }
+
+        @AfterTemplate
+        public Double valueOf(double value) {
+            return Double.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Double(String)` constructor invocations",
+        description = "Replace deprecated `Double(String)` constructor invocations with `Double.valueOf(String)`."
+    )
+    public static class DoubleStringConstructor {
+        @BeforeTemplate
+        public Double stringConstructor(String value) {
+            return new Double(value);
+        }
+
+        @AfterTemplate
+        public Double valueOf(String value) {
+            return Double.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Float(float)` constructor invocations",
+        description = "Replace deprecated `Float(float)` constructor invocations with `Float.valueOf(float)`."
+    )
+    public static class FloatConstructor {
+        @BeforeTemplate
+        public Float floatConstructor(float value) {
+            return new Float(value);
+        }
+
+        @AfterTemplate
+        public Float valueOf(float value) {
+            return Float.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Float(String)` constructor invocations",
+        description = "Replace deprecated `Float(String)` constructor invocations with `Float.valueOf(String)`."
+    )
+    public static class FloatStringConstructor {
+        @BeforeTemplate
+        public Float stringConstructor(String value) {
+            return new Float(value);
+        }
+
+        @AfterTemplate
+        public Float valueOf(String value) {
+            return Float.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Float(Double)` constructor invocations",
+        description = "Replace deprecated `Float(Double)` constructor invocations with `Float.valueOf(Double#floatValue)`."
+    )
+    public static class FloatDoubleConstructor {
+        @BeforeTemplate
+        public Float doubleConstructor(Double value) {
+            return new Float(value);
+        }
+
+        @AfterTemplate
+        public Float valueOf(Double value) {
+            return Float.valueOf(value.floatValue());
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Integer(int)` constructor invocations",
+        description = "Replace deprecated `Integer(int)` constructor invocations with `Integer.valueOf(int)`."
+    )
+    public static class IntegerConstructor {
+        @BeforeTemplate
+        public Integer intConstructor(int value) {
+            return new Integer(value);
+        }
+
+        @AfterTemplate
+        public Integer valueOf(int value) {
+            return Integer.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Integer(String)` constructor invocations",
+        description = "Replace deprecated `Integer(String)` constructor invocations with `Integer.valueOf(String)`."
+    )
+    public static class IntegerStringConstructor {
+        @BeforeTemplate
+        public Integer stringConstructor(String value) {
+            return new Integer(value);
+        }
+
+        @AfterTemplate
+        public Integer valueOf(String value) {
+            return Integer.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Long(long)` constructor invocations",
+        description = "Replace deprecated `Long(long)` constructor invocations with `Long.valueOf(long)`."
+    )
+    public static class LongConstructor {
+        @BeforeTemplate
+        public Long longConstructor(long value) {
+            return new Long(value);
+        }
+
+        @AfterTemplate
+        public Long valueOf(long value) {
+            return Long.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Long(String)` constructor invocations",
+        description = "Replace deprecated `Long(String)` constructor invocations with `Long.valueOf(String)`."
+    )
+    public static class LongStringConstructor {
+        @BeforeTemplate
+        public Long stringConstructor(String value) {
+            return new Long(value);
+        }
+
+        @AfterTemplate
+        public Long valueOf(String value) {
+            return Long.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Short(short)` constructor invocations",
+        description = "Replace deprecated `Short(short)` constructor invocations with `Short.valueOf(short)`."
+    )
+    public static class ShortConstructor {
+        @BeforeTemplate
+        public Short shortConstructor(short value) {
+            return new Short(value);
+        }
+
+        @AfterTemplate
+        public Short valueOf(short value) {
+            return Short.valueOf(value);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace deprecated `Short(String)` constructor invocations",
+        description = "Replace deprecated `Short(String)` constructor invocations with `Short.valueOf(String)`."
+    )
+    public static class ShortStringConstructor {
+        @BeforeTemplate
+        public Short stringConstructor(String value) {
+            return new Short(value);
+        }
+
+        @AfterTemplate
+        public Short valueOf(String value) {
+            return Short.valueOf(value);
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -40,6 +40,7 @@ recipeList:
   - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
   - org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs
   - org.openrewrite.java.migrate.lang.JavaLangAPIs
+  - org.openrewrite.java.migrate.lang.MigrateDeprecatedBoxedPrimitiveConstructorsRecipes
   - org.openrewrite.java.migrate.logging.JavaLoggingAPIs
   - org.openrewrite.java.migrate.lombok.UpdateLombokToJava11
   - org.openrewrite.java.migrate.net.JavaNetAPIs

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeSunJavaToJava11Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeSunJavaToJava11Test.java
@@ -247,4 +247,27 @@ class UpgradeSunJavaToJava11Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @SuppressWarnings("removal")
+    void testBoxedPrimitiveConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Integer i = new Integer(12);
+                  Boolean b = new Boolean("true");
+              }
+              """,
+            """
+              class Test {
+                  Integer i = Integer.valueOf(12);
+                  Boolean b = Boolean.valueOf("true");
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/MigrateDeprecatedBoxedPrimitiveConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/MigrateDeprecatedBoxedPrimitiveConstructorsTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings("removal")
+class MigrateDeprecatedBoxedPrimitiveConstructorsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MigrateDeprecatedBoxedPrimitiveConstructorsRecipes());
+    }
+
+    @Test
+    void booleanConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Boolean b1 = new Boolean(true);
+                  Boolean b2 = new Boolean("true");
+                  Boolean b3 = true; // Negative test, should not be rewritten
+                  Boolean b4 = Boolean.parseBoolean("true"); // Negative test, should not be rewritten
+              }
+              """,
+            """
+              class Test {
+                  Boolean b1 = Boolean.valueOf(true);
+                  Boolean b2 = Boolean.valueOf("true");
+                  Boolean b3 = true; // Negative test, should not be rewritten
+                  Boolean b4 = Boolean.parseBoolean("true"); // Negative test, should not be rewritten
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void byteConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Byte b1 = new Byte((byte) 42);
+                  Byte b2 = new Byte("42");
+                  Byte b3 = 84; // Negative test, should not be rewritten
+                  Byte b4 = Byte.parseByte("84"); // Negative test, should not be rewritten
+              }
+              """,
+            """
+              class Test {
+                  Byte b1 = Byte.valueOf((byte) 42);
+                  Byte b2 = Byte.valueOf("42");
+                  Byte b3 = 84; // Negative test, should not be rewritten
+                  Byte b4 = Byte.parseByte("84"); // Negative test, should not be rewritten
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void charConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Character c1 = new Character('a');
+                  Character c2 = 'a'; // Negative test, should not be rewritten
+              }
+              """,
+            """
+              class Test {
+                  Character c1 = Character.valueOf('a');
+                  Character c2 = 'a'; // Negative test, should not be rewritten
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doubleConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Double d1 = new Double(3.14);
+                  Double d2 = new Double("3.14");
+                  Double d3 = 3.14; // Negative test, should not be rewritten
+                  Double d4 = Double.parseDouble("3.14"); // Negative test, should not be rewritten
+              }
+              """,
+            """
+              class Test {
+                  Double d1 = Double.valueOf(3.14);
+                  Double d2 = Double.valueOf("3.14");
+                  Double d3 = 3.14; // Negative test, should not be rewritten
+                  Double d4 = Double.parseDouble("3.14"); // Negative test, should not be rewritten
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void floatConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Float f1 = new Float(Double.valueOf(12.3));
+                  Float f2 = new Float(42.0f);
+                  Float f3 = new Float("3.14");
+                  Float f4 = 3.14f; // Negative test, should not be rewritten
+                  Float f5 = Float.parseFloat("3.14"); // Negative test, should not be rewritten
+                  // This recipe doesn't handle new Float(double)
+                  Float f6 = new Float(45.6);
+              }
+              """,
+            """
+              class Test {
+                  Float f1 = Float.valueOf(Double.valueOf(12.3).floatValue());
+                  Float f2 = Float.valueOf(42.0f);
+                  Float f3 = Float.valueOf("3.14");
+                  Float f4 = 3.14f; // Negative test, should not be rewritten
+                  Float f5 = Float.parseFloat("3.14"); // Negative test, should not be rewritten
+                  // This recipe doesn't handle new Float(double)
+                  Float f6 = new Float(45.6);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void intConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Integer i1 = new Integer(42);
+                  Integer i2 = new Integer("42");
+                  Integer i3 = 42; // Negative test, should not be rewritten
+                  Integer i4 = Integer.parseInt("42"); // Negative test, should not be rewritten
+              }
+              """,
+            """
+              class Test {
+                  Integer i1 = Integer.valueOf(42);
+                  Integer i2 = Integer.valueOf("42");
+                  Integer i3 = 42; // Negative test, should not be rewritten
+                  Integer i4 = Integer.parseInt("42"); // Negative test, should not be rewritten
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void longConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Long l1 = new Long(42L);
+                  Long l2 = new Long("42");
+                  Long l3 = 84L; // Negative test, should not be rewritten
+                  Long l4 = Long.parseLong("84"); // Negative test, should not be rewritten
+              }
+              """,
+            """
+              class Test {
+                  Long l1 = Long.valueOf(42L);
+                  Long l2 = Long.valueOf("42");
+                  Long l3 = 84L; // Negative test, should not be rewritten
+                  Long l4 = Long.parseLong("84"); // Negative test, should not be rewritten
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shortConstructors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Short s1 = new Short((short) 42);
+                  Short s2 = new Short("42");
+                  Short s3 = 84; // Negative test, should not be rewritten
+                  Short s4 = Short.parseShort("84"); // Negative test, should not be rewritten
+              }
+              """,
+            """
+              class Test {
+                  Short s1 = Short.valueOf((short) 42);
+                  Short s2 = Short.valueOf("42");
+                  Short s3 = 84; // Negative test, should not be rewritten
+                  Short s4 = Short.parseShort("84"); // Negative test, should not be rewritten
+              }
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a set of Refaster recipes to deal with boxed primitive constructors that were [deprecated in Java 9](https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/deprecated-list.html#constructor).

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
https://rewriteoss.slack.com/archives/C01A843MWG5/p1698430647117759?thread_ts=1698429230.444949&cid=C01A843MWG5

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Unless I missed something, I think I covered all deprecated constructors **except** `new Float(double) -> Float.valueOf((float) double)`. Due to how Refaster generates the code, I end up in a situation like the following:

**Refaster Template**
```java
@RecipeDescriptor(
    name = "Replace deprecated `Float(double)` constructor invocations",
    description = "Replace deprecated `Float(double)` constructor invocations with `Float.valueOf((float) double)`."
)
public static class FloatDoubleConstructor {
    @BeforeTemplate
    public Float doubleConstructor(double value) {
        return new Float(value);
    }

    @AfterTemplate
    public Float valueOf(double value) {
        return Float.valueOf((float) value);
    }
}
```

**Generated Code Error**
```java
error: incompatible types: Double cannot be converted to float
                final JavaTemplate valueOf = Semantics.expression(this, "valueOf", (@Primitive Double value) -> Float.valueOf((float)value)).build();
```

Therefore I was only able to cover `new Float(Double) -> new Float(Double.floatValue())` instead.

Is there any way to force a real primitive in this line via Refaster _(or use e.g.: a String-format template somehow)_?
Do we need to make a separate imperative recipe just to cover the `Float(double)` edge case?

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 🙏 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
We could use imperative recipes but the change seems simple enough that the Refaster usage seems to be justified and seems to avoid a lot of repeated boilerplate code.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
