### PR TITLE
Recipe- BeansXmlNamespace

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/BeansXmlNamespace.java
+++ b/src/main/java/org/openrewrite/java/migrate/BeansXmlNamespace.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.XmlVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class BeansXmlNamespace extends Recipe {
+
+    private static final XPathMatcher BEANS_MATCHER = new XPathMatcher("/beans");
+    private static final String NS_SUN = "http://java.sun.com/xml/ns/javaee";
+    private static final String NS_JCP = "http://xmlns.jcp.org/xml/ns/javaee";
+    private static final String SUN_SCHEMA_LOCATION = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd";
+    private static final String JCP_SCHEMA_LOCATION = "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd";
+    private static final String DISABLE_VALIDATING = "org.jboss.weld.xml.disableValidating";
+
+    @Override
+    public String getDisplayName() {
+        return "Check valid namespace and schema location in the`beans.xml` file ";
+    }
+
+    @Override
+    public String getDescription() {
+        return " Adds JVM property `org.jboss.weld.xml.disableValidating=true` when valid namespace and schema location is not found in file.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        XmlVisitor<ExecutionContext> xmlVisitor = new XmlVisitor<ExecutionContext>() {
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
+                if (!BEANS_MATCHER.matches(getCursor()) || t.getAttributes().stream().map(Xml.Attribute::getKeyAsString).noneMatch("xmlns"::equals)) {
+                    return t;
+                }
+                String nameSpaceValue = null, schemaLocation = null;
+                for (Xml.Attribute attribute : t.getAttributes()) {
+                    if (attribute.getKeyAsString().equals("xmlns")) {
+                        nameSpaceValue = attribute.getValueAsString();
+                    } else if (attribute.getKeyAsString().endsWith("schemaLocation")) {
+                        schemaLocation = attribute.getValueAsString();
+                    } else if (DISABLE_VALIDATING.equalsIgnoreCase(attribute.getKeyAsString())) {
+                        return t;
+                    }
+
+                }
+                if (!checkNameSpaceSchemaLocation(nameSpaceValue, schemaLocation)) {
+                    return addAttribute(t, DISABLE_VALIDATING, String.valueOf(true), ctx);
+                }
+                return t;
+            }
+
+            private Xml.Tag addAttribute(Xml.Tag t, String name, String all, ExecutionContext ctx) {
+                Xml.Attribute attribute = new Xml.Attribute(Tree.randomId(), "", Markers.EMPTY, new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, name), "", new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY, Xml.Attribute.Value.Quote.Double, all));
+                return t.withAttributes(ListUtils.concat(t.getAttributes(), autoFormat(attribute, ctx)));
+            }
+
+            private boolean checkNameSpaceSchemaLocation(String nameSpaceValue, String schemaLocation) {
+                if (NS_SUN.equalsIgnoreCase(nameSpaceValue) && SUN_SCHEMA_LOCATION.equalsIgnoreCase(schemaLocation)) {
+                    return true;
+                }
+                return nameSpaceValue.equalsIgnoreCase(NS_JCP) && schemaLocation.equalsIgnoreCase(JCP_SCHEMA_LOCATION);
+            }
+
+        };
+        return Preconditions.check(new HasSourcePath<>("**/beans.xml"), xmlVisitor);
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/BeansXmlNamespace.java
+++ b/src/main/java/org/openrewrite/java/migrate/BeansXmlNamespace.java
@@ -39,12 +39,12 @@ public class BeansXmlNamespace extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Check valid namespace and schema location in the`beans.xml` file ";
+        return "Change `beans.xml` `schemaLocation` to match XML namespace";
     }
 
     @Override
     public String getDescription() {
-        return "The recipe updates incompatible namespaces with the right value of schemaLocation.";
+        return "Set the `schemaLocation` that corresponds to the `xmlns` set in `beans.xml` files.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/BeansXmlNamespace.java
+++ b/src/main/java/org/openrewrite/java/migrate/BeansXmlNamespace.java
@@ -23,6 +23,10 @@ import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Xml;
 
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class BeansXmlNamespace extends Recipe {
@@ -32,7 +36,6 @@ public class BeansXmlNamespace extends Recipe {
     private static final String NS_JCP = "http://xmlns.jcp.org/xml/ns/javaee";
     private static final String SUN_SCHEMA_LOCATION = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd";
     private static final String JCP_SCHEMA_LOCATION = "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd";
-    private static final String DISABLE_VALIDATING = "org.jboss.weld.xml.disableValidating";
 
     @Override
     public String getDisplayName() {
@@ -46,45 +49,22 @@ public class BeansXmlNamespace extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        XmlVisitor<ExecutionContext> xmlVisitor = new XmlVisitor<ExecutionContext>() {
+        return Preconditions.check(new HasSourcePath<>("**/beans.xml"), new XmlVisitor<ExecutionContext>() {
             @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
-                if (!BEANS_MATCHER.matches(getCursor()) || t.getAttributes().stream().map(Xml.Attribute::getKeyAsString).noneMatch("xmlns"::equals)) {
-                    return t;
-                }
-                String nameSpaceValue = null, schemaLocation = null;
-                for (Xml.Attribute attribute : t.getAttributes()) {
-                    String key = attribute.getKeyAsString();
-                    String value = attribute.getValueAsString();
-                    if ("xmlns".equals(key)) {
-                        nameSpaceValue = value;
-                    } else if (key.endsWith("schemaLocation")) {
-                        schemaLocation = value;
+                if (BEANS_MATCHER.matches(getCursor())) {
+                    Map<String, String> attributes = t.getAttributes().stream().collect(toMap(Xml.Attribute::getKeyAsString, Xml.Attribute::getValueAsString));
+                    String xmlns = attributes.get("xmlns");
+                    String schemaLocation = attributes.get("xsi:schemaLocation");
+                    if (NS_SUN.equalsIgnoreCase(xmlns) && !SUN_SCHEMA_LOCATION.equalsIgnoreCase(schemaLocation)) {
+                        doAfterVisit(new ChangeTagAttribute("beans", "xsi:schemaLocation", SUN_SCHEMA_LOCATION, null).getVisitor());
+                    } else if (NS_JCP.equalsIgnoreCase(xmlns) && !JCP_SCHEMA_LOCATION.equalsIgnoreCase(schemaLocation)) {
+                        doAfterVisit(new ChangeTagAttribute("beans", "xsi:schemaLocation", JCP_SCHEMA_LOCATION, null).getVisitor());
                     }
                 }
-                if (!updateNameSpaceSchemaLocation(nameSpaceValue, schemaLocation).isEmpty()) {
-                    t = updateAttribute(t, updateNameSpaceSchemaLocation(nameSpaceValue, schemaLocation), ctx);
-                }
                 return t;
             }
-
-            private Xml.Tag updateAttribute(Xml.Tag t, String value, ExecutionContext ctx) {
-                TreeVisitor<?, ExecutionContext> changeTagVisitor = new ChangeTagAttribute("beans", "xsi:schemaLocation", value, null).getVisitor();
-                t = (Xml.Tag) changeTagVisitor.visit(t, ctx, getCursor());
-                return t;
-            }
-
-            private String updateNameSpaceSchemaLocation(String nameSpaceValue, String schemaLocation) {
-                if (NS_SUN.equalsIgnoreCase(nameSpaceValue) && !(SUN_SCHEMA_LOCATION.equalsIgnoreCase(schemaLocation))) {
-                    return (SUN_SCHEMA_LOCATION);
-                } else if (NS_JCP.equalsIgnoreCase(nameSpaceValue) && !(JCP_SCHEMA_LOCATION.equalsIgnoreCase(schemaLocation))) {
-                    return (JCP_SCHEMA_LOCATION);
-                }
-                return "";
-            }
-
-        };
-        return Preconditions.check(new HasSourcePath<>("**/beans.xml"), xmlVisitor);
+        });
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
@@ -58,19 +58,19 @@ class BeansXmlNamespaceTest implements RewriteTest {
           //language=xml
           xml(
             """
-                   <?xml version="1.0" encoding="UTF-8"?>
-                   <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                      xsi:schemaLocation="http://xmlns.jcp.org/DDDDxml/ns/javaee22 http://xmlns.jcp.org11/xml/ns/javaee777/beans_1_1.xsd">
-                   </beans> 
-                   """,
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://xmlns.jcp.org/DDDDxml/ns/javaee22 http://xmlns.jcp.org11/xml/ns/javaee777/beans_1_1.xsd">
+              </beans> 
+              """,
             """
-                   <?xml version="1.0" encoding="UTF-8"?>
-                   <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-                   </beans> 
-                   """,
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
+              </beans> 
+              """,
             sourceSpecs -> sourceSpecs.path("beans.xml")
           )
         );

--- a/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
@@ -27,99 +27,82 @@ class BeansXmlNamespaceTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new BeansXmlNamespace());
     }
+
     @Test
     void noSchemaCD1() {
         rewriteRun(
           //language=xml
-          xml(
-            """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <beans xmlns="http://java.sun.com/xml/ns/javaee"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
-              </beans>
-              """,
-            """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <beans xmlns="http://java.sun.com/xml/ns/javaee"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" org.jboss.weld.xml.disableValidating="true">
-              </beans>
-              """,
-            sourceSpecs -> sourceSpecs.path("beans.xml")
-          )
-        );
+          xml("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <beans xmlns="http://java.sun.com/xml/ns/javaee"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://jakarta.ee/xml/ns/jakarXXtaee https://jakarta.ee/xml/ns/jakartaee/beans111_3_0.xsd">
+            </beans>
+            """, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <beans xmlns="http://java.sun.com/xml/ns/javaee"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+            </beans>
+            """, sourceSpecs -> sourceSpecs.path("beans.xml")));
     }
+
     @Test
     void noSchemaCD12() {
         rewriteRun(
           //language=xml
-          xml(
-            """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-		       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee22 http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-              </beans> 
-              """,
-            """
-             <?xml version="1.0" encoding="UTF-8"?>
-             <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-		      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee22 http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" org.jboss.weld.xml.disableValidating="true">
-             </beans> 
-              """,
-            sourceSpecs -> sourceSpecs.path("beans.xml")
-          )
-        );
+          xml("""
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://xmlns.jcp.org/DDDDxml/ns/javaee22 http://xmlns.jcp.org11/xml/ns/javaee777/beans_1_1.xsd">
+                 </beans> 
+                 """, """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
+                 </beans> 
+                  """, sourceSpecs -> sourceSpecs.path("beans.xml")));
     }
+
     @Nested
     class NoChanges {
         @Test
         void fileNotNamedBeansXml() {
             rewriteRun(
               //language=xml
-              xml(
-                """
-                  <beans xmlns="http://java.sun.com/xml/ns/javaee" 
-		                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-                  </beans> 
-                  """,
-                sourceSpecs -> sourceSpecs.path("not-beans.xml")
-              )
-            );
+              xml("""
+                <beans xmlns="http://java.sun.com/xml/ns/javaee" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+                </beans> 
+                """, sourceSpecs -> sourceSpecs.path("not-beans.xml")));
         }
+
         @Test
         void alreadyHasRightSchemaLocationSun() {
             rewriteRun(
               //language=xml
-              xml(
-                """
-                  <beans xmlns="http://java.sun.com/xml/ns/javaee" 
-		                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-                  </beans> 
-                  """,
-                sourceSpecs -> sourceSpecs.path("beans.xml")
-              )
-            );
+              xml("""
+                <beans xmlns="http://java.sun.com/xml/ns/javaee" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+                </beans> 
+                """, sourceSpecs -> sourceSpecs.path("beans.xml")));
         }
+
         @Test
         void alreadyHasRightSchemaLocation() {
             rewriteRun(
               //language=xml
-              xml(
-                """
-                  <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-		                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		                xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
-		  				bean-discovery-mode="all" version="1.1">
-                  </beans>
-                  """,
-                sourceSpecs -> sourceSpecs.path("beans.xml")
-              )
-            );
+              xml("""
+                <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
+                 bean-discovery-mode="all" version="1.1">
+                </beans>
+                """, sourceSpecs -> sourceSpecs.path("beans.xml")));
         }
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
@@ -32,38 +32,48 @@ class BeansXmlNamespaceTest implements RewriteTest {
     void noSchemaCD1() {
         rewriteRun(
           //language=xml
-          xml("""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <beans xmlns="http://java.sun.com/xml/ns/javaee"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="https://jakarta.ee/xml/ns/jakarXXtaee https://jakarta.ee/xml/ns/jakartaee/beans111_3_0.xsd">
-            </beans>
-            """, """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <beans xmlns="http://java.sun.com/xml/ns/javaee"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-            </beans>
-            """, sourceSpecs -> sourceSpecs.path("beans.xml")));
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakarXXtaee https://jakarta.ee/xml/ns/jakartaee/beans111_3_0.xsd">
+              </beans>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+              </beans>
+              """,
+            sourceSpecs -> sourceSpecs.path("beans.xml")
+          )
+        );
     }
 
     @Test
     void noSchemaCD12() {
         rewriteRun(
           //language=xml
-          xml("""
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://xmlns.jcp.org/DDDDxml/ns/javaee22 http://xmlns.jcp.org11/xml/ns/javaee777/beans_1_1.xsd">
-                 </beans> 
-                 """, """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-                 </beans> 
-                  """, sourceSpecs -> sourceSpecs.path("beans.xml")));
+          xml(
+            """
+                   <?xml version="1.0" encoding="UTF-8"?>
+                   <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://xmlns.jcp.org/DDDDxml/ns/javaee22 http://xmlns.jcp.org11/xml/ns/javaee777/beans_1_1.xsd">
+                   </beans> 
+                   """,
+            """
+                   <?xml version="1.0" encoding="UTF-8"?>
+                   <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
+                   </beans> 
+                   """,
+            sourceSpecs -> sourceSpecs.path("beans.xml")
+          )
+        );
     }
 
     @Nested
@@ -72,37 +82,49 @@ class BeansXmlNamespaceTest implements RewriteTest {
         void fileNotNamedBeansXml() {
             rewriteRun(
               //language=xml
-              xml("""
-                <beans xmlns="http://java.sun.com/xml/ns/javaee" 
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-                </beans> 
-                """, sourceSpecs -> sourceSpecs.path("not-beans.xml")));
+              xml(
+                """
+                  <beans xmlns="http://java.sun.com/xml/ns/javaee" 
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+                  </beans> 
+                  """,
+                sourceSpecs -> sourceSpecs.path("not-beans.xml")
+              )
+            );
         }
 
         @Test
         void alreadyHasRightSchemaLocationSun() {
             rewriteRun(
               //language=xml
-              xml("""
-                <beans xmlns="http://java.sun.com/xml/ns/javaee" 
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-                </beans> 
-                """, sourceSpecs -> sourceSpecs.path("beans.xml")));
+              xml(
+                """
+                  <beans xmlns="http://java.sun.com/xml/ns/javaee" 
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+                  </beans> 
+                  """,
+                sourceSpecs -> sourceSpecs.path("beans.xml")
+              )
+            );
         }
 
         @Test
         void alreadyHasRightSchemaLocation() {
             rewriteRun(
               //language=xml
-              xml("""
-                <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
-                 bean-discovery-mode="all" version="1.1">
-                </beans>
-                """, sourceSpecs -> sourceSpecs.path("beans.xml")));
+              xml(
+                """
+                  <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
+                      bean-discovery-mode="all" version="1.1">
+                  </beans>
+                  """,
+                sourceSpecs -> sourceSpecs.path("beans.xml")
+              )
+            );
         }
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BeansXmlNamespaceTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class BeansXmlNamespaceTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new BeansXmlNamespace());
+    }
+    @Test
+    void noSchemaCD1() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
+              </beans>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" org.jboss.weld.xml.disableValidating="true">
+              </beans>
+              """,
+            sourceSpecs -> sourceSpecs.path("beans.xml")
+          )
+        );
+    }
+    @Test
+    void noSchemaCD12() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+		       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee22 http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
+              </beans> 
+              """,
+            """
+             <?xml version="1.0" encoding="UTF-8"?>
+             <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+		      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee22 http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" org.jboss.weld.xml.disableValidating="true">
+             </beans> 
+              """,
+            sourceSpecs -> sourceSpecs.path("beans.xml")
+          )
+        );
+    }
+    @Nested
+    class NoChanges {
+        @Test
+        void fileNotNamedBeansXml() {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                  <beans xmlns="http://java.sun.com/xml/ns/javaee" 
+		                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+                  </beans> 
+                  """,
+                sourceSpecs -> sourceSpecs.path("not-beans.xml")
+              )
+            );
+        }
+        @Test
+        void alreadyHasRightSchemaLocationSun() {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                  <beans xmlns="http://java.sun.com/xml/ns/javaee" 
+		                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+                  </beans> 
+                  """,
+                sourceSpecs -> sourceSpecs.path("beans.xml")
+              )
+            );
+        }
+        @Test
+        void alreadyHasRightSchemaLocation() {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                  <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+		                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		                xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
+		  				bean-discovery-mode="all" version="1.1">
+                  </beans>
+                  """,
+                sourceSpecs -> sourceSpecs.path("beans.xml")
+              )
+            );
+        }
+    }
+}


### PR DESCRIPTION

## What's changed?
<img width="1273" alt="image" src="https://github.com/openrewrite/rewrite-migrate-java/assets/93149514/ffa72c30-1093-463f-ba9d-dd5ba633af3c">

<img width="1273" alt="image" src="https://github.com/openrewrite/rewrite-migrate-java/assets/93149514/9f471861-9557-44b8-9864-40c2889358ce">


## Anyone you would like to review specifically?
<!-- @mention them here -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
