### PR TITLE
LombokValueToRecord should be part of Java 17 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -34,6 +34,7 @@ recipeList:
       minimumJavaMajorVersion: 17
   - org.openrewrite.staticanalysis.InstanceOfPatternMatch
   - org.openrewrite.java.migrate.lang.UseTextBlocks
+  - org.openrewrite.java.migrate.lombok.LombokValueToRecord
   - org.openrewrite.java.migrate.DeprecatedJavaxSecurityCert
   - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
   - org.openrewrite.java.migrate.RemovedLegacySunJSSEProviderName

--- a/src/main/resources/META-INF/rewrite/lombok.yml
+++ b/src/main/resources/META-INF/rewrite/lombok.yml
@@ -19,7 +19,7 @@ name: org.openrewrite.java.migrate.lombok.UpdateLombokToJava11
 displayName: Migrate Lombok to a Java 11 compatible version
 description: Update Lombok dependency to a version that is compatible with Java 11 and migrate experimental Lombok types that have been promoted.
 tags:
-  - java17
+  - java11
   - lombok
 recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
@@ -42,4 +42,3 @@ recipeList:
       oldFullyQualifiedTypeName: lombok.experimental.val
       newFullyQualifiedTypeName: lombok.val
   - org.openrewrite.java.migrate.lombok.LombokValToFinalVar
-  - org.openrewrite.java.migrate.lombok.LombokValueToRecord


### PR DESCRIPTION
It was not triggered when moving to 17 and above, likely because of markers not set correctly yet.