### PR TITLE
Automatically review PRs

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -11,4 +11,4 @@ on:
 # Since this pull request has write permissions on the target repo, we should **NOT** execute any untrusted code.
 jobs:
   post-suggestions:
-    uses: openrewrite/gh-automation/.github/workflows/comment-pr.yml@review-prs
+    uses: openrewrite/gh-automation/.github/workflows/comment-pr.yml@main

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -1,0 +1,14 @@
+name: comment-pr
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+on:
+  workflow_run:
+    workflows: ["receive-pr"]
+    types:
+      - completed
+
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# Since this pull request has write permissions on the target repo, we should **NOT** execute any untrusted code.
+jobs:
+  post-suggestions:
+    uses: openrewrite/gh-automation/.github/workflows/comment-pr.yml@review-prs

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -1,0 +1,13 @@
+name: receive-pr
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# Since this pull request receives untrusted code, we should **NOT** have any secrets in the environment.
+jobs:
+  upload-patch:
+    uses: openrewrite/gh-automation/.github/workflows/receive-pr.yml@review-prs

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -10,4 +10,4 @@ on:
 # Since this pull request receives untrusted code, we should **NOT** have any secrets in the environment.
 jobs:
   upload-patch:
-    uses: openrewrite/gh-automation/.github/workflows/receive-pr.yml@review-prs
+    uses: openrewrite/gh-automation/.github/workflows/receive-pr.yml@main


### PR DESCRIPTION
## What's changed?
Add two workflows that together automatically add code suggestions on opened pull requests.

## What's your motivation?
Keep up with community contributions more easily, by suggesting code changes to conform to our best practices.

## Any additional context
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- https://github.com/googleapis/code-suggester?tab=readme-ov-file#review-a-pull-request
- https://github.com/timtebeek/code-suggester-action-reproducer
- https://docs.openrewrite.org/recipes/java/recipes
- https://github.com/openrewrite/gh-automation/pull/48