### PR TITLE
Remove Jakarta annotation dependency when moving to Jakarta packages

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -61,6 +61,8 @@ recipeList:
   - org.openrewrite.java.migrate.jakarta.UpdateApacheWSSecurityPackages
   - org.openrewrite.java.migrate.javaee8
   - org.openrewrite.java.migrate.jakarta.JavaxEEApiToJakarta
+  - org.openrewrite.java.migrate.jakarta.RemoveJakartaAnnotationDependency
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxActivationMigrationToJakartaActivation
@@ -988,3 +990,15 @@ recipeList:
       groupId: jakarta.platform
       artifactId: "*"
       newVersion: 9.0.0
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.RemoveJakartaAnnotationDependency
+displayName: Remove jakarta.annotation-api dependency if already manage by other dependency
+description: This recipe mainly revert the jakarta.annotation-api added by org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
+recipeList:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: jakarta.annotation
+      artifactIdPattern: jakarta.annotation-api
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -993,8 +993,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.RemoveJakartaAnnotationDependency
-displayName: Remove jakarta.annotation-api dependency if already manage by spring boot
-description: This recipe mainly revert the jakarta.annotation-api added by org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
+displayName: Remove `jakarta.annotation-api` dependency when managed by Spring Boot
+description: Counteract the `jakarta.annotation-api` added by `org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies` for Spring Boot applications.
 preconditions:
   - org.openrewrite.java.dependencies.DependencyInsight:
       groupIdPattern: org.springframework.boot

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -993,12 +993,12 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.RemoveJakartaAnnotationDependency
-displayName: Remove jakarta.annotation-api dependency if already manage by other dependency
+displayName: Remove jakarta.annotation-api dependency if already manage by spring boot
 description: This recipe mainly revert the jakarta.annotation-api added by org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
 preconditions:
   - org.openrewrite.java.dependencies.DependencyInsight:
-      groupIdPattern: jakarta.annotation
-      artifactIdPattern: jakarta.annotation-api
+      groupIdPattern: org.springframework.boot
+      artifactIdPattern: spring-boot-starter
 recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: jakarta.annotation

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -995,10 +995,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.RemoveJakartaAnnotationDependency
 displayName: Remove jakarta.annotation-api dependency if already manage by other dependency
 description: This recipe mainly revert the jakarta.annotation-api added by org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
-recipeList:
+preconditions:
   - org.openrewrite.java.dependencies.DependencyInsight:
       groupIdPattern: jakarta.annotation
       artifactIdPattern: jakarta.annotation-api
+recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: jakarta.annotation
       artifactId: jakarta.annotation-api

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
@@ -437,47 +437,48 @@ class JavaxToJakartaTest implements RewriteTest {
           spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javaxServlet)),
           mavenProject(
             "Sample",
+            //language=xml
             pomXml(
               """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                        <modelVersion>4.0.0</modelVersion>
-                        <parent>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>2.7.6</version>
+                        <relativePath/> <!-- lookup parent from repository -->
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <name>demo</name>
+                    <description>Demo project for Spring Boot</description>
+                    <properties>
+                        <java.version>17</java.version>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                             <groupId>jakarta.servlet</groupId>
+                         <artifactId>jakarta.servlet-api</artifactId>
+                         </dependency>
+                        <dependency>
                             <groupId>org.springframework.boot</groupId>
-                            <artifactId>spring-boot-starter-parent</artifactId>
-                            <version>2.7.6</version>
-                            <relativePath/> <!-- lookup parent from repository -->
-                        </parent>
-                        <groupId>com.example</groupId>
-                        <artifactId>demo</artifactId>
-                        <version>0.0.1-SNAPSHOT</version>
-                        <name>demo</name>
-                        <description>Demo project for Spring Boot</description>
-                        <properties>
-                            <java.version>17</java.version>
-                        </properties>
-                        <dependencies>
-                            <dependency>
-                                 <groupId>jakarta.servlet</groupId>
-                             <artifactId>jakarta.servlet-api</artifactId>
-                             </dependency>
-                            <dependency>
+                            <artifactId>spring-boot-starter-web</artifactId>
+                        </dependency>
+                    </dependencies>
+
+                    <build>
+                        <plugins>
+                            <plugin>
                                 <groupId>org.springframework.boot</groupId>
-                                <artifactId>spring-boot-starter-web</artifactId>
-                            </dependency>
-                        </dependencies>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                            </plugin>
+                        </plugins>
+                    </build>
 
-                        <build>
-                            <plugins>
-                                <plugin>
-                                    <groupId>org.springframework.boot</groupId>
-                                    <artifactId>spring-boot-maven-plugin</artifactId>
-                                </plugin>
-                            </plugins>
-                        </build>
-
-                    </project>
+                </project>
                 """
             ),
             srcMainJava(
@@ -505,6 +506,7 @@ class JavaxToJakartaTest implements RewriteTest {
           spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javaxServlet)),
           mavenProject(
             "Sample",
+            //language=xml
             pomXml(
               """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -520,11 +522,6 @@ class JavaxToJakartaTest implements RewriteTest {
                     <groupId>com.example</groupId>
                     <artifactId>demo</artifactId>
                     <version>0.0.1-SNAPSHOT</version>
-                    <name>demo</name>
-                    <description>Demo project for Spring Boot</description>
-                    <properties>
-                        <java.version>17</java.version>
-                    </properties>
                     <dependencies>
                         <dependency>
                             <groupId>jakarta.annotation</groupId>
@@ -536,16 +533,6 @@ class JavaxToJakartaTest implements RewriteTest {
                             <artifactId>spring-boot-starter-web</artifactId>
                         </dependency>
                     </dependencies>
-
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.springframework.boot</groupId>
-                                <artifactId>spring-boot-maven-plugin</artifactId>
-                            </plugin>
-                        </plugins>
-                    </build>
-
                 </project>
                 """,
               """
@@ -562,27 +549,12 @@ class JavaxToJakartaTest implements RewriteTest {
                     <groupId>com.example</groupId>
                     <artifactId>demo</artifactId>
                     <version>0.0.1-SNAPSHOT</version>
-                    <name>demo</name>
-                    <description>Demo project for Spring Boot</description>
-                    <properties>
-                        <java.version>17</java.version>
-                    </properties>
                     <dependencies>
                         <dependency>
                             <groupId>org.springframework.boot</groupId>
                             <artifactId>spring-boot-starter-web</artifactId>
                         </dependency>
                     </dependencies>
-
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.springframework.boot</groupId>
-                                <artifactId>spring-boot-maven-plugin</artifactId>
-                            </plugin>
-                        </plugins>
-                    </build>
-
                 </project>
                 """
             ),
@@ -610,9 +582,9 @@ class JavaxToJakartaTest implements RewriteTest {
             srcMainJava(
               java(
                 """
-                                    import jakarta.servlet.A;
-                                    public class TestApplication {
-                                    }
+                  import jakarta.servlet.A;
+                  public class TestApplication {
+                  }
                   """
               )
             ),

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
@@ -500,7 +500,7 @@ class JavaxToJakartaTest implements RewriteTest {
     }
 
     @Test
-    void projectWithSpringBoot3StarterWeb() {
+    void projectWithSpringBoot3StarterWebShouldRemoveJakartaDependency() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javaxServlet)),
           mavenProject(
@@ -595,6 +595,45 @@ class JavaxToJakartaTest implements RewriteTest {
                   }
                   """
               )
+            )
+          )
+        );
+    }
+
+    @Test
+    void doNothingIfNotFoundTransitiveDependency() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javaxServlet)),
+          mavenProject(
+            "Sample",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                                    import jakarta.servlet.A;
+                                    public class TestApplication {
+                                    }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>jakarta.annotation</groupId>
+                      <artifactId>jakarta.annotation-api</artifactId>
+                      <version>1.3.5</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
             )
           )
         );

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
@@ -498,4 +498,105 @@ class JavaxToJakartaTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void projectWithSpringBoot3StarterWeb() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javaxServlet)),
+          mavenProject(
+            "Sample",
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.2.5</version>
+                        <relativePath/> <!-- lookup parent from repository -->
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <name>demo</name>
+                    <description>Demo project for Spring Boot</description>
+                    <properties>
+                        <java.version>17</java.version>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>jakarta.annotation</groupId>
+                            <artifactId>jakarta.annotation-api</artifactId>
+                            <version>1.3.5</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-web</artifactId>
+                        </dependency>
+                    </dependencies>
+
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                            </plugin>
+                        </plugins>
+                    </build>
+
+                </project>
+                """,
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.2.5</version>
+                        <relativePath/> <!-- lookup parent from repository -->
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <name>demo</name>
+                    <description>Demo project for Spring Boot</description>
+                    <properties>
+                        <java.version>17</java.version>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-web</artifactId>
+                        </dependency>
+                    </dependencies>
+
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                            </plugin>
+                        </plugins>
+                    </build>
+
+                </project>
+                """
+            ),
+            srcMainJava(
+              //language=java
+              java(
+                """
+                  import jakarta.servlet.A;
+                  public class TestApplication {
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add a recipe to revert the jakarta.annotation-api added by org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies



## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fix https://github.com/openrewrite/rewrite-migrate-java/issues/481
- https://github.com/openrewrite/rewrite-migrate-java/issues/481

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
