### PR TITLE
Hint at `Thread.stop()` throwing `UnsupportedOperationException`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupported.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupported.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+
+public class ThreadStopUnsupported extends Recipe {
+    private static final MethodMatcher THREAD_STOP_MATCHER = new MethodMatcher("java.lang.Thread stop()");
+
+    @Override
+    public String getDisplayName() {
+        return "Replace `Thread.stop()` with `throw new UnsupportedOperationException()`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "`Thread.stop()` always throws a `new UnsupportedOperationException` in Java 21+. " +
+               "This recipe makes that explicit, as the migration is more complicated." +
+               "See https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html .";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesJavaVersion<>(21),
+                new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        if (THREAD_STOP_MATCHER.matches(method)) {
+                            JavaTemplate template = JavaTemplate.builder("throw new UnsupportedOperationException()")
+                                    .contextSensitive().build();
+                            J throwNewUOE = template.apply(getCursor(), method.getCoordinates().replace());
+                            String prefixWhitespace = throwNewUOE.getPrefix().getWhitespace();
+                            String commentText =
+                                    prefixWhitespace + " * `Thread.stop()` always throws a `new UnsupportedOperationException()` in Java 21+." +
+                                    prefixWhitespace + " * For detailed migration instructions see the migration guide available at" +
+                                    prefixWhitespace + " * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html" +
+                                    prefixWhitespace + " ";
+                            return throwNewUOE.withComments(Collections.singletonList(new TextComment(true, commentText, prefixWhitespace, Markers.EMPTY)));
+                        }
+                        return super.visitMethodInvocation(method, executionContext);
+                    }
+                });
+    }
+}

--- a/src/main/resources/META-INF/rewrite/java-version-21.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-21.yml
@@ -26,6 +26,7 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava17
   - org.openrewrite.java.migrate.JavaVersion21
+  - org.openrewrite.java.migrate.lang.ThreadStopUnsupported
   - org.openrewrite.java.migrate.net.URLConstructorsToURIRecipes
   - org.openrewrite.java.migrate.util.SequencedCollection
   - org.openrewrite.java.migrate.util.UseLocaleOf

--- a/src/test/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupportedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupportedTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+class ThreadStopUnsupportedTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ThreadStopUnsupported())
+          .allSources(src -> src.markers(javaVersion(21)));
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/194")
+    @DocumentExample
+    void replaceWithThrows() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      Thread.currentThread().stop();
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      /*
+                       * `Thread.stop()` always throws a `new UnsupportedOperationException()` in Java 21+.
+                       * For detailed migration instructions see the migration guide available at
+                       * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html
+                       */
+                      throw new UnsupportedOperationException();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Replace `Thread.stop()` with `throw new UnsupportedOperationException()` on Java 21, with reference to the migration guide.

## What's your motivation?
This helps surface any remaining such migration issues, as the exception is otherwise thrown implicitly.

## Have you considered any alternatives or workarounds?
From the links below a proper replacement will be a lot more complicated; this way we at least already surface the problem to the user, rather than have that be a runtime realization.

## Any additional context
- #194
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#stop()
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html