### PR TITLE
allow @Builder annotation in LombokValueToBuilder 

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -101,7 +101,7 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
                 return cd;
             }
 
-            assert cd.getType() != null:"Class type must not be null"; // Checked in isRelevantClass
+            assert cd.getType() != null : "Class type must not be null"; // Checked in isRelevantClass
             Set<String> memberVariableNames = getMemberVariableNames(memberVariables);
             if (implementsConflictingInterfaces(cd, memberVariableNames)) {
                 return cd;
@@ -117,11 +117,11 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
         private boolean isRelevantClass(J.ClassDeclaration classDeclaration) {
             List<J.Annotation> allAnnotations = classDeclaration.getAllAnnotations();
             return classDeclaration.getType() != null
-                    && !J.ClassDeclaration.Kind.Type.Record.equals(classDeclaration.getKind())
-                    && hasMatchingAnnotations(classDeclaration)
-                    && !hasGenericTypeParameter(classDeclaration)
-                    && classDeclaration.getBody().getStatements().stream().allMatch(this::isRecordCompatibleField)
-                    && !hasIncompatibleModifier(classDeclaration);
+                   && !J.ClassDeclaration.Kind.Type.Record.equals(classDeclaration.getKind())
+                   && hasMatchingAnnotations(classDeclaration)
+                   && !hasGenericTypeParameter(classDeclaration)
+                   && classDeclaration.getBody().getStatements().stream().allMatch(this::isRecordCompatibleField)
+                   && !hasIncompatibleModifier(classDeclaration);
         }
 
         private static Predicate<J.Annotation> matchAnnotationWithNoArguments(AnnotationMatcher matcher) {
@@ -131,6 +131,7 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
         private static boolean hasMatchingAnnotations(J.ClassDeclaration classDeclaration) {
             List<J.Annotation> allAnnotations = classDeclaration.getAllAnnotations();
             if (allAnnotations.stream().anyMatch(matchAnnotationWithNoArguments(LOMBOK_VALUE_MATCHER))) {
+                // Tolerate a limited set of other annotations like Builder, that work well with records too
                 return allAnnotations.stream().allMatch(
                         matchAnnotationWithNoArguments(LOMBOK_VALUE_MATCHER)
                                 // compatible annotations can be added here
@@ -268,8 +269,8 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
             String classFqn = classType.getFullyQualifiedName();
 
             return recordTypeToMembers.containsKey(classFqn)
-                    && methodName.startsWith(STANDARD_GETTER_PREFIX)
-                    && recordTypeToMembers.get(classFqn).contains(getterMethodNameToFluentMethodName(methodName));
+                   && methodName.startsWith(STANDARD_GETTER_PREFIX)
+                   && recordTypeToMembers.get(classFqn).contains(getterMethodNameToFluentMethodName(methodName));
         }
 
         private static boolean isClassExpression(@Nullable Expression expression) {
@@ -318,7 +319,7 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
         }
 
         private static JavaType.Class buildRecordType(J.ClassDeclaration classDeclaration) {
-            assert classDeclaration.getType() != null:"Class type must not be null";
+            assert classDeclaration.getType() != null : "Class type must not be null";
             String className = classDeclaration.getType().getFullyQualifiedName();
 
             return JavaType.ShallowClass.build(className)

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -243,6 +243,39 @@ class LombokValueToRecordTest implements RewriteTest {
         );
     }
 
+    @Test
+    void plainLombokBuilder() {
+        //language=java
+        rewriteRun(
+          s -> s.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              package example;
+              
+              import lombok.Value;
+              import lombok.Builder;
+              
+              @Value
+              @Builder
+              public class A implements Serializable {
+                String test;
+              }
+              """,
+            """
+              package example;
+              
+              import lombok.Builder;
+              
+              @Builder
+              public record A(
+                String test) implements Serializable {
+              }
+              """
+          )
+        );
+
+    }
+
     @Nested
     class Unchanged {
         @Test


### PR DESCRIPTION
`@Builder` is often used with `@Value`.
It also works really well with records,
so lets just allow it in the recipe.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
LombokValueToBuilder now also transforms value classes which have a `@Builder` annotation.

## What's your motivation?
In our codebase, `@Value` and `@Builder` are almost always used together.
Migrating from `@Value` to record does not require further changes (at least I did not find any examples in our codebase)

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
