### PR TITLE
Replace URL constructors in Java 21

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/net/URLConstructorsToURI.java
+++ b/src/main/java/org/openrewrite/java/migrate/net/URLConstructorsToURI.java
@@ -1,0 +1,55 @@
+package org.openrewrite.java.migrate.net;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+public class URLConstructorsToURI {
+    @RecipeDescriptor(
+            name = "Convert `new URL(String)` to `URI.create(String).toURL()`",
+            description = "Converts `new URL(String)` constructors to `URI.create(String).toURL()`."
+    )
+    public static class URLSingleArgumentConstructor {
+        @BeforeTemplate
+        java.net.URL urlConstructor(String spec) throws Exception {
+            return new java.net.URL(spec);
+        }
+
+        @AfterTemplate
+        java.net.URL uriCreateToURL(String spec) throws Exception {
+            return java.net.URI.create(spec).toURL();
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Convert `new URL(String, String, String)` to `new URI(...).toURL()`",
+            description = "Converts `new URL(String, String, String)` constructors to `new URI(...).toURL()`."
+    )
+    public static class URLThreeArgumentConstructor {
+        @BeforeTemplate
+        java.net.URL urlConstructor(String protocol, String host, String file) throws Exception {
+            return new java.net.URL(protocol, host, file);
+        }
+
+        @AfterTemplate
+        java.net.URL newUriToUrl(String protocol, String host, String file) throws Exception {
+            return new java.net.URI(protocol, null, host, -1, file, null, null).toURL();
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Convert `new URL(String, String, int, String)` to `new URI(...).toURL()`",
+            description = "Converts `new URL(String, String, int, String)` constructors to `new URI(...).toURL()`."
+    )
+    public static class URLFourArgumentConstructor {
+        @BeforeTemplate
+        java.net.URL urlConstructor(String protocol, String host, int port, String file) throws Exception {
+            return new java.net.URL(protocol, host, port, file);
+        }
+
+        @AfterTemplate
+        java.net.URL newUriToUrl(String protocol, String host, int port, String file) throws Exception {
+            return new java.net.URI(protocol, null, host, port, file, null, null).toURL();
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/net/URLConstructorsToURI.java
+++ b/src/main/java/org/openrewrite/java/migrate/net/URLConstructorsToURI.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.net;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;

--- a/src/main/resources/META-INF/rewrite/java-version-21.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-21.yml
@@ -26,9 +26,10 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava17
   - org.openrewrite.java.migrate.JavaVersion21
+  - org.openrewrite.java.migrate.net.URLConstructorsToURIRecipes
+  - org.openrewrite.java.migrate.util.SequencedCollection
   - org.openrewrite.java.migrate.util.UseLocaleOf
   - org.openrewrite.staticanalysis.ReplaceDeprecatedRuntimeExecMethods
-  - org.openrewrite.java.migrate.util.SequencedCollection
   - org.openrewrite.github.SetupJavaUpgradeJavaVersion
 
 ---

--- a/src/test/java/org/openrewrite/java/migrate/net/URLConstructorsToURITest.java
+++ b/src/test/java/org/openrewrite/java/migrate/net/URLConstructorsToURITest.java
@@ -1,0 +1,50 @@
+package org.openrewrite.java.migrate.net;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class URLConstructorsToURITest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new URLConstructorsToURIRecipes());
+    }
+
+    @Test
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/191")
+    void urlConstructor() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.net.URL;
+              
+              class Test {
+                  void urlConstructor(String spec) throws Exception {
+                      URL url1 = new URL(spec);
+                      URL url2 = new URL(spec, "localhost", "file");
+                      URL url3 = new URL(spec, "localhost", 8080, "file");
+                  }
+              }
+              """,
+            """
+              import java.net.URI;
+              import java.net.URL;
+              
+              class Test {
+                  void urlConstructor(String spec) throws Exception {
+                      URL url1 = URI.create(spec).toURL();
+                      URL url2 = new URI(spec, null, "localhost", -1, "file", null, null).toURL();
+                      URL url3 = new URI(spec, null, "localhost", 8080, "file", null, null).toURL();
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/net/URLConstructorsToURITest.java
+++ b/src/test/java/org/openrewrite/java/migrate/net/URLConstructorsToURITest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.net;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What's changed?
Added three Refaster recipes in `URLConstructorsToURI` to replace URL constructors with `URI.create` and `new URI` with `.toURL()`.

## What's your motivation?
Fixes #191

## Any additional context
As per https://bugs.openjdk.org/browse/JDK-8294241 
