### PR TITLE
ClassCastException in OptionalNotEmptyToIsPresent

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresent.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresent.java
@@ -55,29 +55,29 @@ public class OptionalNotEmptyToIsPresent extends Recipe {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(
                 new UsesJavaVersion<>(11),
                 new UsesMethod<>(JAVA_UTIL_OPTIONAL_IS_EMPTY));
-        MethodMatcher optionalIsPresentMatcher = new MethodMatcher(JAVA_UTIL_OPTIONAL_IS_EMPTY);
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
-            public Statement visitStatement(Statement s, ExecutionContext ctx) {
-                Statement statement = (Statement) super.visitStatement(s, ctx);
-                if (statement instanceof J.Unary) {
-                    J.Unary unary = (J.Unary) statement;
+            public J visitStatement(Statement s, ExecutionContext ctx) {
+                J superReturn = super.visitStatement(s, ctx);
+                if (superReturn instanceof J.Unary) {
+                    J.Unary unary = (J.Unary) superReturn;
                     if (unary.getOperator() == Type.Not) {
                         Expression expression = unary.getExpression();
                         if (expression instanceof J.MethodInvocation) {
                             J.MethodInvocation m = (J.MethodInvocation) expression;
+                            MethodMatcher optionalIsPresentMatcher = new MethodMatcher(JAVA_UTIL_OPTIONAL_IS_EMPTY);
                             if (optionalIsPresentMatcher.matches(m)) {
                                 return JavaTemplate.builder("#{any()}.isPresent()")
                                         .contextSensitive()
                                         .build()
                                         .apply(getCursor(),
-                                                statement.getCoordinates().replace(),
+                                                unary.getCoordinates().replace(),
                                                 m.getSelect());
                             }
                         }
                     }
                 }
-                return statement;
+                return superReturn;
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmpty.java
@@ -55,26 +55,26 @@ public class OptionalNotPresentToIsEmpty extends Recipe {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(
                 new UsesJavaVersion<>(11),
                 new UsesMethod<>(JAVA_UTIL_OPTIONAL_IS_PRESENT));
-        MethodMatcher optionalIsPresentMatcher = new MethodMatcher(JAVA_UTIL_OPTIONAL_IS_PRESENT);
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
-            public Statement visitStatement(Statement s, ExecutionContext ctx) {
-                Statement statement = (Statement) super.visitStatement(s, ctx);
-                if (statement instanceof J.Unary) {
-                    J.Unary unary = (J.Unary) statement;
+            public J visitStatement(Statement s, ExecutionContext ctx) {
+                J superReturn = super.visitStatement(s, ctx);
+                if (superReturn instanceof J.Unary) {
+                    J.Unary unary = (J.Unary) superReturn;
                     if (unary.getOperator() == Type.Not) {
                         Expression expression = unary.getExpression();
                         if (expression instanceof J.MethodInvocation) {
                             J.MethodInvocation methodInvocation = (J.MethodInvocation) expression;
+                            MethodMatcher optionalIsPresentMatcher = new MethodMatcher(JAVA_UTIL_OPTIONAL_IS_PRESENT);
                             if (optionalIsPresentMatcher.matches(methodInvocation)) {
                                 return JavaTemplate.builder("#{any(java.util.Optional)}.isEmpty()")
                                         .build()
-                                        .apply(getCursor(), statement.getCoordinates().replace(), methodInvocation.getSelect());
+                                        .apply(getCursor(), unary.getCoordinates().replace(), methodInvocation.getSelect());
                             }
                         }
                     }
                 }
-                return statement;
+                return superReturn;
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmpty.java
@@ -24,7 +24,6 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.J.Unary.Type;
 import org.openrewrite.java.tree.Statement;
@@ -58,14 +57,11 @@ public class OptionalNotPresentToIsEmpty extends Recipe {
             public J visitStatement(Statement s, ExecutionContext ctx) {
                 if (s instanceof J.Unary) {
                     J.Unary unary = (J.Unary) s;
-                    Expression expression = unary.getExpression();
-                    if (unary.getOperator() == Type.Not && expression instanceof J.MethodInvocation) {
-                        J.MethodInvocation methodInvocation = (J.MethodInvocation) expression;
-                        if (optionalIsPresentMatcher.matches(methodInvocation)) {
-                            return JavaTemplate.builder("#{any(java.util.Optional)}.isEmpty()")
-                                    .build()
-                                    .apply(getCursor(), unary.getCoordinates().replace(), methodInvocation.getSelect());
-                        }
+                    if (unary.getOperator() == Type.Not && optionalIsPresentMatcher.matches(unary.getExpression())) {
+                        return JavaTemplate.apply("#{any(java.util.Optional)}.isEmpty()",
+                                getCursor(),
+                                unary.getCoordinates().replace(),
+                                ((J.MethodInvocation) unary.getExpression()).getSelect());
                     }
                 }
                 return super.visitStatement(s, ctx);

--- a/src/test/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresentTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresentTest.java
@@ -43,7 +43,7 @@ class OptionalNotEmptyToIsPresentTest implements RewriteTest {
                 package com.example.app;
                 import java.util.Optional;
                 class App {
-                    boolean notPresent(Optional<String> bar){
+                    boolean notEmpty(Optional<String> bar){
                         return !bar.isEmpty();
                     }
                 }
@@ -52,8 +52,42 @@ class OptionalNotEmptyToIsPresentTest implements RewriteTest {
                 package com.example.app;
                 import java.util.Optional;
                 class App {
-                    boolean notPresent(Optional<String> bar){
+                    boolean notEmpty(Optional<String> bar){
                         return bar.isPresent();
+                    }
+                }
+                """
+            ),
+            11
+          )
+        );
+    }
+
+    @Test
+    void ifStatement() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                package com.example.app;
+                import java.util.Optional;
+                class App {
+                    void ifNotEmpty(Optional<String> bar){
+                        if (!bar.isEmpty()) {
+                            System.out.print("not empty");
+                        }
+                    }
+                }
+                """,
+              """
+                package com.example.app;
+                import java.util.Optional;
+                class App {
+                    void ifNotEmpty(Optional<String> bar){
+                        if (bar.isPresent()) {
+                            System.out.print("not empty");
+                        }
                     }
                 }
                 """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This should fix #417, but I haven't been able to verify locally due to my only reproduction example taking an eternity, and sitting behind a restricted company proxy that prohibits successufully building with gradle.

Don't assume the super call to still return an instance of Statement, but rather take the most generic type of the super declaration.

Also move the matcher declaration into the visitor, since its unused code unless we enter the inner parts of the visitor method.

The additional test is green with and without the main code change, so it does NOT reproduce the bug.

Finally rename the previously existing test example to match the actual test intention.

## Anything in particular you'd like reviewers to focus on?
There is one more difference between the 2 OptionalNotFooToBar recipes: The Java pattern builder once uses "any" and once uses "any(Optional)". I have no idea if that is relevant, but that difference should not exist due to the symmetry of these implementations.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
