### PR TITLE
refactor: Assorted Refaster rules that do not (yet) belong in one of the other classes with more topical Refaster rules

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSet.java
@@ -56,7 +56,7 @@ public class NoGuavaSetsNewHashSet extends Recipe {
                 if (NEW_HASH_SET.matches(method)) {
                     maybeRemoveImport("com.google.common.collect.Sets");
                     maybeAddImport("java.util.HashSet");
-                    if (method.getArguments().isEmpty() || (!method.getArguments().isEmpty() && method.getArguments().get(0) instanceof J.Empty)) {
+                    if (method.getArguments().isEmpty() || method.getArguments().get(0) instanceof J.Empty) {
                         return JavaTemplate.builder("new HashSet<>()")
                                 .contextSensitive()
                                 .imports("java.util.HashSet")


### PR DESCRIPTION
Was again playing around a little bit with the platform :). This change looks safe. 

Use this link to re-run the recipe: https://app.moderne.io/recipes/tech.picnic.errorprone.refasterrules.AssortedRulesRecipes?organizationId=T3BlblJld3JpdGU%3D