### PR TITLE
Also change Guava Predicate method name

### DIFF
--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -161,6 +161,10 @@ tags:
   - guava
   - RSPEC-S4738
 recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.google.common.base.Predicate apply(..)
+      newMethodName: test
+      matchOverrides: true
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.google.common.base.Predicate
       newFullyQualifiedTypeName: java.util.function.Predicate

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilPredicateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilPredicateTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -29,6 +30,7 @@ class PreferJavaUtilPredicateTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath("guava"));
     }
 
+    @DocumentExample
     @Test
     void changeTypeAndMethodName() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilPredicateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilPredicateTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class PreferJavaUtilPredicateTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.migrate.guava.PreferJavaUtilPredicate")
+          .parser(JavaParser.fromJavaVersion().classpath("guava"));
+    }
+
+    @Test
+    void changeTypeAndMethodName() {
+        rewriteRun(
+          //language=java
+          java(
+            """   
+              import com.google.common.base.Predicate;
+
+              class A {
+                  public static Predicate<String> makeStringPredicate() {
+                      return new Predicate<String>() {
+                          @Override
+                          public boolean apply(String input) {
+                              return input.isEmpty();
+                          }
+                      };
+                  }
+              }
+              """,
+            """ 
+              import java.util.function.Predicate;
+
+              class A {
+                  public static Predicate<String> makeStringPredicate() {
+                      return new Predicate<String>() {
+                          @Override
+                          public boolean test(String input) {
+                              return input.isEmpty();
+                          }
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added an additional `ChangeMethodName` and unit test to `PreferJavaUtilPredicate`.

## What's your motivation?
Fixes #435

## Anything in particular you'd like reviewers to focus on?
`ChangeMethodName` for now ignores the `NewClass`, instead looking for `ClassDeclaration` when trying to match the method pattern supplied, which therefor mismatches and fails to do the required replacement. This should probably be fixed upstream in rewrite-java.

## Have you considered any alternatives or workarounds?
We could add a dedicated recipe here for that replacement, but then any similar such change would need the same. It'd be easier if `ChangeMethodName` supported this out of the box, especially when using `matchOverrides`.

## Any additional context
- #435