### PR TITLE
fix: Fix setNetworkTimeout methodPattern in java-version-7.yml

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-7.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-7.yml
@@ -15,7 +15,6 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-
 name: org.openrewrite.java.migrate.UpgradeToJava7
 displayName: Migrate to Java 7
 description: >

--- a/src/main/resources/META-INF/rewrite/java-version-7.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-7.yml
@@ -15,6 +15,7 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
+
 name: org.openrewrite.java.migrate.UpgradeToJava7
 displayName: Migrate to Java 7
 description: >
@@ -45,7 +46,7 @@ recipeList:
       methodTemplateString: "public java.lang.String getSchema() { \n\t// TODO Auto-generated method stub\n return null; }"
   - org.openrewrite.java.migrate.AddMissingMethodImplementation:
       fullyQualifiedClassName: java.sql.Connection
-      methodPattern: "*..* setNetworkTimeout(java.util.concurrent.Executor)"
+      methodPattern: "*..* setNetworkTimeout(java.util.concurrent.Executor, int)"
       methodTemplateString: "public void setNetworkTimeout(java.util.concurrent.Executor executor, int milliseconds) { \n\t// TODO Auto-generated method stub\n }"
   - org.openrewrite.java.migrate.AddMissingMethodImplementation:
       fullyQualifiedClassName: java.sql.Connection

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava7Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava7Test.java
@@ -41,7 +41,7 @@ class UpgradeToJava7Test implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                               
               import java.io.InputStream;
@@ -2033,7 +2033,7 @@ class UpgradeToJava7Test implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                                   
               import javax.sql.ConnectionPoolDataSource;
@@ -2123,7 +2123,7 @@ class UpgradeToJava7Test implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                                   
               import javax.sql.CommonDataSource;
@@ -2199,7 +2199,7 @@ class UpgradeToJava7Test implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                                 
               import javax.sql.CommonDataSource;
@@ -2271,37 +2271,37 @@ class UpgradeToJava7Test implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
-            package com.test.withoutV170Methods;
-                                
-            import javax.sql.CommonDataSource;
-                                
-            import java.io.PrintWriter;
-            import java.sql.SQLException;
-                                
-                                
-            public abstract class JRE7JdbcCommonDataSource implements CommonDataSource {
-                                
-              public int getLoginTimeout() throws SQLException {
-                return 0;
-              }
-                                
-              public PrintWriter getLogWriter() throws SQLException {
-                return null;
-              }
-                                
-              public void setLoginTimeout(int seconds) throws SQLException {
-                                
-                
-              }
-                                
-              public void setLogWriter(PrintWriter out) throws SQLException {
-                                
-                
-              }
-                                
-            }
             """
+              package com.test.withoutV170Methods;
+                                  
+              import javax.sql.CommonDataSource;
+                                  
+              import java.io.PrintWriter;
+              import java.sql.SQLException;
+                                  
+                                  
+              public abstract class JRE7JdbcCommonDataSource implements CommonDataSource {
+                                  
+                public int getLoginTimeout() throws SQLException {
+                  return 0;
+                }
+                                  
+                public PrintWriter getLogWriter() throws SQLException {
+                  return null;
+                }
+                                  
+                public void setLoginTimeout(int seconds) throws SQLException {
+                                  
+                  
+                }
+                                  
+                public void setLogWriter(PrintWriter out) throws SQLException {
+                                  
+                  
+                }
+                                  
+              }
+              """
           )
         );
     }
@@ -2312,7 +2312,7 @@ class UpgradeToJava7Test implements RewriteTest {
           spec -> spec.cycles(1).expectedCyclesThatMakeChanges(1),
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                                   
               import java.sql.*;
@@ -2791,11 +2791,263 @@ class UpgradeToJava7Test implements RewriteTest {
     }
 
     @Test
+    void connectionWithMethodsPresent() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.test.withoutV170Methods;
+                                  
+              import java.sql.*;
+              import java.util.Map;
+              import java.util.Properties;
+                                  
+              import javax.sql.*;
+                                  
+                                  
+              public class JRE7JdbcConnection implements java.sql.Connection {
+                                  
+                public <T> T unwrap(Class<T> iface) throws SQLException {
+                  return null;
+                }
+                                  
+                public boolean isWrapperFor(Class<?> iface) throws SQLException {
+                  return false;
+                }
+                                  
+                public void clearWarnings() throws SQLException {
+                  
+                }
+                                  
+                public void close() throws SQLException {
+                  
+                }
+                                  
+                public void commit() throws SQLException {
+                  
+                }
+                                  
+                public Statement createStatement() throws SQLException {
+                  return null;
+                }
+                                  
+                public Statement createStatement(int resultSetType, int resultSetConcurrency)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public Statement createStatement(int resultSetType,
+                    int resultSetConcurrency, int resultSetHoldability)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public boolean getAutoCommit() throws SQLException {
+                  return false;
+                }
+                                  
+                public String getCatalog() throws SQLException {
+                  return null;
+                }
+                                  
+                public int getHoldability() throws SQLException {
+                  return 0;
+                }
+                                  
+                public DatabaseMetaData getMetaData() throws SQLException {
+                  return null;
+                }
+                                  
+                public int getTransactionIsolation() throws SQLException {
+                  return 0;
+                }
+                                  
+                public Map<String, Class<?>> getTypeMap() throws SQLException {
+                  return null;
+                }
+                                  
+                public SQLWarning getWarnings() throws SQLException {
+                  return null;
+                }
+                                  
+                public boolean isClosed() throws SQLException {
+                  return false;
+                }
+                                  
+                public boolean isReadOnly() throws SQLException {
+                  return false;
+                }
+                                  
+                public String nativeSQL(String sql) throws SQLException {
+                  return null;
+                }
+                                  
+                public CallableStatement prepareCall(String sql) throws SQLException {
+                  return null;
+                }
+                                  
+                public CallableStatement prepareCall(String sql, int resultSetType,
+                    int resultSetConcurrency) throws SQLException {
+                  return null;
+                }
+                                  
+                public CallableStatement prepareCall(String sql, int resultSetType,
+                    int resultSetConcurrency, int resultSetHoldability)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public PreparedStatement prepareStatement(String sql) throws SQLException {
+                  return null;
+                }
+                                  
+                public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public PreparedStatement prepareStatement(String sql, int[] columnIndexes)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public PreparedStatement prepareStatement(String sql, int resultSetType,
+                    int resultSetConcurrency) throws SQLException {
+                  return null;
+                }
+                                  
+                public PreparedStatement prepareStatement(String sql, int resultSetType,
+                    int resultSetConcurrency, int resultSetHoldability)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public PreparedStatement prepareStatement(String sql, String[] columnNames)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+                  
+                }
+                                  
+                public void rollback() throws SQLException {
+                  
+                }
+                                  
+                public void rollback(Savepoint savepoint) throws SQLException {
+                  
+                }
+                                  
+                public void setAutoCommit(boolean autoCommit) throws SQLException {
+                  
+                }
+                                  
+                public void setCatalog(String catalog) throws SQLException {
+                  
+                }
+                                  
+                public void setHoldability(int holdability) throws SQLException {
+                  
+                }
+                                  
+                public void setReadOnly(boolean readOnly) throws SQLException {
+                  
+                }
+                                  
+                public Savepoint setSavepoint() throws SQLException {
+                  return null;
+                }
+                                  
+                public Savepoint setSavepoint(String name) throws SQLException {
+                  return null;
+                }
+                                  
+                public void setTransactionIsolation(int level) throws SQLException {
+                  
+                }
+                                  
+                public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+                  
+                }
+                                  
+                public Clob createClob() throws SQLException {
+                  return null;
+                }
+                                  
+                public Blob createBlob() throws SQLException {
+              \s
+                  return null;
+                }
+                                  
+                public NClob createNClob() throws SQLException {
+                  return null;
+                }
+                                  
+                public SQLXML createSQLXML() throws SQLException {
+                  return null;
+                }
+                                  
+                public boolean isValid(int timeout) throws SQLException {
+                    return false;
+                }
+                                  
+                public void setClientInfo(String name, String value) throws SQLClientInfoException {
+                  
+                }
+                                  
+                public void setClientInfo(Properties properties)
+                    throws SQLClientInfoException {
+                   
+                }
+                                  
+                public String getClientInfo(String name) throws SQLException {
+                  return null;
+                }
+                                  
+                public Properties getClientInfo() throws SQLException {
+                  return null;
+                }
+                                  
+                public Array createArrayOf(String typeName, Object[] elements)
+                    throws SQLException {
+                  return null;
+                }
+                                  
+                public Struct createStruct(String typeName, Object[] attributes)
+                    throws SQLException {
+                  return null;
+                }
+                
+                public void abort(java.util.concurrent.Executor executor) {
+                }
+                           
+                public int getNetworkTimeout() {
+                  return 0;
+                }
+                          
+                public java.lang.String getSchema() {
+                  return null;
+                }
+                 
+                public void setNetworkTimeout(java.util.concurrent.Executor executor, int milliseconds) {
+                }
+                               
+                public void setSchema(java.lang.String schema) throws java.sql.SQLException {
+                }
+                
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void dataSource() {
         rewriteRun(
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                                   
               import javax.sql.DataSource;
@@ -2909,7 +3161,7 @@ class UpgradeToJava7Test implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                                   
               import java.sql.Connection;
@@ -3001,7 +3253,7 @@ class UpgradeToJava7Test implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
+            """
               package com.test.withoutV170Methods;
                                   
               import java.io.InputStream;

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava7Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava7Test.java
@@ -2976,7 +2976,7 @@ class UpgradeToJava7Test implements RewriteTest {
                 }
                                   
                 public Blob createBlob() throws SQLException {
-              \s
+              
                   return null;
                 }
                                   


### PR DESCRIPTION

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fixed the methodPattern for setNetworkTimeout in java-version-7.yml.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
The incorrect methodPattern resulted in creating a duplicate setNetworkTimeout() method when such a method already existed.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
