### PR TITLE
Expand ListFirstAndLast covered cases to include `getList().get(0)`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/ListFirstAndLast.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ListFirstAndLast.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class ListFirstAndLast extends Recipe {
 
-    // `List` has `get`, `add`, and `remove` methods that take an index, even if more SequencedCollections have `*First` and `*Last` methods
+    // While more SequencedCollections have `*First` and `*Last` methods, only list has `get`, `add`, and `remove` methods that take an index
     private static final MethodMatcher ADD_MATCHER = new MethodMatcher("java.util.List add(int, ..)", true); // , * fails
     private static final MethodMatcher GET_MATCHER = new MethodMatcher("java.util.List get(int)", true);
     private static final MethodMatcher REMOVE_MATCHER = new MethodMatcher("java.util.List remove(int)", true);
@@ -42,7 +42,7 @@ public class ListFirstAndLast extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Replace `List` `get`, `add`, and `remove` with `SequencedCollection` `*First` and `*Last` methods";
+        return "Replace `List.get(int)`, `add(int, Object)`, and `remove(int)` with `SequencedCollection` `*First` and `*Last` methods";
     }
 
     @Override
@@ -80,15 +80,14 @@ public class ListFirstAndLast extends Recipe {
                 return mi;
             }
 
-            // Limit ourselves to identifiers for now, as x.get(x.size() - 1) requires the same reference for x
+            // Limit *Last to identifiers for now, as x.get(x.size() - 1) requires the same reference for x
             if (mi.getSelect() instanceof J.Identifier) {
                 return handleSelectIdentifier((J.Identifier) mi.getSelect(), mi, operation);
             }
 
-            // XXX Maybe handle J.FieldAccess explicitly as well?
+            // XXX Maybe handle J.FieldAccess explicitly as well to support *Last on fields too
 
-            // Support limit cases like `getList().get(0)` -> `getList().getFirst()`
-            // Only handle argument of zero for now, as we can't guarantee the same reference for the collection
+            // For anything else support limited cases, as we can't guarantee the same reference for the collection
             if (J.Literal.isLiteralValue(mi.getArguments().get(0), 0)) {
                 return getMethodInvocation(mi, operation, "First");
             }

--- a/src/main/java/org/openrewrite/java/migrate/util/ListFirstAndLast.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ListFirstAndLast.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 public class ListFirstAndLast extends Recipe {
 
+    // `List` has `get`, `add`, and `remove` methods that take an index, even if more SequencedCollections have `*First` and `*Last` methods
     private static final MethodMatcher ADD_MATCHER = new MethodMatcher("java.util.List add(int, ..)", true); // , * fails
     private static final MethodMatcher GET_MATCHER = new MethodMatcher("java.util.List get(int)", true);
     private static final MethodMatcher REMOVE_MATCHER = new MethodMatcher("java.util.List remove(int)", true);

--- a/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
@@ -65,6 +65,7 @@ class ListFirstAndLastTest implements RewriteTest {
         }
 
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/423")
         void getFirstFromMethodInvocation() {
             rewriteRun(
               //language=java
@@ -146,6 +147,42 @@ class ListFirstAndLastTest implements RewriteTest {
                   class Foo {
                       String bar(List<String> collection) {
                           return collection.removeFirst();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/423")
+        void removeFirstFromMethodInvocation() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import java.util.*;
+                                
+                  class Foo {
+                      List<String> collection() {
+                          return new ArrayList<>();
+                      }
+                  
+                      String bar() {
+                          return collection().remove(0);
+                      }
+                  }
+                  """,
+                """
+                  import java.util.*;
+                                
+                  class Foo {
+                      List<String> collection() {
+                          return new ArrayList<>();
+                      }
+                  
+                      String bar() {
+                          return collection().removeFirst();
                       }
                   }
                   """

--- a/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
@@ -128,6 +128,40 @@ class ListFirstAndLastTest implements RewriteTest {
         }
 
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/423")
+        void addFirstFromMethodInvocation() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import java.util.*;
+                                
+                  class Foo {
+                      List<String> collection() {
+                          return new ArrayList<>();
+                      }
+                      void bar() {
+                          collection().add(0, "first");
+                      }
+                  }
+                  """,
+                """
+                  import java.util.*;
+                                
+                  class Foo {
+                      List<String> collection() {
+                          return new ArrayList<>();
+                      }
+                      void bar() {
+                          collection().addFirst("first");
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void removeFirst() {
             rewriteRun(
               //language=java

--- a/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
@@ -65,6 +65,41 @@ class ListFirstAndLastTest implements RewriteTest {
         }
 
         @Test
+        void getFirstFromMethodInvocation() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import java.util.*;
+                                
+                  class Foo {
+                      List<String> collection() {
+                          return new ArrayList<>();
+                      }
+                  
+                      String bar() {
+                          return collection().get(0);
+                      }
+                  }
+                  """,
+                """
+                  import java.util.*;
+                                
+                  class Foo {
+                      List<String> collection() {
+                          return new ArrayList<>();
+                      }
+                  
+                      String bar() {
+                          return collection().getFirst();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void addFirst() {
             rewriteRun(
               //language=java


### PR DESCRIPTION
## What's your motivation?
Fixes https://github.com/openrewrite/rewrite-migrate-java/issues/423
- https://github.com/openrewrite/rewrite-migrate-java/issues/423

## Anything in particular you'd like reviewers to focus on?
There's still a strong overfit here in:
1. only looking at identifiers (mostly)
2. only supporting `getFirst()` for method invocations

## Have you considered any alternatives or workarounds?
Likely iterate to reduce the overfit.

## Any additional context
Would be nice to run these tests in CI, finally
- https://github.com/openrewrite/rewrite-migrate-java/pull/337