### PR TITLE
feat: Missing "Add explicit Common Annotations dependencies" in "Migrate to Java 11"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,5 +51,6 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
+    testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:1.3.5")
     testRuntimeOnly(gradleApi())
 }

--- a/src/main/resources/META-INF/rewrite/add-common-annotations-dependencies.yml
+++ b/src/main/resources/META-INF/rewrite/add-common-annotations-dependencies.yml
@@ -1,0 +1,47 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
+displayName: Add explicit Common Annotations dependencies
+description: >
+  This recipe will add the necessary `annotation-api` dependency from Jakarta EE 8 to maintain compatibility with Java
+  version 11 or greater.
+tags:
+  - javax
+  - java11
+  - jsr250
+  - jakarta
+recipeList:
+  # Add or update the jakarta.annotation-api to a maven project. This artifact still uses the javax.annotation name space.
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.annotation
+      oldArtifactId: javax.annotation-api
+      newGroupId: jakarta.annotation
+      newArtifactId: jakarta.annotation-api
+      newVersion: 1.3.x
+  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
+      oldGroupId: javax.annotation
+      oldArtifactId: javax.annotation-api
+      newGroupId: jakarta.annotation
+      newArtifactId: jakarta.annotation-api
+      newVersion: 1.3.x
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api
+      version: 1.3.x
+      onlyIfUsing: javax.annotation..*
+      acceptTransitive: true

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -37,6 +37,7 @@ recipeList:
   - org.openrewrite.java.migrate.javax.AddJaxbDependencies
   - org.openrewrite.java.migrate.javax.AddJaxwsDependencies
   - org.openrewrite.java.migrate.javax.AddInjectDependencies
+  - org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
   # Remediate deprecations
   - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
   - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
@@ -1,0 +1,106 @@
+package org.openrewrite.java.migrate.javax;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.java.Assertions.srcMainJava;
+import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+@SuppressWarnings("LanguageMismatch")
+class AddCommonAnnotationsDependenciesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(
+          Environment.builder()
+            .scanYamlResources()
+            .build()
+            .activateRecipes("org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies"))
+          .allSources(src -> src.markers(javaVersion(8)));
+    }
+
+    @Test
+    void addDependencyIfAnnotationJsr250Present() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("jakarta.annotation-api")),
+          mavenProject("my-project",
+            //language=java
+            srcMainJava(version(java("""
+              import javax.annotation.Generated;
+              
+              @Generated("Hello")
+              class A {
+              }
+              """), 8)),
+            //language=xml
+            pomXml("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+
+                  <dependencies>
+                  </dependencies>
+
+                </project>
+                """,
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+
+                  <dependencies>
+                    <dependency>
+                      <groupId>jakarta.annotation</groupId>
+                      <artifactId>jakarta.annotation-api</artifactId>
+                      <version>1.3.5</version>
+                    </dependency>
+                  </dependencies>
+
+                </project>
+                """)
+          )
+        );
+    }
+
+    @Test
+    void dontAddDependencyWhenAnnotationJsr250Absent() {
+        rewriteRun(
+          mavenProject("my-project",
+            //language=java
+            srcMainJava(java("""
+                class A {
+                }
+                """,
+              src -> src.markers(javaVersion(8)))),
+            //language=xml
+            pomXml("""
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+
+                <dependencies>
+                </dependencies>
+
+              </project>
+              """)
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
Refs: #455
