### PR TITLE
fix: Add Jakarta XML WS API when using javax.xml.ws

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -183,12 +183,19 @@ recipeList:
       newGroupId: jakarta.xml.ws
       newArtifactId: jakarta.xml.ws-api
       newVersion: 2.3.x
-  # Add the jakarta JAXB artifact if it is missing but a project uses types in java.xml.bind
+  # Add the jakarta JAXB artifact if it is missing but a project uses types in javax.jws and javax.xml.ws
+  # Unfortunately, onlyIfUsing does not support multiple patterns so we need to add two separate rules.
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.xml.ws
       artifactId: jakarta.xml.ws-api
       version: 2.3.x
       onlyIfUsing: javax.jws..*
+      acceptTransitive: true
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: jakarta.xml.ws
+      artifactId: jakarta.xml.ws-api
+      version: 2.3.x
+      onlyIfUsing: javax.xml.ws..*
       acceptTransitive: true
   # If a project already had the jakarta api, make sure it is at the latest version.
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -183,8 +183,7 @@ recipeList:
       newGroupId: jakarta.xml.ws
       newArtifactId: jakarta.xml.ws-api
       newVersion: 2.3.x
-  # Add the jakarta JAXB artifact if it is missing but a project uses types in javax.jws and javax.xml.ws
-  # Unfortunately, onlyIfUsing does not support multiple patterns so we need to add two separate rules.
+  # Add the jakarta JAXB artifact if it is missing but a project uses types in either javax.jws or javax.xml.ws
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.xml.ws
       artifactId: jakarta.xml.ws-api

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
@@ -48,11 +48,11 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-               
+              
               repositories {
                   mavenCentral()
               }
-               
+              
               dependencies {
                   implementation "jakarta.xml.ws:jakarta.xml.ws-api:2.3.2"
               }
@@ -68,16 +68,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                   
+                  
                   repositories {
                       mavenCentral()
                   }
-                   
+                  
                   dependencies {
                       compileOnly "com.sun.xml.ws:jaxws-rt:%s"
-                                    
+                  
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
-                                    
+                  
                       testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
                   """.formatted(rtVersion, wsApiVersion, rtVersion);
@@ -141,16 +141,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-                            
+              
               repositories {
                   mavenCentral()
               }
-                            
+              
               dependencies {
                   compileOnly "com.sun.xml.ws:jaxws-ri:2.3.2"
-                            
+              
                   implementation "javax.xml.ws:jaxws-api:2.3.1"
-                            
+              
                   testImplementation "com.sun.xml.ws:jaxws-ri:2.3.2"
               }
               """,
@@ -165,14 +165,14 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                                    
+                  
                   repositories {
                       mavenCentral()
                   }
-                                    
+                  
                   dependencies {
                       implementation "com.sun.xml.ws:jaxws-rt:%s"
-                                    
+                  
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
                   }
                   """.formatted(rtVersion, wsApiVersion);
@@ -242,16 +242,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-                            
+              
               repositories {
                   mavenCentral()
               }
-                            
+              
               dependencies {
                   compileOnly "com.sun.xml.ws:jaxws-ri:2.3.2"
-                            
+              
                   implementation "jakarta.xml.ws:jakarta.xml.ws-api:2.3.2"
-                            
+              
                   testImplementation "com.sun.xml.ws:jaxws-ri:2.3.2"
               }
               """,
@@ -266,14 +266,14 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                                    
+                  
                   repositories {
                       mavenCentral()
                   }
-                                    
+                  
                   dependencies {
                       implementation "com.sun.xml.ws:jaxws-rt:%s"
-                                    
+                  
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
                   }
                   """.formatted(rtVersion, wsApiVersion);
@@ -343,11 +343,11 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-                            
+              
               repositories {
                   mavenCentral()
               }
-                            
+              
               dependencies {
                   implementation "jakarta.xml.ws:jakarta.xml.ws-api:2.3.2"
               }
@@ -363,16 +363,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                                    
+                  
                   repositories {
                       mavenCentral()
                   }
-                                    
+                  
                   dependencies {
                       compileOnly "com.sun.xml.ws:jaxws-rt:%s"
-                                    
+                  
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
-                                    
+                  
                       testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
                   """.formatted(rtVersion, wsApiVersion, rtVersion);

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.migrate.javax;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
@@ -29,7 +28,6 @@ import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-@Disabled
 class AddJaxwsDependenciesTest implements RewriteTest {
 
     @Override
@@ -50,11 +48,11 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-              
+               
               repositories {
                   mavenCentral()
               }
-              
+               
               dependencies {
                   implementation "jakarta.xml.ws:jakarta.xml.ws-api:2.3.2"
               }
@@ -70,16 +68,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                  
+                   
                   repositories {
                       mavenCentral()
                   }
-                  
+                   
                   dependencies {
                       compileOnly "com.sun.xml.ws:jaxws-rt:%s"
-                  
+                                    
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
-                  
+                                    
                       testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
                   """.formatted(rtVersion, wsApiVersion, rtVersion);
@@ -143,16 +141,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-              
+                            
               repositories {
                   mavenCentral()
               }
-              
+                            
               dependencies {
                   compileOnly "com.sun.xml.ws:jaxws-ri:2.3.2"
-              
+                            
                   implementation "javax.xml.ws:jaxws-api:2.3.1"
-              
+                            
                   testImplementation "com.sun.xml.ws:jaxws-ri:2.3.2"
               }
               """,
@@ -167,19 +165,17 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                  
+                                    
                   repositories {
                       mavenCentral()
                   }
-                  
+                                    
                   dependencies {
-                      compileOnly "com.sun.xml.ws:jaxws-rt:%s"
-                  
+                      implementation "com.sun.xml.ws:jaxws-rt:%s"
+                                    
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
-                  
-                      testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
-                  """.formatted(rtVersion, wsApiVersion, rtVersion);
+                  """.formatted(rtVersion, wsApiVersion);
             })
           ),
           pomXml(
@@ -246,16 +242,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-              
+                            
               repositories {
                   mavenCentral()
               }
-              
+                            
               dependencies {
                   compileOnly "com.sun.xml.ws:jaxws-ri:2.3.2"
-              
+                            
                   implementation "jakarta.xml.ws:jakarta.xml.ws-api:2.3.2"
-              
+                            
                   testImplementation "com.sun.xml.ws:jaxws-ri:2.3.2"
               }
               """,
@@ -270,19 +266,17 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                  
+                                    
                   repositories {
                       mavenCentral()
                   }
-                  
+                                    
                   dependencies {
-                      compileOnly "com.sun.xml.ws:jaxws-rt:%s"
-                  
+                      implementation "com.sun.xml.ws:jaxws-rt:%s"
+                                    
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
-                  
-                      testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
-                  """.formatted(rtVersion, wsApiVersion, rtVersion);
+                  """.formatted(rtVersion, wsApiVersion);
             })
           ),
           pomXml(
@@ -349,11 +343,11 @@ class AddJaxwsDependenciesTest implements RewriteTest {
               plugins {
                   id "java-library"
               }
-              
+                            
               repositories {
                   mavenCentral()
               }
-              
+                            
               dependencies {
                   implementation "jakarta.xml.ws:jakarta.xml.ws-api:2.3.2"
               }
@@ -369,16 +363,16 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                  
+                                    
                   repositories {
                       mavenCentral()
                   }
-                  
+                                    
                   dependencies {
                       compileOnly "com.sun.xml.ws:jaxws-rt:%s"
-                  
+                                    
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
-                  
+                                    
                       testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
                   """.formatted(rtVersion, wsApiVersion, rtVersion);


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

* jakarta.xml.ws-api contains packages javax.jws and javax.xml.ws, so we need to add the dependency when either is in use.
* Fixed and re-enabled AddJaxwsDependenciesTest by correcting the after specs to line up with expected results

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Running the Java 11 migration against my code base resulted in jakarta.xml.ws-api not being added to some projects that only used classes in javax.xml.ws

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Validate the revised expected results for AddJaxwsDependenciesTest line up with expectations

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
