### PR TITLE
adding recipe RemovedToolProviderConstructor

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/RemovedToolProviderConstructor.java
+++ b/src/main/java/org/openrewrite/java/migrate/RemovedToolProviderConstructor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static org.openrewrite.Tree.randomId;
+
+public class RemovedToolProviderConstructor extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "TBD";
+    }
+
+    @Override
+    public String getDescription() {
+        return "TBD.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+            private final MethodMatcher COMPILER_METHODMATCHER = new MethodMatcher("javax.tools.ToolProvider getSystemJavaCompiler()", false);
+            private final MethodMatcher DOCUMENTATION_METHODMATCHER = new MethodMatcher("javax.tools.ToolProvider getSystemDocumentationTool()", false);
+            private final MethodMatcher CLASSLOADER_METHODMATCHER = new MethodMatcher("javax.tools.ToolProvider getSystemToolClassLoader()", false);
+            private final JavaType.FullyQualified classType = JavaType.ShallowClass.build("javax.tools.ToolProvider");
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m =  method;
+
+                if ( COMPILER_METHODMATCHER.matches(method, false)||(DOCUMENTATION_METHODMATCHER.matches(method, false)) ||(CLASSLOADER_METHODMATCHER.matches(method, false))) {
+                    JavaType.Method transformedType = null;
+                    if (method.getMethodType() != null) {
+                        maybeRemoveImport(method.getMethodType().getDeclaringType());
+                        transformedType = method.getMethodType().withDeclaringType(classType);
+                        if (!method.getMethodType().hasFlags(Flag.Static)) {
+                            Set<Flag> flags = new LinkedHashSet<>(method.getMethodType().getFlags());
+                            flags.add(Flag.Static);
+                            transformedType = transformedType.withFlags(flags);
+                        }
+                    }
+                    if (m.getSelect() == null) {
+                        maybeAddImport("javax.tools.ToolProvider", m.getSimpleName(), true);
+                    } else {
+                        maybeAddImport("javax.tools.ToolProvider", true);
+                        m = method.withSelect(
+                                new J.Identifier(randomId(),
+                                        method.getSelect() == null ?
+                                                Space.EMPTY :
+                                                method.getSelect().getPrefix(),
+                                        Markers.EMPTY,
+                                        emptyList(),
+                                        classType.getClassName(),
+                                        classType,
+                                        null
+                                )
+                        );
+                    }
+                    m = m.withMethodType(transformedType)
+                            .withName(m.getName().withType(transformedType));
+                }
+                return m;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -54,6 +54,8 @@ recipeList:
   - org.openrewrite.java.migrate.SunNetSslPackageUnavailable
   - org.openrewrite.java.migrate.RemovedRMIConnectorServerCredentialTypesConstant
   - org.openrewrite.java.migrate.RemovedFileIOFinalizeMethods
+  - org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors
+  - org.openrewrite.java.migrate.RemovedToolProviderConstructor
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.JavaVersion17
@@ -202,3 +204,4 @@ recipeList:
       methodPattern: "java.io.FileOutputStream finalize()"
       newMethodName: close
       ignoreDefinition: true
+

--- a/src/test/java/org/openrewrite/java/migrate/RemovedToolProviderConstructorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/RemovedToolProviderConstructorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class RemovedToolProviderConstructorTest  implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+            spec.expectedCyclesThatMakeChanges(2).recipe(new RemovedToolProviderConstructor());
+   }
+    @Test
+    void moveToStaticTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.test;
+               
+              import javax.tools.ToolProvider;
+               
+              public class RemovedToolProviderConstructorApp {
+               
+                   public void test() throws Exception {
+                       ToolProvider tp = null;
+                       tp.getSystemJavaCompiler();     
+                       tp.getSystemDocumentationTool();
+                       tp.getSystemToolClassLoader();  
+                       System.out.println(ToolProvider.getSystemJavaCompiler());      
+                   }
+              }          
+              """,
+            """
+              package com.test;
+               
+              import javax.tools.ToolProvider;
+               
+              public class RemovedToolProviderConstructorApp {
+               
+                   public void test() throws Exception {
+                       ToolProvider tp = null;
+                       ToolProvider.getSystemJavaCompiler();     
+                       ToolProvider.getSystemDocumentationTool();
+                       ToolProvider.getSystemToolClassLoader();  
+                       System.out.println(ToolProvider.getSystemJavaCompiler());              
+                   }
+              }          
+              """
+          )
+        );
+    }
+
+
+}


### PR DESCRIPTION


## What's changed?
 Created RemovedToolProviderConstructor Recipe:
For the following rule:
![image](https://github.com/openrewrite/rewrite-migrate-java/assets/93149514/d5ef60db-5527-453f-89ec-428c6de9ece0)


## What's your motivation?
This recipe checks for a specific method pattern and converts it to a static call.The existing recipe ChangeMethodTargetToStatic did not work in this case since it doesn't meet the criteria of the method should not be static and should not be of the SameReceiverType
## Anything in particular you'd like reviewers to focus on?
@cjobinabo 

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
