### PR TITLE
expand thread stop recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupported.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupported.java
@@ -36,14 +36,14 @@ public class ThreadStopUnsupported extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Replace `Thread.stop()` with `throw new UnsupportedOperationException()`";
+        return "Replace `Thread.resume()`, `Thread.stop()`, and `Thread.suspend()` with `throw new UnsupportedOperationException()`";
     }
 
     @Override
     public String getDescription() {
-        return "`Thread.stop()` always throws a `new UnsupportedOperationException` in Java 21+. " +
-               "This recipe makes that explicit, as the migration is more complicated." +
-               "See https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html .";
+        return "`Thread.resume()`, `Thread.stop()`, and `Thread.suspend()` always throws a `new UnsupportedOperationException` in Java 21+. " +
+                "This recipe makes that explicit, as the migration is more complicated." +
+                "See https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html .";
     }
 
     @Override
@@ -52,7 +52,7 @@ public class ThreadStopUnsupported extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J j = super.visitMethodInvocation(method, ctx);
-                if (THREAD_STOP_MATCHER.matches(method) || THREAD_RESUME_MATCHER.matches(method) ||THREAD_SUSPEND_MATCHER.matches(method)) {
+                if (THREAD_STOP_MATCHER.matches(method) || THREAD_RESUME_MATCHER.matches(method) || THREAD_SUSPEND_MATCHER.matches(method)) {
                     if (usesJava21(ctx)) {
                         JavaTemplate template = JavaTemplate.builder("throw new UnsupportedOperationException()")
                                 .contextSensitive().build();
@@ -74,9 +74,9 @@ public class ThreadStopUnsupported extends Recipe {
                 String prefixWhitespace = j.getPrefix().getWhitespace();
                 String commentText =
                         prefixWhitespace + " * `Thread." + methodName + "()` always throws a `new UnsupportedOperationException()` in Java 21+." +
-                        prefixWhitespace + " * For detailed migration instructions see the migration guide available at" +
-                        prefixWhitespace + " * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html" +
-                        prefixWhitespace + " ";
+                                prefixWhitespace + " * For detailed migration instructions see the migration guide available at" +
+                                prefixWhitespace + " * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html" +
+                                prefixWhitespace + " ";
                 return j.withComments(Collections.singletonList(new TextComment(true, commentText, prefixWhitespace, Markers.EMPTY)));
             }
         };

--- a/src/main/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupported.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupported.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 
 public class ThreadStopUnsupported extends Recipe {
     private static final MethodMatcher THREAD_STOP_MATCHER = new MethodMatcher("java.lang.Thread stop()");
+    private static final MethodMatcher THREAD_RESUME_MATCHER = new MethodMatcher("java.lang.Thread resume()");
+    private static final MethodMatcher THREAD_SUSPEND_MATCHER = new MethodMatcher("java.lang.Thread suspend()");
 
     @Override
     public String getDisplayName() {
@@ -50,14 +52,14 @@ public class ThreadStopUnsupported extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J j = super.visitMethodInvocation(method, ctx);
-                if (THREAD_STOP_MATCHER.matches(method)) {
+                if (THREAD_STOP_MATCHER.matches(method) || THREAD_RESUME_MATCHER.matches(method) ||THREAD_SUSPEND_MATCHER.matches(method)) {
                     if (usesJava21(ctx)) {
                         JavaTemplate template = JavaTemplate.builder("throw new UnsupportedOperationException()")
                                 .contextSensitive().build();
                         j = template.apply(getCursor(), method.getCoordinates().replace());
                     }
                     if (j.getComments().isEmpty()) {
-                        j = getWithComment(j);
+                        j = getWithComment(j, method.getName().getSimpleName());
                     }
                 }
                 return j;
@@ -68,10 +70,10 @@ public class ThreadStopUnsupported extends Recipe {
                 return javaSourceFile != null && new UsesJavaVersion<>(21).visit(javaSourceFile, ctx) != javaSourceFile;
             }
 
-            private J getWithComment(J j) {
+            private J getWithComment(J j, String methodName) {
                 String prefixWhitespace = j.getPrefix().getWhitespace();
                 String commentText =
-                        prefixWhitespace + " * `Thread.stop()` always throws a `new UnsupportedOperationException()` in Java 21+." +
+                        prefixWhitespace + " * `Thread." + methodName + "()` always throws a `new UnsupportedOperationException()` in Java 21+." +
                         prefixWhitespace + " * For detailed migration instructions see the migration guide available at" +
                         prefixWhitespace + " * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html" +
                         prefixWhitespace + " ";

--- a/src/test/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupportedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/ThreadStopUnsupportedTest.java
@@ -84,7 +84,7 @@ class ThreadStopUnsupportedTest implements RewriteTest {
     @Test
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/194")
     @DocumentExample
-    void replaceWithThrowsOnJava21() {
+    void replaceStopWithThrowsOnJava21() {
         rewriteRun(
           //language=java
           java(
@@ -100,6 +100,68 @@ class ThreadStopUnsupportedTest implements RewriteTest {
                   void bar() {
                       /*
                        * `Thread.stop()` always throws a `new UnsupportedOperationException()` in Java 21+.
+                       * For detailed migration instructions see the migration guide available at
+                       * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html
+                       */
+                      throw new UnsupportedOperationException();
+                  }
+              }
+              """,
+            src -> src.markers(javaVersion(21))
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/194")
+    @DocumentExample
+    void replaceResumeWithThrowsOnJava21() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      Thread.currentThread().resume();
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      /*
+                       * `Thread.resume()` always throws a `new UnsupportedOperationException()` in Java 21+.
+                       * For detailed migration instructions see the migration guide available at
+                       * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html
+                       */
+                      throw new UnsupportedOperationException();
+                  }
+              }
+              """,
+            src -> src.markers(javaVersion(21))
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/194")
+    @DocumentExample
+    void replaceSuspendWithThrowsOnJava21() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      Thread.currentThread().suspend();
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      /*
+                       * `Thread.suspend()` always throws a `new UnsupportedOperationException()` in Java 21+.
                        * For detailed migration instructions see the migration guide available at
                        * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html
                        */


### PR DESCRIPTION
## What's changed?
core-libs/java.lang

[➜](https://www.oracle.com/java/technologies/javase/20all-relnotes.html#JDK-8289610) Thread.Stop Changed to Throw UnsupportedOperationException ([JDK-8289610](https://bugs.openjdk.org/browse/JDK-8289610))

The ability to "stop" a thread with the Thread.stop() method has been removed in this release. The method has been changed to throw UnsupportedOperationException. Stopping a thread by causing it to throw java.lang.ThreadDeath was inherently unsafe. The stop method has been deprecated since JDK 1.2 (1998). The corresponding method in ThreadGroup, to "stop" a group of threads, was changed to throw UnsupportedOperationException in Java 19.

As part of this change, java.lang.ThreadDeath has been deprecated for removal.

core-libs/java.lang

[➜](https://www.oracle.com/java/technologies/javase/20all-relnotes.html#JDK-8249627) Thread.suspend/resume Changed to Throw UnsupportedOperationException ([JDK-8249627](https://bugs.openjdk.org/browse/JDK-8249627))

The ability to suspend or resume a thread with the Thread.suspend() and Thread.resume() methods has been removed in this release. The methods have been changed to throw UnsupportedOperationException. These methods were inherently deadlock prone and have been deprecated since JDK 1.2 (1998). The corresponding methods in ThreadGroup, to suspend or resume a group of threads, were changed to throw UnsupportedOperationException in Java 19.

## What's your motivation?


## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
