### PR TITLE
CastArraysAsListToList Recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/CastArraysAsListToList.java
+++ b/src/main/java/org/openrewrite/java/migrate/CastArraysAsListToList.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+
+public class CastArraysAsListToList extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Fix code like `(Type[])Arrays.asList(...).toArray()`";
+    }
+
+    @Override
+    public String getDescription() {
+        //language=markdown
+        return "convert code like `(Integer[]) Arrays.asList(1, 2, 3).toArray()` to `Arrays.asList(1, 2, 3).toArray(new Integer[0])`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        TreeVisitor<?, ExecutionContext> precondition = new UsesType<>("java.util.Arrays", false);
+        return Preconditions.check(precondition, new CastArraysAsListToListVisitor());
+    }
+
+    private static class CastArraysAsListToListVisitor extends JavaVisitor<ExecutionContext> {
+        private static MethodMatcher arraysAsList = new MethodMatcher("java.util.Arrays asList(..)", false);
+        private static MethodMatcher arrayListToArray = new MethodMatcher("java.util.List toArray()", true);
+
+        @Override
+        public J visitTypeCast(J.TypeCast typeCast, ExecutionContext executionContext) {
+            J j = super.visitTypeCast(typeCast, executionContext);
+            if (!(j instanceof J.TypeCast)) {
+                return j;
+            }
+            typeCast = (J.TypeCast) j;
+
+            boolean matches = typeCast.getClazz().getTree() instanceof J.ArrayType
+                    && (typeCast.getType() instanceof JavaType.Class || typeCast.getType() instanceof JavaType.Parameterized)
+                    && ((JavaType.FullyQualified) typeCast.getType()).getOwningClass() == null // does not support inner class now
+                    && arrayListToArray.matches(typeCast.getExpression())
+                    && typeCast.getExpression() instanceof J.MethodInvocation
+                    && arraysAsList.matches(((J.MethodInvocation) typeCast.getExpression()).getSelect());
+            if (!matches) {
+                return typeCast;
+            }
+
+            String fullyQualifiedName = ((JavaType.FullyQualified) typeCast.getType()).getFullyQualifiedName();
+            int dimensionSize = ((J.ArrayType) typeCast.getClazz().getTree()).getDimensions().size();
+
+            if (fullyQualifiedName.equals("java.lang.Object") && dimensionSize == 1) {
+                // we don't need to fix this case because toArray() does return Object[] type
+                return typeCast;
+            }
+
+            // we don't add generic type name here because generic array creation is not allowed
+            StringBuilder newArrayString = new StringBuilder();
+            String className = fullyQualifiedName.substring(fullyQualifiedName.lastIndexOf(".") + 1);
+            newArrayString.append(className);
+            newArrayString.append("[0]");
+            for (int i = 0; i < dimensionSize - 1; i++) {
+                newArrayString.append("[]");
+            }
+
+            JavaTemplate t = JavaTemplate
+                    .builder("#{any(java.util.List)}.toArray(new " + newArrayString + ")")
+                    .imports(fullyQualifiedName)
+                    .build();
+            return t.apply(updateCursor(typeCast), typeCast.getCoordinates().replace(), ((J.MethodInvocation) typeCast.getExpression()).getSelect());
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -32,6 +32,7 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava8
   - org.openrewrite.java.migrate.UseJavaUtilBase64
+  - org.openrewrite.java.migrate.CastArraysAsListToList
   # Add an explicit JAXB/JAX-WS runtime and upgrade the dependencies to Jakarta EE 8
   - org.openrewrite.java.migrate.javax.AddJaxbDependencies
   - org.openrewrite.java.migrate.javax.AddJaxwsDependencies

--- a/src/test/java/org/openrewrite/java/migrate/CastArraysAsListToListTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/CastArraysAsListToListTest.java
@@ -21,38 +21,33 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class CastArraysAsListToListTest implements RewriteTest {
+class CastArraysAsListToListTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new CastArraysAsListToList());
     }
 
     @Test
-    public void positiveCases() {
-        //language=java
+    void positiveCases() {
         rewriteRun(
+          //language=java
           java(
             """
-              import java.util.ArrayList;
               import java.util.Arrays;
-              import java.util.List;
-                            
-              public class Main {
-                  public static void main(String[] args) {
+              
+              class Foo {
+                  void bar() {
                       Integer[] array1 = (Integer[]) Arrays.asList(1, 2, 3).toArray();
                       Integer[][] array2 = (Integer[][]) Arrays.asList(new Integer[]{1}, new Integer[]{2}).toArray();
                       Object[][] array3 = (Object[][]) Arrays.asList(new Object[]{}, new Object[]{}).toArray();
                   }
               }
               """,
-
             """
-              import java.util.ArrayList;
               import java.util.Arrays;
-              import java.util.List;
-                            
-              public class Main {
-                  public static void main(String[] args) {
+              
+              class Foo {
+                  void bar() {
                       Integer[] array1 = Arrays.asList(1, 2, 3).toArray(new Integer[0]);
                       Integer[][] array2 = Arrays.asList(new Integer[]{1}, new Integer[]{2}).toArray(new Integer[0][]);
                       Object[][] array3 = Arrays.asList(new Object[]{}, new Object[]{}).toArray(new Object[0][]);
@@ -64,21 +59,22 @@ public class CastArraysAsListToListTest implements RewriteTest {
     }
 
     @Test
-    public void negativeCases() {
-        //language=java
+    void negativeCases() {
         rewriteRun(
-          java("""
-            import java.util.Arrays;
-            import java.util.Collections;
-            public class Main {
-
-                public static void main(String[] args) {
-                    Object[] array1 = (Object[]) Arrays.asList("a","b").toArray();
-                    Integer[] array2 = (Integer[]) Collections.singletonList(1).toArray();
-                    Integer[] array3 = Arrays.asList(1, 2, 3).toArray(new Integer[0]);
-                }
-            }
+          //language=java
+          java(
             """
+              import java.util.Arrays;
+              import java.util.Collections;
+              
+              class Foo {
+                  void bar() {
+                      Object[] array1 = (Object[]) Arrays.asList("a","b").toArray();
+                      Integer[] array2 = (Integer[]) Collections.singletonList(1).toArray();
+                      Integer[] array3 = Arrays.asList(1, 2, 3).toArray(new Integer[0]);
+                  }
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/CastArraysAsListToListTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/CastArraysAsListToListTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class CastArraysAsListToListTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new CastArraysAsListToList());
+    }
+
+    @Test
+    public void positiveCases() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.Arrays;
+              import java.util.List;
+                            
+              public class Main {
+                  public static void main(String[] args) {
+                      Integer[] array1 = (Integer[]) Arrays.asList(1, 2, 3).toArray();
+                      Integer[][] array2 = (Integer[][]) Arrays.asList(new Integer[]{1}, new Integer[]{2}).toArray();
+                      Object[][] array3 = (Object[][]) Arrays.asList(new Object[]{}, new Object[]{}).toArray();
+                  }
+              }
+              """,
+
+            """
+              import java.util.ArrayList;
+              import java.util.Arrays;
+              import java.util.List;
+                            
+              public class Main {
+                  public static void main(String[] args) {
+                      Integer[] array1 = Arrays.asList(1, 2, 3).toArray(new Integer[0]);
+                      Integer[][] array2 = Arrays.asList(new Integer[]{1}, new Integer[]{2}).toArray(new Integer[0][]);
+                      Object[][] array3 = Arrays.asList(new Object[]{}, new Object[]{}).toArray(new Object[0][]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    public void negativeCases() {
+        //language=java
+        rewriteRun(
+          java("""
+            import java.util.Arrays;
+            import java.util.Collections;
+            public class Main {
+
+                public static void main(String[] args) {
+                    Object[] array1 = (Object[]) Arrays.asList("a","b").toArray();
+                    Integer[] array2 = (Integer[]) Collections.singletonList(1).toArray();
+                    Integer[] array3 = Arrays.asList(1, 2, 3).toArray(new Integer[0]);
+                }
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Add a new recipe convert code like `(Integer[]) Arrays.asList(1, 2, 3).toArray()` to `Arrays.asList(1, 2, 3).toArray(new Integer[0])`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Arrays.asList(1, 2, 3).toArray() could be cast to Integer[] in JDK8 or earlier but there will be ClassCastException in JDK11 because now toArray() always return an array with Object[] type. During our internal applications' migration process from JDK8 to JDK11, we have identified some similar code patterns, so we hope to add a recipe to automatically fix them.
