### PR TITLE
Java SE 17 Recipe - RemovedFileIOFinalizeMethods

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -53,6 +53,7 @@ recipeList:
   - org.openrewrite.java.migrate.RemovedSSLSessionGetPeerCertificateChainMethodImpl
   - org.openrewrite.java.migrate.SunNetSslPackageUnavailable
   - org.openrewrite.java.migrate.RemovedRMIConnectorServerCredentialTypesConstant
+  - org.openrewrite.java.migrate.RemovedFileIOFinalizeMethods
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.JavaVersion17
@@ -184,3 +185,20 @@ recipeList:
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
       existingFullyQualifiedConstantName: javax.management.remote.rmi.RMIConnectorServer.CREDENTIAL_TYPES
       fullyQualifiedConstantName:  javax.management.remote.rmi.RMIConnectorServer.CREDENTIALS_FILTER_PATTERN
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedFileIOFinalizeMethods
+displayName: Replace `finalize` method in `java.io.FileInputStream`  and `java.io.FileOutputStream`
+description: >
+  The `finalize` method in `java.io.FileInputStream` and `java.io.FileOutputStream` is no longer available in Java SE 12 and later. The recipe replaces it with the `close` method.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "java.io.FileInputStream finalize()"
+      newMethodName: close
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "java.io.FileOutputStream finalize()"
+      newMethodName: close
+      ignoreDefinition: true


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This is a simple recipe that replaces the finalize() method in java.io.FileInputStream  and java.io.FileOutputStream to close()

<img width="888" alt="image" src="https://github.com/openrewrite/rewrite-migrate-java/assets/93149514/ec481e45-6f56-4460-812a-29c37c431f97">


## Anyone you would like to review specifically?
@cjobinabo 


## Any additional context
Since this involves pre Java 12, there are no tests for this recipe since  there's no good way to unit test such recipes given the underlying JDK doesn't change and we can only update the markers while running the tst

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
