### PR TITLE
Fix #478: EE bean validation.properties and SPI

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -271,6 +271,13 @@ recipeList:
       oldPackageName: javax.validation
       newPackageName: jakarta.validation
       recursive: true
+  - org.openrewrite.RenameFile:
+      fileMatcher: '**/javax.validation.ConstraintValidator'
+      fileName: jakarta.validation.ConstraintValidator
+  - org.openrewrite.text.FindAndReplace:
+      find: "javax."
+      replace: "jakarta."
+      filePattern: '**/ValidationMessages*.properties'
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxDecoratorToJakartaDecorator


### PR DESCRIPTION
Fix #478: EE bean validation.properties and SPI

- Renames `javax.validation.ConstraintValidator` to `jakarta.validation.ConstraintValidator`
- Finds all `ValidationMessages.properties` including lang specific like `ValidationMessages_en.properties` and replaces `javax.` with `jakarta.`