### PR TITLE
Add useMimeCoder option to UseJavaUtilBase64

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
+++ b/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
@@ -16,10 +16,7 @@
 package org.openrewrite.java.migrate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.java.ChangeType;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
@@ -37,6 +34,9 @@ import java.util.Base64;
 public class UseJavaUtilBase64 extends Recipe {
     private final String sunPackage;
 
+    @Option(displayName = "Use Mime Coder", description = "Use Base64.getMimeEncoder()/getMimeDecoder() instead of Base64.getEncoder()/getDecoder().", required = false, example = "false")
+    boolean useMimeCoder;
+
     @Override
     public String getDisplayName() {
         return "Prefer `java.util.Base64` instead of `sun.misc`";
@@ -49,13 +49,24 @@ public class UseJavaUtilBase64 extends Recipe {
                "by the Java module system and accessing this class will result in a warning in Java 11 and an error in Java 17.";
     }
 
-    public UseJavaUtilBase64(String sunPackage) {
-        this.sunPackage = sunPackage;
-    }
+
 
     @JsonCreator
     public UseJavaUtilBase64() {
-        this("sun.misc");
+        this("sun.misc", false);
+    }
+
+    public UseJavaUtilBase64(String sunPackage) {
+        this(sunPackage, false);
+    }
+
+    public UseJavaUtilBase64(boolean useMimeCoder) {
+        this("sun.misc", useMimeCoder);
+    }
+
+    public UseJavaUtilBase64(String sunPackage, boolean useMimeCoder) {
+        this.sunPackage = sunPackage;
+        this.useMimeCoder = useMimeCoder;
     }
 
     @Override
@@ -71,16 +82,16 @@ public class UseJavaUtilBase64 extends Recipe {
         MethodMatcher newBase64Decoder = new MethodMatcher(sunPackage + ".BASE64Decoder <constructor>()");
 
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
-            final JavaTemplate getDecoderTemplate = JavaTemplate.builder("Base64.getDecoder()")
+            final JavaTemplate getDecoderTemplate = JavaTemplate.builder(useMimeCoder ? "Base64.getMimeDecoder()" : "Base64.getDecoder()")
                     .contextSensitive()
                     .imports("java.util.Base64")
                     .build();
 
-            final JavaTemplate encodeToString = JavaTemplate.builder("Base64.getEncoder().encodeToString(#{anyArray(byte)})")
+            final JavaTemplate encodeToString = JavaTemplate.builder(useMimeCoder ? "Base64.getMimeEncoder().encodeToString(#{anyArray(byte)})" : "Base64.getEncoder().encodeToString(#{anyArray(byte)})")
                     .imports("java.util.Base64")
                     .build();
 
-            final JavaTemplate decode = JavaTemplate.builder("Base64.getDecoder().decode(#{any(String)})")
+            final JavaTemplate decode = JavaTemplate.builder(useMimeCoder ? "Base64.getMimeDecoder().decode(#{any(String)})" : "Base64.getDecoder().decode(#{any(String)})")
                     .imports("java.util.Base64")
                     .build();
 
@@ -126,9 +137,16 @@ public class UseJavaUtilBase64 extends Recipe {
                 J.NewClass c = (J.NewClass) super.visitNewClass(newClass, ctx);
                 if (newBase64Encoder.matches(c)) {
                     // noinspection Convert2MethodRef
-                    return Semantics.expression(this, "getEncoder", () -> Base64.getEncoder())
-                            .build()
-                            .apply(updateCursor(c), c.getCoordinates().replace());
+                    if (useMimeCoder) {
+                        return Semantics.expression(this, "getMimeEncoder", () -> Base64.getMimeEncoder())
+                                .build()
+                                .apply(updateCursor(c), c.getCoordinates().replace());
+                    } else {
+                        return Semantics.expression(this, "getEncoder", () -> Base64.getEncoder())
+                                .build()
+                                .apply(updateCursor(c), c.getCoordinates().replace());
+                    }
+
                 } else if (newBase64Decoder.matches(c)) {
                     return getDecoderTemplate.apply(updateCursor(c), c.getCoordinates().replace());
                 }

--- a/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
+++ b/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
@@ -34,7 +34,7 @@ import java.util.Base64;
 public class UseJavaUtilBase64 extends Recipe {
     private final String sunPackage;
 
-    @Option(displayName = "Use Mime Coder", description = "Use Base64.getMimeEncoder()/getMimeDecoder() instead of Base64.getEncoder()/getDecoder().", required = false, example = "false")
+    @Option(displayName = "Use Mime Coder", description = "Use `Base64.getMimeEncoder()/getMimeDecoder()` instead of `Base64.getEncoder()/getDecoder()`.", required = false, example = "false")
     boolean useMimeCoder;
 
     @Override
@@ -49,24 +49,14 @@ public class UseJavaUtilBase64 extends Recipe {
                "by the Java module system and accessing this class will result in a warning in Java 11 and an error in Java 17.";
     }
 
-
+    public UseJavaUtilBase64(String sunPackage, boolean useMimeCoder) {
+        this.sunPackage = sunPackage;
+        this.useMimeCoder = useMimeCoder;
+    }
 
     @JsonCreator
     public UseJavaUtilBase64() {
         this("sun.misc", false);
-    }
-
-    public UseJavaUtilBase64(String sunPackage) {
-        this(sunPackage, false);
-    }
-
-    public UseJavaUtilBase64(boolean useMimeCoder) {
-        this("sun.misc", useMimeCoder);
-    }
-
-    public UseJavaUtilBase64(String sunPackage, boolean useMimeCoder) {
-        this.sunPackage = sunPackage;
-        this.useMimeCoder = useMimeCoder;
     }
 
     @Override
@@ -137,15 +127,12 @@ public class UseJavaUtilBase64 extends Recipe {
                 J.NewClass c = (J.NewClass) super.visitNewClass(newClass, ctx);
                 if (newBase64Encoder.matches(c)) {
                     // noinspection Convert2MethodRef
-                    if (useMimeCoder) {
-                        return Semantics.expression(this, "getMimeEncoder", () -> Base64.getMimeEncoder())
-                                .build()
-                                .apply(updateCursor(c), c.getCoordinates().replace());
-                    } else {
-                        return Semantics.expression(this, "getEncoder", () -> Base64.getEncoder())
-                                .build()
-                                .apply(updateCursor(c), c.getCoordinates().replace());
-                    }
+                    JavaTemplate.Builder encoderTemplate = useMimeCoder
+                            ? Semantics.expression(this, "getMimeEncoder", () -> Base64.getMimeEncoder())
+                            : Semantics.expression(this, "getEncoder", () -> Base64.getEncoder());
+                    return encoderTemplate
+                            .build()
+                            .apply(updateCursor(c), c.getCoordinates().replace());
 
                 } else if (newBase64Decoder.matches(c)) {
                     return getDecoderTemplate.apply(updateCursor(c), c.getCoordinates().replace());

--- a/src/test/java/org/openrewrite/java/migrate/UseJavaUtilBase64Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UseJavaUtilBase64Test.java
@@ -172,6 +172,52 @@ class UseJavaUtilBase64Test implements RewriteTest {
         );
     }
 
+    @Test
+    void mime() {
+        rewriteRun(
+          spec -> {
+              spec.recipe(new UseJavaUtilBase64("test.sun.misc", true));
+          },
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+                          
+              import test.sun.misc.BASE64Encoder;
+              import test.sun.misc.BASE64Decoder;
+              import java.io.IOException;
+
+              class Test {
+                  void test(byte[] bBytes) {
+                      BASE64Encoder encoder = new BASE64Encoder();
+                      String encoded = encoder.encode(bBytes);
+                      encoded += encoder.encodeBuffer(bBytes);
+                      try {
+                          byte[] decoded = new BASE64Decoder().decodeBuffer(encoded);
+                      } catch (IOException e) {
+                          e.printStackTrace();
+                      }
+                  }
+              }
+              """,
+            """
+              package test.sun.misc;
+                          
+              import java.util.Base64;
+                          
+              class Test {
+                  void test(byte[] bBytes) {
+                      Base64.Encoder encoder = Base64.getMimeEncoder();
+                      String encoded = encoder.encodeToString(bBytes);
+                      encoded += encoder.encodeToString(bBytes);
+                      byte[] decoded = Base64.getMimeDecoder().decode(encoded);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/212")
     @Test
     void otherBase64() {

--- a/src/test/java/org/openrewrite/java/migrate/UseJavaUtilBase64Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UseJavaUtilBase64Test.java
@@ -25,107 +25,107 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 class UseJavaUtilBase64Test implements RewriteTest {
-
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new UseJavaUtilBase64("test.sun.misc"))
+        spec.recipe(new UseJavaUtilBase64("test.sun.misc", false))
           .parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
             //language=java
             .dependsOn(
               """
-                    package test.sun.misc;
-                                                    
-                    import java.io.InputStream;
-                    import java.io.ByteArrayInputStream;
-                    import java.io.OutputStream;
-                    import java.io.ByteArrayOutputStream;
-                    import java.io.PrintStream;
-                    import java.io.IOException;
-                    import java.nio.ByteBuffer;
-                                 
-                    @SuppressWarnings("RedundantThrows")
-                    class CharacterEncoder {
-                        public void encode(InputStream inStream, OutputStream outStream) throws IOException {
-                        }
-
-                        public void encode(byte[] aBuffer, OutputStream aStream) throws IOException {
-                        }
-                                                    
-                        public String encode(byte[] aBuffer) {
-                            return "";
-                        }
-
-                        public void encode(ByteBuffer aBuffer, OutputStream aStream) throws IOException {
-                        }
-                        
-                        public String encode(ByteBuffer aBuffer) {
-                            return "";
-                        }
-                                
-                        public void encodeBuffer(InputStream inStream, OutputStream outStream) throws IOException {
-                        }
-                                                    
-                        public void encodeBuffer(byte[] aBuffer, OutputStream aStream) throws IOException {
-                        }
-                                                    
-                        public String encodeBuffer(byte[] aBuffer) {
-                            return "";
-                        }
-                        
-                        public void encodeBuffer(ByteBuffer aBuffer, OutputStream aStream) throws IOException {
-                        }
-                        
-                        public String encodeBuffer(ByteBuffer aBuffer) {
-                            return "";
-                        }
+                package test.sun.misc;
+                                                
+                import java.io.InputStream;
+                import java.io.ByteArrayInputStream;
+                import java.io.OutputStream;
+                import java.io.ByteArrayOutputStream;
+                import java.io.PrintStream;
+                import java.io.IOException;
+                import java.nio.ByteBuffer;
+                             
+                @SuppressWarnings("RedundantThrows")
+                class CharacterEncoder {
+                    public void encode(InputStream inStream, OutputStream outStream) throws IOException {
                     }
+
+                    public void encode(byte[] aBuffer, OutputStream aStream) throws IOException {
+                    }
+                
+                    public String encode(byte[] aBuffer) {
+                        return "";
+                    }
+
+                    public void encode(ByteBuffer aBuffer, OutputStream aStream) throws IOException {
+                    }
+                
+                    public String encode(ByteBuffer aBuffer) {
+                        return "";
+                    }
+                
+                    public void encodeBuffer(InputStream inStream, OutputStream outStream) throws IOException {
+                    }
+                
+                    public void encodeBuffer(byte[] aBuffer, OutputStream aStream) throws IOException {
+                    }
+                
+                    public String encodeBuffer(byte[] aBuffer) {
+                        return "";
+                    }
+                
+                    public void encodeBuffer(ByteBuffer aBuffer, OutputStream aStream) throws IOException {
+                    }
+                
+                    public String encodeBuffer(ByteBuffer aBuffer) {
+                        return "";
+                    }
+                }
                 """,
               """
-                  package test.sun.misc;
-                                                  
-                  import java.io.InputStream;
-                  import java.io.ByteArrayInputStream;
-                  import java.io.OutputStream;
-                  import java.io.ByteArrayOutputStream;
-                  import java.io.PrintStream;
-                  import java.io.IOException;
-                  import java.nio.ByteBuffer;
-                  
-                  @SuppressWarnings("RedundantThrows")
-                  class CharacterDecoder {
-                      public void decode(InputStream inStream, OutputStream outStream) throws IOException {
-                      }
-                  
-                      public void decode(String inString, OutputStream outStream) throws IOException {
-                      }
-                                                  
-                      public void decodeBuffer(InputStream inStream, OutputStream outStream) throws IOException {
-                      }
-                  
-                      public void decodeBuffer(String inString, OutputStream outStream) throws IOException {
-                      }
-                                                  
-                      public byte[] decodeBuffer(String inString) throws IOException {
-                          return new byte[0];
-                      }
-                      
-                      public byte[] decodeBuffer(InputStream inStream) throws IOException {
-                          return new byte[0];
-                      }
-                  }
-              """,
+                package test.sun.misc;
+                                                
+                import java.io.InputStream;
+                import java.io.ByteArrayInputStream;
+                import java.io.OutputStream;
+                import java.io.ByteArrayOutputStream;
+                import java.io.PrintStream;
+                import java.io.IOException;
+                import java.nio.ByteBuffer;
+                
+                @SuppressWarnings("RedundantThrows")
+                class CharacterDecoder {
+                    public void decode(InputStream inStream, OutputStream outStream) throws IOException {
+                    }
+                
+                    public void decode(String inString, OutputStream outStream) throws IOException {
+                    }
+                
+                    public void decodeBuffer(InputStream inStream, OutputStream outStream) throws IOException {
+                    }
+                
+                    public void decodeBuffer(String inString, OutputStream outStream) throws IOException {
+                    }
+                
+                    public byte[] decodeBuffer(String inString) throws IOException {
+                        return new byte[0];
+                    }
+                
+                    public byte[] decodeBuffer(InputStream inStream) throws IOException {
+                        return new byte[0];
+                    }
+                }
+                """,
               """
                 package test.sun.misc;
                 class BASE64Encoder extends CharacterEncoder {
                 }
-              """,
+                """,
               """
                 package test.sun.misc;
                 class BASE64Decoder extends CharacterDecoder {
                 }
-              """
-            ));
+                """
+            )
+          );
     }
 
     @DocumentExample
@@ -224,7 +224,7 @@ class UseJavaUtilBase64Test implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-                """
+            """
               package test.sun.misc;
               
               public class App {
@@ -247,7 +247,8 @@ class UseJavaUtilBase64Test implements RewriteTest {
               
               class Base64 {
               }
-              """)
+              """
+          )
         );
     }
 }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Add useMimeCoder option to UseJavaUtilBase64 recipe, allowing user to migrate sun.misc.Base64 api using java.lang.Base64.getMimeEncoder()/getMimeDecoder() instead of Base64.getEncoder()/getDecoder(). This option is false by default.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

UseJavaUtilBase64 helps user to migrate code from legacy base64 api. This recipe is useful on our applications, but recently we found some problem. If an application that has not been migrated encodes a String using old api and sends the result to another application that has been migrated to Java11 for decoding, there will be an exception, because Base64.getDecoder() does not tolerate line breaks. See the following example:

``` java
import sun.misc.BASE64Encoder;
import java.util.Base64;

public class Main {
    // This application has not migrated yet
    private static String application1(byte[] bytes) {
        return new BASE64Encoder().encode(bytes);
    }

    // This application been migrated using UseJavaUtilBase64
    private static byte[] application2(String s) throws Exception {
        // Current way to migrate, which causes
        // Exception in thread "main" java.lang.IllegalArgumentException: Illegal base64 character a
        return Base64.getDecoder().decode(s);

        // My proposal
        //  return Base64.getMimeDecoder().decode(s);
    }

    public static void main(String[] args) throws Exception {
        String s = "A very long content that will be encoded to multiple lines by sun.misc.Base64Encoder";
        String encoded = application1(s.getBytes());
        byte[] decoded = application2(encoded);
        System.out.println(new String(decoded));
    }
}


```

Therefore I propose to add an option to this recipe that allows migrating to java.lang.Base64.getMimeEncoder()/getMimeDecoder() which tolerates line breaks and solves the problem.