### PR TITLE
Consolidate Javax to Jakarta recipes

### DIFF
--- a/src/main/resources/META-INF/rewrite/add-inject-dependencies.yml
+++ b/src/main/resources/META-INF/rewrite/add-inject-dependencies.yml
@@ -25,7 +25,6 @@ tags:
   - java11
   - inject
   - jakarta
-
 recipeList:
   # Add or update the jakarta.inject-api to a maven project. This artifact still uses the javax.inject name space.
   - org.openrewrite.java.dependencies.AddDependency:

--- a/src/main/resources/META-INF/rewrite/jacoco.yml
+++ b/src/main/resources/META-INF/rewrite/jacoco.yml
@@ -25,7 +25,6 @@ description: This recipe will upgrade the JaCoCo Maven plugin to a more recent v
 tags:
   - java11
   - jacoco
-
 recipeList:
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.jacoco

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -153,7 +153,6 @@ displayName: Use `StateManagementStrategy`
 description: >
       Methods that were removed from the `jakarta.faces.application.StateManager` and `javax.faces.application.StateManager` classes in Jakarta Faces 4.0 are replaced
       by `jakarta.faces.view.StateManagementStrategy` or `javax.faces.view.StateManagementStrategy` based on Jakarta10 migration in Faces 4.0
-
 recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: "*.faces.application.StateManager getComponentStateToSave(*.faces.context.FacesContext)"

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -69,7 +69,6 @@ tags:
   - activation
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.activation
@@ -92,53 +91,19 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxAnnotationMigrationToJakartaAnnotation
-displayName: Migrate deprecated `javax.annotation` packages to `jakarta.annotation`
+displayName: Migrate deprecated `javax.annotation` to `jakarta.annotation`
 description: Java EE has been rebranded to Jakarta EE, necessitating a package relocation.
 tags:
   - annotation
   - javax
   - jakarta
 recipeList:
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: jakarta.annotation
-      artifactId: jakarta.annotation-api
-      version: latest.release
-      onlyIfUsing: javax.annotation..*
-      acceptTransitive: true
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: jakarta.annotation
-      artifactId: jakarta.annotation-api
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.annotation
+      oldArtifactId: javax.annotation-api
+      newGroupId: jakarta.annotation
+      newArtifactId: jakarta.annotation-api
       newVersion: latest.release
-  - org.openrewrite.java.migrate.jakarta.ChangeJavaxAnnotationToJakarta
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: javax.annotation
-      artifactId: javax.annotation-api
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.ChangeJavaxAnnotationToJakarta
-displayName: Migrate deprecated `javax.annotation` packages to `jakarta.annotation`
-description: Java EE has been rebranded to Jakarta EE, necessitating a package relocation. Excludes `javax.annotation.processing`.
-tags:
-  - batch
-  - javax
-  - jakarta
-
-recipeList:
-  - org.openrewrite.java.migrate.jakarta.JavaxAnnotationPackageToJakarta
-  - org.openrewrite.java.migrate.jakarta.JavaxAnnotationSecurityPackageToJakarta
-  - org.openrewrite.java.migrate.jakarta.JavaxAnnotationSqlPackageToJakarta
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JavaxAnnotationPackageToJakarta
-displayName: Migrate deprecated `javax.annotation` packages to `jakarta.annotation`
-description: Change type of classes in the `javax.annotation` package to jakarta.
-tags:
-  - batch
-  - javax
-  - jakarta
-recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Generated
       newFullyQualifiedTypeName: jakarta.annotation.Generated
@@ -166,6 +131,8 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Resources
       newFullyQualifiedTypeName: jakarta.annotation.Resources
+  - org.openrewrite.java.migrate.jakarta.JavaxAnnotationSecurityPackageToJakarta
+  - org.openrewrite.java.migrate.jakarta.JavaxAnnotationSqlPackageToJakarta
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -173,7 +140,6 @@ name: org.openrewrite.java.migrate.jakarta.JavaxAnnotationSecurityPackageToJakar
 displayName: Migrate deprecated `javax.annotation.security` packages to `jakarta.annotation.security`
 description: Change type of classes in the `javax.annotation.security` package to jakarta.
 tags:
-  - batch
   - javax
   - jakarta
 recipeList:
@@ -199,7 +165,6 @@ name: org.openrewrite.java.migrate.jakarta.JavaxAnnotationSqlPackageToJakarta
 displayName: Migrate deprecated `javax.annotation.sql` packages to `jakarta.annotation.sql`
 description: Change type of classes in the `javax.annotation.sql` package to jakarta.
 tags:
-  - batch
   - javax
   - jakarta
 recipeList:
@@ -255,7 +220,6 @@ tags:
   - security
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.authorization
@@ -284,7 +248,6 @@ tags:
   - batch
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.batch
@@ -312,7 +275,6 @@ tags:
   - validation
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.validation
@@ -473,7 +435,6 @@ tags:
   - inject
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.inject
@@ -707,7 +668,6 @@ tags:
   - transaction
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.transaction
@@ -781,7 +741,6 @@ tags:
   - jaxb
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.xml.bind
@@ -846,7 +805,6 @@ tags:
   - jaxws
   - javax
   - jakarta
-
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.xml.ws
@@ -881,7 +839,6 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxPersistenceXmlToJakartaPersistenceXml
 displayName: Migrate xmlns entries in `persistence.xml` files
 description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
-
 recipeList:
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: name
@@ -918,7 +875,6 @@ displayName: Migrate Jackson from javax to jakarta namespace
 description: >
   Java EE has been rebranded to Jakarta EE.  This recipe replaces existing Jackson dependencies with their counterparts
   that are compatible with Jakarta EE 9.
-
 recipeList:
   # JAXB annotations support
   - org.openrewrite.java.dependencies.ChangeDependency:
@@ -1030,7 +986,6 @@ displayName: Migrate Ehcache from javax to jakarta namespace
 description: >
   Java EE has been rebranded to Jakarta EE.  This recipe replaces existing Ehcache dependencies with their counterparts
   that are compatible with Jakarta EE 9.
-
 recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.ehcache
@@ -1053,7 +1008,6 @@ displayName: Migrate Johnzon from javax to jakarta namespace
 description: >
   Java EE has been rebranded to Jakarta EE.  This recipe replaces existing Johnzon dependencies with their counterparts
   that are compatible with Jakarta EE 9.
-
 recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.apache.johnzon

--- a/src/main/resources/META-INF/rewrite/java-lang-apis.yml
+++ b/src/main/resources/META-INF/rewrite/java-lang-apis.yml
@@ -34,7 +34,6 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterToIsJavaIdentifierStart
 displayName: Use `Character#isJavaIdentifierStart(char)`
 description: Use `Character#isJavaIdentifierStart(char)` instead of the deprecated `Character#isJavaLetter(char)` in Java 1.1 or higher.
-
 recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: java.lang.Character isJavaLetter(char)

--- a/src/main/resources/META-INF/rewrite/remove-cobertura-maven-plugin.yml
+++ b/src/main/resources/META-INF/rewrite/remove-cobertura-maven-plugin.yml
@@ -21,7 +21,6 @@ description: This recipe will remove Cobertura, as it is not compatible with Jav
 tags:
   - java11
   - cobertura
-
 recipeList:
   - org.openrewrite.maven.RemovePlugin:
       groupId: org.codehaus.mojo

--- a/src/main/resources/META-INF/rewrite/wro4j-maven-plugin.yml
+++ b/src/main/resources/META-INF/rewrite/wro4j-maven-plugin.yml
@@ -21,7 +21,6 @@ description: This recipe will upgrade Wro4j to a more recent version compatible 
 tags:
   - java11
   - wro4j
-
 recipeList:
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: ro.isdc.wro4j


### PR DESCRIPTION
## What's changed?
Merge the three Javax to Jakarta Yaml recipes we had with identical display name into a single migration recipe.

## What's your motivation?
The existing situation was confusing, with separate recipes to update the dependency, core package and sub packages, all with identical display names showing in the documentations. Users were unsure which one to run, as all of them are composite recipes. Now we have just the one that runs all three.

## Have you considered any alternatives or workarounds?
We could have clarified the display names, but then still there would have been four recipes with nuances, and users unsure which to run when, all for what's likely to be a single migration.

## Any additional context
- https://rewriteoss.slack.com/archives/C01A843MWG5/p1700466808540169