### PR TITLE
adding recipe JREThrowableFinalMethods

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.migrate;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -23,7 +25,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
-
+@Value
+@EqualsAndHashCode(callSuper = false)
 class JREThrowableFinalMethods extends Recipe {
     @Override
     public String getDisplayName() {
@@ -33,8 +36,8 @@ class JREThrowableFinalMethods extends Recipe {
     @Override
     public String getDescription() {
         return "The recipe renames  `getSuppressed()` and `addSuppressed(Throwable exception)` methods  in classes "
-                + "that extend `java.lang.Throwable` to `myGetSuppressed` and `myAddSuppressed(Throwable)`."
-                + "These methods were added to Throwable in Java 7 and are marked final which cannot be overridden.";
+               + "that extend `java.lang.Throwable` to `myGetSuppressed` and `myAddSuppressed(Throwable)`."
+               + "These methods were added to Throwable in Java 7 and are marked final which cannot be overridden.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -51,23 +51,19 @@ class JREThrowableFinalMethods extends Recipe {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
                 J.MethodDeclaration md = super.visitMethodDeclaration(methodDecl, ctx);
-                if (md.getMethodType() == null || !TypeUtils.isAssignableTo(JAVA_THROWABLE_CLASS, md.getMethodType().getDeclaringType())) {
-                    return md;
-                }
-
-                if (md.getMethodType() != null && md.getReturnTypeExpression() != null) {
-                    String sn = md.getSimpleName();
-                    JavaType rte = md.getReturnTypeExpression().getType();
-                    JavaType.Method t = md.getMethodType();
-                    JavaType returnElementType = null;
-                    if (rte instanceof JavaType.Array) {
-                        returnElementType = ((JavaType.Array) rte).getElemType();
-                    }
-                    if ("add1Suppressed".equals(sn) && JavaType.Primitive.Void.equals(rte)) {
-                        md = md.withName(md.getName().withSimpleName("myAddSuppressed")).withMethodType(t.withName("myAddSuppressed"));
-                    }
-                    if ("get1Suppressed".equals(sn) && JAVA_THROWABLE_CLASS.equals(returnElementType.toString())) {
-                        md = md.withName(md.getName().withSimpleName("myGetSuppressed")).withMethodType(t.withName("myGetSuppressed"));
+                JavaType.Method mt = md.getMethodType();
+                if (mt != null && TypeUtils.isAssignableTo(JAVA_THROWABLE_CLASS, mt.getDeclaringType())) {
+                    J.ClassDeclaration classDeclaration = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                    if (classDeclaration != null) {
+                        if (METHOD_ADDSUPPRESSED.matches(md, classDeclaration)) {
+                            JavaType.Method myAddSuppressed = mt.withName("myAddSuppressed");
+                            return md.withName(md.getName().withSimpleName("myAddSuppressed").withType(myAddSuppressed))
+                                    .withMethodType(myAddSuppressed);
+                        } else if (METHOD_GETSUPPRESSED.matches(md, classDeclaration)) {
+                            JavaType.Method myGetSuppressed = mt.withName("myGetSuppressed");
+                            return md.withName(md.getName().withSimpleName("myGetSuppressed").withType(myGetSuppressed))
+                                    .withMethodType(myGetSuppressed);
+                        }
                     }
                 }
                 return md;
@@ -76,12 +72,16 @@ class JREThrowableFinalMethods extends Recipe {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodInv, ExecutionContext ctx) {
                 J.MethodInvocation mi = super.visitMethodInvocation(methodInv, ctx);
-                if (mi.getMethodType() != null) {
-                    String superClass = mi.getMethodType().getDeclaringType().getSupertype().getFullyQualifiedName();
-                    if (METHOD_ADDSUPPRESSED.matches(mi) && "java.lang.Throwable".equals(superClass)) {
-                        mi = mi.withName(mi.getName().withSimpleName("myAddSuppressed"));
-                    } else if (METHOD_GETSUPPRESSED.matches(mi) && "java.lang.Throwable".equals(superClass)) {
-                        mi = mi.withName(mi.getName().withSimpleName("myGetSuppressed"));
+                JavaType.Method mt = mi.getMethodType();
+                if (mt != null && TypeUtils.isAssignableTo(JAVA_THROWABLE_CLASS, mt.getDeclaringType())) {
+                    if (METHOD_ADDSUPPRESSED.matches(mi)) {
+                        JavaType.Method myAddSuppressed = mt.withName("myAddSuppressed");
+                        mi = mi.withName(mi.getName().withSimpleName("myAddSuppressed").withType(myAddSuppressed))
+                                .withMethodType(myAddSuppressed);
+                    } else if (METHOD_GETSUPPRESSED.matches(mi)) {
+                        JavaType.Method myGetSuppressed = mt.withName("myGetSuppressed");
+                        mi = mi.withName(mi.getName().withSimpleName("myGetSuppressed").withType(myGetSuppressed))
+                                .withMethodType(myGetSuppressed);
                     }
                 }
                 return mi;

--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -24,7 +24,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
 
-public class JREThrowableFinalMethods extends Recipe {
+class JREThrowableFinalMethods extends Recipe {
     @Override
     public String getDisplayName() {
         return "Rename final method declarations `getSuppressed()` and `addSuppressed(Throwable exception)` in classes that extend `Throwable`";

--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -23,6 +23,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -63,7 +64,10 @@ class JREThrowableFinalMethods extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                Preconditions.or(new UsesType<>("java.lang.Throwable", true)),
+                Preconditions.and(
+                        new UsesJavaVersion<>(1, 6),
+                        new UsesType<>("java.lang.Throwable", true)
+                ),
                 new JavaIsoVisitor<ExecutionContext>() {
                     private final MethodMatcher METHOD_ADDSUPPRESSED = new MethodMatcher(methodPatternAddSuppressed, false);
                     private final MethodMatcher METHOD_GETSUPPRESSED = new MethodMatcher(methodPatternGetSuppressed, false);

--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+
+public class JREThrowableFinalMethods extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Rename final method declarations `getSuppressed()` and `addSuppressed(Throwable exception)` in classes that extend `Throwable`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The recipe renames  `getSuppressed()` and `addSuppressed(Throwable exception)` methods  in classes " +
+                "that extend `java.lang.Throwable` to `myGetSuppressed` and `myAddSuppressed(Throwable)`." +
+                "These methods were added to Throwable in Java 7 and are marked final which cannot be overridden.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+            private final MethodMatcher METHOD_GETSUPPRESSED = new MethodMatcher("*..*  get1Suppressed()", false);
+            private final MethodMatcher METHOD_ADDSUPPRESSED = new MethodMatcher("*..*  add1Suppressed(Throwable)", false);
+            private final String JAVA_THROWABLE_CLASS = "java.lang.Throwable";
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                if (method.getMethodType() != null && method.getReturnTypeExpression() != null) {
+                    String sn = method.getSimpleName();
+                    JavaType rte = method.getReturnTypeExpression().getType();
+                    JavaType.Method t = method.getMethodType();
+                    JavaType returnElementType = null;
+                    if (rte instanceof JavaType.Array) {
+                        returnElementType = ((JavaType.Array) rte).getElemType();
+                    }
+                    String superClass = method.getMethodType().getDeclaringType().getSupertype().getFullyQualifiedName();
+                    if ("add1Suppressed".equals(sn) && JavaType.Primitive.Void.equals(rte) && JAVA_THROWABLE_CLASS.equals(superClass)) {
+                        method = method.withName(method.getName().withSimpleName("myAddSuppressed")).withMethodType(t.withName("myAddSuppressed"));
+                    }
+
+                    if ("get1Suppressed".equals(sn) && JAVA_THROWABLE_CLASS.equals(returnElementType.toString()) && JAVA_THROWABLE_CLASS.equals(superClass)) {
+                        method = method.withName(method.getName().withSimpleName("myGetSuppressed")).withMethodType(t.withName("myGetSuppressed"));
+                    }
+                }
+                return (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+            }
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+
+                if (method.getMethodType() != null) {
+                    String superClass = method.getMethodType().getDeclaringType().getSupertype().getFullyQualifiedName();
+                    if (METHOD_ADDSUPPRESSED.matches(method) && "java.lang.Throwable".equals(superClass)) {
+                        method = method.withName(method.getName().withSimpleName("myAddSuppressed"));
+                    } else if (METHOD_GETSUPPRESSED.matches(method) && "java.lang.Throwable".equals(superClass)) {
+                        method = method.withName(method.getName().withSimpleName("myGetSuppressed"));
+                    }
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -15,20 +15,39 @@
  */
 package org.openrewrite.java.migrate;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
 class JREThrowableFinalMethods extends Recipe {
+
+    private final String methodPatternAddSuppressed;
+    private final String methodPatternGetSuppressed;
+
+    @JsonCreator
+    public JREThrowableFinalMethods() {
+        this.methodPatternAddSuppressed = "*..* addSuppressed(Throwable)";
+        this.methodPatternGetSuppressed = "*..* getSuppressed()";
+    }
+
+    /**
+     * Overload constructor to allow for custom method patterns used in tests only.
+     */
+    JREThrowableFinalMethods(String methodPatternAddSuppressed, String methodPatternGetSuppressed) {
+        this.methodPatternAddSuppressed = methodPatternAddSuppressed;
+        this.methodPatternGetSuppressed = methodPatternGetSuppressed;
+    }
+
     @Override
     public String getDisplayName() {
         return "Rename final method declarations `getSuppressed()` and `addSuppressed(Throwable exception)` in classes that extend `Throwable`";
@@ -43,49 +62,52 @@ class JREThrowableFinalMethods extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaIsoVisitor<ExecutionContext>() {
-            private final MethodMatcher METHOD_GETSUPPRESSED = new MethodMatcher("*..*  get1Suppressed()", false);
-            private final MethodMatcher METHOD_ADDSUPPRESSED = new MethodMatcher("*..*  add1Suppressed(Throwable)", false);
-            private final String JAVA_THROWABLE_CLASS = "java.lang.Throwable";
+        return Preconditions.check(
+                Preconditions.or(new UsesType<>("java.lang.Throwable", true)),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    private final MethodMatcher METHOD_ADDSUPPRESSED = new MethodMatcher(methodPatternAddSuppressed, false);
+                    private final MethodMatcher METHOD_GETSUPPRESSED = new MethodMatcher(methodPatternGetSuppressed, false);
+                    private final String JAVA_THROWABLE_CLASS = "java.lang.Throwable";
 
-            @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
-                J.MethodDeclaration md = super.visitMethodDeclaration(methodDecl, ctx);
-                JavaType.Method mt = md.getMethodType();
-                if (mt != null && TypeUtils.isAssignableTo(JAVA_THROWABLE_CLASS, mt.getDeclaringType())) {
-                    J.ClassDeclaration classDeclaration = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                    if (classDeclaration != null) {
-                        if (METHOD_ADDSUPPRESSED.matches(md, classDeclaration)) {
-                            JavaType.Method myAddSuppressed = mt.withName("myAddSuppressed");
-                            return md.withName(md.getName().withSimpleName("myAddSuppressed").withType(myAddSuppressed))
-                                    .withMethodType(myAddSuppressed);
-                        } else if (METHOD_GETSUPPRESSED.matches(md, classDeclaration)) {
-                            JavaType.Method myGetSuppressed = mt.withName("myGetSuppressed");
-                            return md.withName(md.getName().withSimpleName("myGetSuppressed").withType(myGetSuppressed))
-                                    .withMethodType(myGetSuppressed);
+                    @Override
+                    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
+                        J.MethodDeclaration md = super.visitMethodDeclaration(methodDecl, ctx);
+                        JavaType.Method mt = md.getMethodType();
+                        if (mt != null && TypeUtils.isAssignableTo(JAVA_THROWABLE_CLASS, mt.getDeclaringType())) {
+                            J.ClassDeclaration classDeclaration = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                            if (classDeclaration != null) {
+                                if (METHOD_ADDSUPPRESSED.matches(md, classDeclaration)) {
+                                    JavaType.Method myAddSuppressed = mt.withName("myAddSuppressed");
+                                    return md.withName(md.getName().withSimpleName("myAddSuppressed").withType(myAddSuppressed))
+                                            .withMethodType(myAddSuppressed);
+                                } else if (METHOD_GETSUPPRESSED.matches(md, classDeclaration)) {
+                                    JavaType.Method myGetSuppressed = mt.withName("myGetSuppressed");
+                                    return md.withName(md.getName().withSimpleName("myGetSuppressed").withType(myGetSuppressed))
+                                            .withMethodType(myGetSuppressed);
+                                }
+                            }
                         }
+                        return md;
                     }
-                }
-                return md;
-            }
 
-            @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodInv, ExecutionContext ctx) {
-                J.MethodInvocation mi = super.visitMethodInvocation(methodInv, ctx);
-                JavaType.Method mt = mi.getMethodType();
-                if (mt != null && TypeUtils.isAssignableTo(JAVA_THROWABLE_CLASS, mt.getDeclaringType())) {
-                    if (METHOD_ADDSUPPRESSED.matches(mi)) {
-                        JavaType.Method myAddSuppressed = mt.withName("myAddSuppressed");
-                        mi = mi.withName(mi.getName().withSimpleName("myAddSuppressed").withType(myAddSuppressed))
-                                .withMethodType(myAddSuppressed);
-                    } else if (METHOD_GETSUPPRESSED.matches(mi)) {
-                        JavaType.Method myGetSuppressed = mt.withName("myGetSuppressed");
-                        mi = mi.withName(mi.getName().withSimpleName("myGetSuppressed").withType(myGetSuppressed))
-                                .withMethodType(myGetSuppressed);
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodInv, ExecutionContext ctx) {
+                        J.MethodInvocation mi = super.visitMethodInvocation(methodInv, ctx);
+                        JavaType.Method mt = mi.getMethodType();
+                        if (mt != null && TypeUtils.isAssignableTo(JAVA_THROWABLE_CLASS, mt.getDeclaringType())) {
+                            if (METHOD_ADDSUPPRESSED.matches(mi)) {
+                                JavaType.Method myAddSuppressed = mt.withName("myAddSuppressed");
+                                mi = mi.withName(mi.getName().withSimpleName("myAddSuppressed").withType(myAddSuppressed))
+                                        .withMethodType(myAddSuppressed);
+                            } else if (METHOD_GETSUPPRESSED.matches(mi)) {
+                                JavaType.Method myGetSuppressed = mt.withName("myGetSuppressed");
+                                mi = mi.withName(mi.getName().withSimpleName("myGetSuppressed").withType(myGetSuppressed))
+                                        .withMethodType(myGetSuppressed);
+                            }
+                        }
+                        return mi;
                     }
                 }
-                return mi;
-            }
-        };
+        );
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -32,9 +32,9 @@ public class JREThrowableFinalMethods extends Recipe {
 
     @Override
     public String getDescription() {
-        return "The recipe renames  `getSuppressed()` and `addSuppressed(Throwable exception)` methods  in classes " +
-                "that extend `java.lang.Throwable` to `myGetSuppressed` and `myAddSuppressed(Throwable)`." +
-                "These methods were added to Throwable in Java 7 and are marked final which cannot be overridden.";
+        return "The recipe renames  `getSuppressed()` and `addSuppressed(Throwable exception)` methods  in classes "
+                + "that extend `java.lang.Throwable` to `myGetSuppressed` and `myAddSuppressed(Throwable)`."
+                + "These methods were added to Throwable in Java 7 and are marked final which cannot be overridden.";
     }
 
     @Override
@@ -68,7 +68,6 @@ public class JREThrowableFinalMethods extends Recipe {
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-
                 if (method.getMethodType() != null) {
                     String superClass = method.getMethodType().getDeclaringType().getSupertype().getFullyQualifiedName();
                     if (METHOD_ADDSUPPRESSED.matches(method) && "java.lang.Throwable".equals(superClass)) {

--- a/src/main/resources/META-INF/rewrite/java-version-7.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-7.yml
@@ -25,7 +25,7 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava6
   - org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods
-  - - org.openrewrite.java.migrate.JREThrowableFinalMethods
+  - org.openrewrite.java.migrate.JREThrowableFinalMethods
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods

--- a/src/main/resources/META-INF/rewrite/java-version-7.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-7.yml
@@ -25,6 +25,7 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava6
   - org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods
+  - - org.openrewrite.java.migrate.JREThrowableFinalMethods
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods

--- a/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
@@ -8,7 +8,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class JREThrowableFinalMethodsTest implements RewriteTest {
+class JREThrowableFinalMethodsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new JREThrowableFinalMethods() );

--- a/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
 
 class JREThrowableFinalMethodsTest implements RewriteTest {
     @Override
@@ -58,7 +59,8 @@ class JREThrowableFinalMethodsTest implements RewriteTest {
                       return null;
                   }
               }
-              """
+              """,
+            spec -> spec.markers(javaVersion(6))
           ),
           //language=java
           java(
@@ -79,13 +81,14 @@ class JREThrowableFinalMethodsTest implements RewriteTest {
                       t1.myGetSuppressed();
                   }
               }
-              """
+              """,
+            spec -> spec.markers(javaVersion(6))
           )
         );
     }
 
     @Test
-    void shouldNotTouchOtherThrowables() {
+    void shouldRenameOnJava6() {
         //language=java
         rewriteRun(
           spec -> spec.recipe(new JREThrowableFinalMethods()),
@@ -97,7 +100,35 @@ class JREThrowableFinalMethodsTest implements RewriteTest {
                       t1.getSuppressed();
                   }
               }
-              """
+              """,
+            """
+              class ClassUsingThrowable {
+                  void methodUsingRenamedMethodsAlready(Throwable t1) {
+                      t1.myAddSuppressed(new Throwable());
+                      t1.myGetSuppressed();
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(6))
+          )
+        );
+    }
+
+    @Test
+    void shouldNotRenameOnJava7() {
+        //language=java
+        rewriteRun(
+          spec -> spec.recipe(new JREThrowableFinalMethods()),
+          java(
+            """
+              class ClassUsingThrowable {
+                  void methodUsingRenamedMethodsAlready(Throwable t1) {
+                      t1.addSuppressed(new Throwable());
+                      t1.getSuppressed();
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(7))
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
@@ -25,14 +25,17 @@ import static org.openrewrite.java.Assertions.java;
 class JREThrowableFinalMethodsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new JREThrowableFinalMethods());
     }
 
     @DocumentExample
     @Test
     void renameMethodDeclarationsAndUsagesElsewhere() {
-        //language=java
         rewriteRun(
+          // Override method patterns as test examples would not compile otherwise
+          spec -> spec.recipe(new JREThrowableFinalMethods(
+            "*..* add1Suppressed(Throwable)",
+            "*..* get1Suppressed()")),
+          //language=java
           java(
             """
               package com.test;
@@ -57,6 +60,7 @@ class JREThrowableFinalMethodsTest implements RewriteTest {
               }
               """
           ),
+          //language=java
           java(
             """
               import com.test.ThrowableWithIllegalOverrrides;
@@ -84,11 +88,12 @@ class JREThrowableFinalMethodsTest implements RewriteTest {
     void shouldNotTouchOtherThrowables() {
         //language=java
         rewriteRun(
+          spec -> spec.recipe(new JREThrowableFinalMethods()),
           java(
             """
               class ClassUsingThrowable {
                   void methodUsingRenamedMethodsAlready(Throwable t1) {
-                      t1.addSuppressed(null);
+                      t1.addSuppressed(new Throwable());
                       t1.getSuppressed();
                   }
               }

--- a/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
@@ -1,0 +1,51 @@
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.ChangeMethodName;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class JREThrowableFinalMethodsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new JREThrowableFinalMethods() );
+    }
+
+    @Test
+    void renameOverRideMethods() {
+        rewriteRun(
+          //language=java
+          java(
+            """     
+             package com.test;
+
+             public class MyBadThrowableExceptionAddGet extends Throwable{
+                public void add1Suppressed(Throwable exception) {  }
+                public Throwable[] get1Suppressed() { return null;}
+                public static void main(String args[]) {
+                   MyBadThrowableExceptionAddGet t1;
+                   t1.add1Suppressed(null);
+                   t1.get1Suppressed();
+                }
+             }
+             """,
+            """
+             package com.test;
+
+             public class MyBadThrowableExceptionAddGet extends Throwable{
+                public void myAddSuppressed(Throwable exception) {  }
+                public Throwable[] myGetSuppressed() { return null;}
+                public static void main(String args[]) {
+                   MyBadThrowableExceptionAddGet t1;
+                   t1.myAddSuppressed(null);
+                   t1.myGetSuppressed();
+                }
+             }     
+             """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
This recipe deals with the following rule:
![image](https://github.com/openrewrite/rewrite-migrate-java/assets/93149514/f6a0c477-d4e1-4115-b474-d60aaaff008d)

## What's your motivation?
This is a custom recipe that renames the method declarations `getSuppressed()` and `addSuppressed(Throwable exception)`  to `myGetSuppressed()` and `myAddSuppressed(Throwable exception)` in classes that extend `Throwable`.



## Anything in particular you'd like reviewers to focus on?
Currently, there is no way to test the recipe since the methods were replaced in Java 7. And to test the recipe would entail using Java6.
So as a workaround, the test uses `get1Suppressed` and `add1Suppresed` for method names and replaces them.
Once we have reviewed the recipe and agree on the implementation, I will modify the recipe to use `getSuppressed` and `addSuppressed` methods.

## Anyone you would like to review specifically?
@cjobinabo @timtebeek 


### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
