### PR TITLE
Add missing method impl interface

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/AddMissingMethodImplementation.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMissingMethodImplementation.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.migrate;
 
+import static org.openrewrite.java.tree.J.ClassDeclaration.Kind.Type.Interface;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -49,7 +51,7 @@ public class AddMissingMethodImplementation extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Adds missing method implementations.";
+        return "Adds missing method implementations";
     }
 
     @Override
@@ -71,8 +73,8 @@ public class AddMissingMethodImplementation extends Recipe {
             // need to make sure we handle sub-classes
             J.ClassDeclaration classDecl = super.visitClassDeclaration(cs, ctx);
 
-            // No need to make changes to abstract classes; only change concrete classes.
-            if (classDecl.hasModifier(J.Modifier.Type.Abstract)) {
+            // No need to make changes to abstract classes or interfaces; only change concrete classes.
+            if (classDecl.hasModifier(J.Modifier.Type.Abstract) || classDecl.getKind() == Interface) {
                 return classDecl;
             }
             // Don't make changes to classes that don't match the fully qualified name

--- a/src/main/java/org/openrewrite/java/migrate/AddMissingMethodImplementation.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMissingMethodImplementation.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.migrate;
 
-import static org.openrewrite.java.tree.J.ClassDeclaration.Kind.Type.Interface;
-
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -27,6 +25,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
+
+import static org.openrewrite.java.tree.J.ClassDeclaration.Kind.Type.Interface;
 
 @Value
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/org/openrewrite/java/migrate/AddMissingMethodImplementation.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMissingMethodImplementation.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.tree.TypeUtils;
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class AddMissingMethodImplementation extends Recipe {
+
     @Option(displayName = "Fully Qualified Class Name",
             description = "A fully qualified class being implemented with missing method.",
             example = "com.yourorg.FooBar")
@@ -65,6 +66,7 @@ public class AddMissingMethodImplementation extends Recipe {
     }
 
     public class ClassImplementationVisitor extends JavaIsoVisitor<ExecutionContext> {
+
         private final JavaTemplate methodTemplate = JavaTemplate.builder(methodTemplateString).build();
         private final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, true);
 

--- a/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class AddMissingMethodImplementationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(
+          new AddMissingMethodImplementation("I1", "*..* m1()",
+            "public void m1() { System.out.println(\"m1\"); }"))
+          .allSources(src -> src.markers(javaVersion(21)));
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/459")
+    void skipInterfaces() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              interface I1 {}
+              interface I2 extends I1 {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void skipAbstractClasses() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              interface I1 {}
+              abstract class AC2 implements I1 {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void happyPath() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              interface I1 {}
+              class C2 implements I1 {}
+              """,
+            """
+              interface I1 {}
+              class C2 implements I1 {
+                  public void m1() {
+                      System.out.println("m1");
+                  }}
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodExists() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              interface I1 {}
+              class C2 implements I1 {
+                  public void m1() {
+                      System.out.println("m1");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodExistsDiffImpl() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              interface I1 {}
+              class C2 implements I1 {
+                  public void m1() {
+                      System.out.println("m1 diff");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodExistsDiffSignature() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              interface I1 {}
+              class C2 implements I1 {
+                  protected void m1() {
+                      System.out.println("m1");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
@@ -15,13 +15,14 @@
  */
 package org.openrewrite.java.migrate;
 
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.javaVersion;
 
 class AddMissingMethodImplementationTest implements RewriteTest {
 

--- a/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
@@ -16,15 +16,14 @@
 package org.openrewrite.java.migrate;
 
 import org.openrewrite.DocumentExample;
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.javaVersion;
-
-class AddMissingMethodImplementationTest implements RewriteTest {
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-public class AddMissingMethodImplementationTest implements RewriteTest {
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+class AddMissingMethodImplementationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
@@ -15,10 +15,11 @@
  */
 package org.openrewrite.java.migrate;
 
+import org.openrewrite.DocumentExample;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
 
-import org.junit.jupiter.api.Test;
+class AddMissingMethodImplementationTest implements RewriteTest {
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
@@ -28,8 +28,8 @@ public class AddMissingMethodImplementationTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(
-          new AddMissingMethodImplementation("I1", "*..* m1()",
-            "public void m1() { System.out.println(\"m1\"); }"))
+            new AddMissingMethodImplementation("I1", "*..* m1()",
+              "public void m1() { System.out.println(\"m1\"); }"))
           .allSources(src -> src.markers(javaVersion(21)));
     }
 

--- a/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
@@ -15,14 +15,14 @@
  */
 package org.openrewrite.java.migrate;
 
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.javaVersion;
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
 
 class AddMissingMethodImplementationTest implements RewriteTest {
 

--- a/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMissingMethodImplementationTest.java
@@ -61,6 +61,7 @@ public class AddMissingMethodImplementationTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
     @Test
     void happyPath() {
         //language=java


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
* AddMissingMethodImplementation will no longer add methods to interfaces
* Added tests for AddMissingMethodImplementation

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes #459

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
