### PR TITLE
Update reference to PreferJavaStringJoin in no-guava

### DIFF
--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -49,7 +49,7 @@ recipeList:
   - org.openrewrite.java.migrate.guava.PreferIntegerCompareUnsigned
   - org.openrewrite.java.migrate.guava.PreferIntegerDivideUnsigned
   - org.openrewrite.java.migrate.guava.PreferIntegerParseUnsignedInt
-  - org.openrewrite.java.migrate.guava.PreferJavaStringJoinVisitor
+  - org.openrewrite.java.migrate.guava.PreferJavaStringJoin
   - org.openrewrite.java.migrate.guava.PreferLongCompareUnsigned
   - org.openrewrite.java.migrate.guava.PreferLongDivideUnsigned
   - org.openrewrite.java.migrate.guava.PreferLongParseUnsignedLong


### PR DESCRIPTION
Fix reference in recipe list to visitor, not recipe, for PreferJavaStringJoin.