### PR TITLE
`AddJaxwsRuntime` should not always add `jaxws-rt`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
@@ -111,27 +111,29 @@ public class AddJaxwsRuntime extends Recipe {
                             .orElseThrow(() -> new RuntimeException("Gradle build scripts must have a GradleProject marker"));
 
                     Set<String> apiConfigurations = getTransitiveDependencyConfiguration(gp, JAKARTA_JAXWS_API_GROUP, JAKARTA_JAXWS_API_ARTIFACT);
-                    Set<String> runtimeConfigurations = getTransitiveDependencyConfiguration(gp, SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT);
 
-                    if (runtimeConfigurations.isEmpty()) {
-                        if (gp.getConfiguration("compileOnly") != null) {
-                            g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "compileOnly", null, null, null, null)
-                                    .visitNonNull(g, ctx);
-                        }
-                        if (gp.getConfiguration("testImplementation") != null) {
-                            g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "testImplementation", null, null, null, null)
-                                    .visitNonNull(g, ctx);
-                        }
-                    } else {
-                        for (String apiConfiguration : apiConfigurations) {
-                            GradleDependencyConfiguration apiGdc = gp.getConfiguration(apiConfiguration);
-                            List<GradleDependencyConfiguration> apiTransitives = gp.configurationsExtendingFrom(apiGdc, true);
-                            for (String runtimeConfiguration : runtimeConfigurations) {
-                                GradleDependencyConfiguration runtimeGdc = gp.getConfiguration(runtimeConfiguration);
-                                List<GradleDependencyConfiguration> runtimeTransitives = gp.configurationsExtendingFrom(runtimeGdc, true);
-                                if (apiTransitives.stream().noneMatch(runtimeTransitives::contains)) {
-                                    g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, apiConfiguration, null, null, null, null)
-                                            .visitNonNull(g, ctx);
+                    if (!apiConfigurations.isEmpty()) {
+                        Set<String> runtimeConfigurations = getTransitiveDependencyConfiguration(gp, SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT);
+                        if (runtimeConfigurations.isEmpty()) {
+                            if (gp.getConfiguration("compileOnly") != null) {
+                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "compileOnly", null, null, null, null)
+                                        .visitNonNull(g, ctx);
+                            }
+                            if (gp.getConfiguration("testImplementation") != null) {
+                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "testImplementation", null, null, null, null)
+                                        .visitNonNull(g, ctx);
+                            }
+                        } else {
+                            for (String apiConfiguration : apiConfigurations) {
+                                GradleDependencyConfiguration apiGdc = gp.getConfiguration(apiConfiguration);
+                                List<GradleDependencyConfiguration> apiTransitives = gp.configurationsExtendingFrom(apiGdc, true);
+                                for (String runtimeConfiguration : runtimeConfigurations) {
+                                    GradleDependencyConfiguration runtimeGdc = gp.getConfiguration(runtimeConfiguration);
+                                    List<GradleDependencyConfiguration> runtimeTransitives = gp.configurationsExtendingFrom(runtimeGdc, true);
+                                    if (apiTransitives.stream().noneMatch(runtimeTransitives::contains)) {
+                                        g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, apiConfiguration, null, null, null, null)
+                                                .visitNonNull(g, ctx);
+                                    }
                                 }
                             }
                         }
@@ -199,13 +201,15 @@ public class AddJaxwsRuntime extends Recipe {
 
                     //Find the highest scope of a transitive dependency on the JAX-WS API (if it exists at all)
                     Scope apiScope = getTransitiveDependencyScope(mavenModel, JAKARTA_JAXWS_API_GROUP, JAKARTA_JAXWS_API_ARTIFACT);
-                    //Find the highest scope of a transitive dependency on the JAX-WS runtime (if it exists at all)
-                    Scope runtimeScope = getTransitiveDependencyScope(mavenModel, SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT);
+                    if (apiScope != null) {
+                        //Find the highest scope of a transitive dependency on the JAX-WS runtime (if it exists at all)
+                        Scope runtimeScope = getTransitiveDependencyScope(mavenModel, SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT);
 
-                    if (apiScope != null && (runtimeScope == null || !apiScope.isInClasspathOf(runtimeScope))) {
-                        String resolvedScope = apiScope == Scope.Test ? "test" : "provided";
-                        d = (Xml.Document) new AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT,
-                                "2.3.x", null, resolvedScope, null, null, null, null, null).visit(d, ctx);
+                        if (runtimeScope == null || !apiScope.isInClasspathOf(runtimeScope)) {
+                            String resolvedScope = apiScope == Scope.Test ? "test" : "provided";
+                            d = (Xml.Document) new AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT,
+                                    "2.3.x", null, resolvedScope, null, null, null, null, null).visit(d, ctx);
+                        }
                     }
 
                     return d;


### PR DESCRIPTION
The Gradle recipe should only add the runtime dependency if the API dependency `jakarta.xml.ws:jakarta.xml.ws-api` is already present. This is already how the Maven recipe operates.
