### PR TITLE
Replace `javax.security.auth.Policy` with `java.security.Policy`

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -240,8 +240,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.RemovedPolicy
-displayName: Use `java.security.Policy` instead of `javax.security.auth.Policy`
-description: Do not use the `javax.security.auth.Policy` class.
+displayName: Replace `javax.security.auth.Policy` with `java.security.Policy`
+description: The `javax.security.auth.Policy` class is not available from Java SE 11 onwards.
 tags:
   - java11
 recipeList:

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 the original author or authors.
+# Copyright 2024 the original author or authors.
 # <p>
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ recipeList:
   - org.openrewrite.java.migrate.InternalBindContextFactory
   - org.openrewrite.java.migrate.RemovedSecurityManagerMethods
   - org.openrewrite.java.migrate.UpgradePluginsForJava11
+  - org.openrewrite.java.migrate.RemovedPolicy
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -235,4 +236,16 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.sun.xml.internal.bind.v2.ContextFactory
       newFullyQualifiedTypeName: com.sun.xml.bind.v2.ContextFactory
+      ignoreDefinition: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedPolicy
+displayName: Use `java.security.Policy` instead of `javax.security.auth.Policy`
+description: Do not use the `javax.security.auth.Policy` class.
+tags:
+  - java11
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.security.auth.Policy
+      newFullyQualifiedTypeName: java.security.Policy
       ignoreDefinition: true


### PR DESCRIPTION
## What's changed?
![image](https://github.com/openrewrite/rewrite-migrate-java/assets/61456973/f4ca5763-f298-4b7e-92cd-6d9fa9ffbd4e)

## What's your motivation?
I used org.openrewrite.java.ChangeType for the recipe RemovedPolicy

## Anyone you would like to review specifically?
@cjobinabo @timtebeek 

## Have you considered any alternatives or workarounds?
Since it was not possible to test the recipe. I created sample files, created a local plugin using
**./gradlew publishToMavenLocal** then ran it in the Java8 Sample App using **mvn rewrite:dryRun**

Attaching the rewrite.patch file
[rewrite.patch](https://github.com/user-attachments/files/15811634/rewrite.patch)

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
