### PR TITLE
Set types on method invocation names to the same type as the compiler.

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnType.java
+++ b/src/main/java/org/openrewrite/java/migrate/ChangeMethodInvocationReturnType.java
@@ -69,6 +69,9 @@ public class ChangeMethodInvocationReturnType extends Recipe {
                 if (methodMatcher.matches(method) && type != null && !newReturnType.equals(type.getReturnType().toString())) {
                     type = type.withReturnType(JavaType.buildType(newReturnType));
                     m = m.withMethodType(type);
+                    if (m.getName().getType() != null) {
+                        m = m.withName(m.getName().withType(type));
+                    }
                     methodUpdated = true;
                 }
                 return m;

--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -63,6 +63,9 @@ public class StringFormatted extends Recipe {
             Optional<JavaType.Method> formatted = method.getMethodType().getDeclaringType().getMethods().stream()
                 .filter(m -> m.getName().equals("formatted")).findAny();
             mi = mi.withMethodType(formatted.orElse(null));
+            if (mi.getName().getType() != null) {
+                mi = mi.withName(mi.getName().withType(mi.getMethodType()));
+            }
             Expression select = wrapperNotNeeded ? arguments.get(0) :
                 new J.Parentheses<>(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(arguments.get(0)));
             mi = mi.withSelect(select);


### PR DESCRIPTION
Changes:

- The JavaType of J.MethodInvocation#name fields will have the same type from the compiler.