### PR TITLE
fix: don't convert classes that implement interfaces

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -114,9 +114,21 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
                     .allMatch(ann -> LOMBOK_VALUE_MATCHER.matches(ann) && (ann.getArguments() == null || ann.getArguments().isEmpty()))
                     && !hasGenericTypeParameter(classDeclaration)
                     && classDeclaration.getBody().getStatements().stream().allMatch(this::isRecordCompatibleField)
-                    && !hasIncompatibleModifier(classDeclaration);
+                    && !hasIncompatibleModifier(classDeclaration)
+                    && !implementsInterfaces(classDeclaration);
         }
 
+        /**
+         * If the class target class implements an interface, transforming it to a record will not work in general,
+         * because the record access methods do not have the "get" prefix.
+         *
+         * @param classDeclaration
+         * @return
+         */
+        private boolean implementsInterfaces(J.ClassDeclaration classDeclaration) {
+            List<TypeTree> classDeclarationImplements = classDeclaration.getImplements();
+            return !(classDeclarationImplements == null || classDeclarationImplements.isEmpty());
+        }
         private boolean hasGenericTypeParameter(J.ClassDeclaration classDeclaration) {
             List<J.TypeParameter> typeParameters = classDeclaration.getTypeParameters();
             return typeParameters != null && !typeParameters.isEmpty();

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -404,5 +404,27 @@ class LombokValueToRecordTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        void classImplementingInterfaces() {
+            //language=java
+            rewriteRun(
+              java("""
+                   package example;
+                                   
+                   import lombok.Value;
+                                   
+                   interface I {
+                       String getTest();
+                   }
+                                   
+                   @Value
+                   public class A implements I {
+                       String test;
+                   }
+                   """)
+            );
+
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

`LombokValueToRecord` will not touch classes that implement interfaces.

## What's your motivation?

Providing a fix for: https://github.com/openrewrite/rewrite-migrate-java/issues/448

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?

There are a couple of possible approaches:

1. modify the implemented interface so that the resulting record in fact implments it

    That is not always possbile and it might not be the intention of the user.

2. generate wrapper methods on the fly

    That would be inconsistent with the approach taken by the recipe:
    Changing all references to getter methods.

The provided fix could also be improved by adding more logic to check if the implemented interface actually defines a getter method.
I assume that this is the case under most circumstances.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
