### PR TITLE
Upgrade jaxb2-maven-plugin to 2.5.x for Java 9+

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -141,6 +141,10 @@ recipeList:
       groupPattern: jakarta.xml.bind
       artifactPattern: "*"
       onlyIfVersionsMatch: true
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.codehaus.mojo
+      artifactId: jaxb2-maven-plugin
+      newVersion: 2.5.x
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.javax.AddJaxwsDependencies


### PR DESCRIPTION
## What's your motivation?
- https://stackoverflow.com/questions/47257811/java-lang-classnotfoundexception-com-sun-codemodel-codewriter-with-jdk9
