### PR TITLE
PrimeFaces 14 and proper EE10 namespaces

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
@@ -111,6 +111,14 @@ recipeList:
       replace: "jakarta.faces"
       filePattern: '**/*.xhtml'
   - org.openrewrite.text.FindAndReplace:
+      find: "http://primefaces.org/ui/extensions"
+      replace: "primefaces.extensions"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://primefaces.org/ui"
+      replace: "primefaces"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
       find: javax.
       replace: jakarta.
       filePattern: '**/*.xhtml'
@@ -477,7 +485,7 @@ recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.primefaces
       artifactId: primefaces
-      newVersion: 13.0.x
+      newVersion: 14.0.x
   - org.openrewrite.maven.ChangeDependencyClassifier:
       groupId: org.primefaces.extensions
       artifactId: primefaces-extensions
@@ -485,7 +493,7 @@ recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.primefaces.extensions
       artifactId: primefaces-extensions
-      newVersion: 13.0.x
+      newVersion: 14.0.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.omnifaces
       artifactId: omnifaces

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JakartaFacesXhtmlTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JakartaFacesXhtmlTest.java
@@ -72,8 +72,8 @@ class JakartaFacesXhtmlTest implements RewriteTest {
                       xmlns:h="jakarta.faces.html"
                       xmlns:ui="jakarta.faces.facelets"
                       xmlns:c="jakarta.tags.core"
-                      xmlns:p="http://primefaces.org/ui"
-                      xmlns:pe="http://primefaces.org/ui/extensions">
+                      xmlns:p="primefaces"
+                      xmlns:pe="primefaces.extensions">
               <script src="https://www.gstatic.com/charts/loader.js"></script>
               <p:outputPanel id="container" layout="block">
                   <h:panelGrid columns="4">
@@ -144,8 +144,8 @@ class JakartaFacesXhtmlTest implements RewriteTest {
                       xmlns:pt="jakarta.faces.passthrough"
                       xmlns:fn="jakarta.tags.functions"
                       xmlns:cc="jakarta.faces.composite"
-                      xmlns:p="http://primefaces.org/ui"
-                      xmlns:pe="http://primefaces.org/ui/extensions">
+                      xmlns:p="primefaces"
+                      xmlns:pe="primefaces.extensions">
               <script src="https://www.gstatic.com/charts/loader.js"></script>
               <div pt:id="container">
                   <h:panelGrid columns="4">

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpgradeFacesOpenSourceLibrariesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpgradeFacesOpenSourceLibrariesTest.java
@@ -51,7 +51,7 @@ class UpgradeFacesOpenSourceLibrariesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(actual -> {
-                String version = Pattern.compile("<version>(13\\.0\\.\\d+)</version>")
+                String version = Pattern.compile("<version>(14\\.0\\.\\d+)</version>")
                   .matcher(actual).results().reduce((a, b) -> b).orElseThrow().group(1);
                 return """
                   <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## What's changed?
- change namespaces from `xmlns:p="http://primefaces.org/ui"` to `xmlns:p="primefaces"`
- Bump PF version to 14.X

