### PR TITLE
Recipe to call Modifier And ConstantBootstraps methods as static

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -35,6 +35,7 @@ recipeList:
   - org.openrewrite.java.migrate.RemoveMethodInvocation:
       methodPattern: java.lang.System traceMethodCalls(boolean)
   - org.openrewrite.java.migrate.RemovedToolProviderConstructor
+  - org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors
   - org.openrewrite.java.migrate.lang.UseTextBlocks
   - org.openrewrite.java.migrate.DeprecatedJavaxSecurityCert
   - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
@@ -240,3 +241,18 @@ recipeList:
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: javax.tools.ToolProvider *()
       fullyQualifiedTargetTypeName: javax.tools.ToolProvider
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors
+displayName: Change `java.lang.reflect.Modifier` and ` java.lang.invoke.ConstantBootstraps` method calls to static
+description: >
+  The `java.lang.reflect.Modifier()` and `java.lang.invoke.ConstantBootstraps()` constructors have been removed in Java SE 15 because both classes only contain static methods.
+  This recipe converts the usage of all methods in the two classes to be  static.
+  For more information on these changes, see https://docs.oracle.com/en/java/javase/15/migrate/index.html#GUID-233853B8-0782-429E-BEF7-7532EE610E63
+recipeList:
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: java.lang.reflect.Modifier *(..)
+      fullyQualifiedTargetTypeName: java.lang.reflect.Modifier
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: java.lang.invoke.ConstantBootstraps *(..)
+      fullyQualifiedTargetTypeName: java.lang.invoke.ConstantBootstraps

--- a/src/test/java/org/openrewrite/java/migrate/RemovedModifierAndConstantBootstrapsConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/RemovedModifierAndConstantBootstrapsConstructorsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemovedModifierAndConstantBootstrapsConstructorsTest  implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/java-version-17.yml", "org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors");
+    }
+
+    @DocumentExample
+    @Test
+    void moveToStaticTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.lang.invoke.ConstantBootstraps;
+              import java.lang.reflect.Modifier;
+              
+              class RemovedModifierAndConstantBootstrapsConstructorsApp {
+                   public void testModifier() throws Exception {
+                       Modifier modifier = new Modifier(); 
+                       modifier.classModifiers();
+                       modifier.fieldModifiers();
+                       modifier.isFinal(1);
+                       modifier.isStatic(1);
+                       Modifier.isPublic(0); 
+                   }             
+                   public void testConstantBootstraps() throws Exception {
+                       ConstantBootstraps constantBootstraps = new ConstantBootstraps(); 
+                       constantBootstraps.enumConstant(null,null,null);
+                       constantBootstraps.primitiveClass(null,null,null);
+                       ConstantBootstraps.nullConstant(null, null, null); 
+                   }
+              }          
+              """,
+            """
+              import java.lang.invoke.ConstantBootstraps;
+              import java.lang.reflect.Modifier;
+              
+              class RemovedModifierAndConstantBootstrapsConstructorsApp {
+                   public void testModifier() throws Exception {
+                       Modifier modifier = new Modifier(); 
+                       Modifier.classModifiers();
+                       Modifier.fieldModifiers();
+                       Modifier.isFinal(1);
+                       Modifier.isStatic(1);
+                       Modifier.isPublic(0); 
+                   }             
+                   public void testConstantBootstraps() throws Exception {
+                       ConstantBootstraps constantBootstraps = new ConstantBootstraps(); 
+                       ConstantBootstraps.enumConstant(null,null,null);
+                       ConstantBootstraps.primitiveClass(null,null,null);
+                       ConstantBootstraps.nullConstant(null, null, null); 
+                   }
+              }          
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This is a simple recipe for Java 17
org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors
![image](https://github.com/openrewrite/rewrite-migrate-java/assets/93149514/725544ba-9218-4178-b99e-af97f993540b)
The recipe calls org.openrewrite.java.ChangeMethodTargetToStatic

- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
