### PR TITLE
Disable UseTextBlocks on Kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-java-tck")
+    testImplementation("org.openrewrite:rewrite-kotlin:$rewriteVersion")
     testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
 
     testImplementation("org.assertj:assertj-core:latest.release")

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -77,7 +78,11 @@ public class UseTextBlocks extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new HasJavaVersion("17", true), new JavaVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> preconditions = Preconditions.and(
+                Preconditions.not(new KotlinFileChecker<>()),
+                new HasJavaVersion("17", true).getVisitor()
+        );
+        return Preconditions.check(preconditions, new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitBinary(J.Binary binary, ExecutionContext ctx) {
                 List<J.Literal> stringLiterals = new ArrayList<>();

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -47,7 +47,7 @@ import static org.openrewrite.Tree.randomId;
 public class UseTextBlocks extends Recipe {
     @Option(displayName = "Whether to convert strings without newlines (the default value is true).",
             description = "Whether or not strings without newlines should be converted to text block when processing code. " +
-                    "The default value is true.",
+                          "The default value is true.",
             example = "true",
             required = false)
     @Nullable
@@ -182,8 +182,8 @@ public class UseTextBlocks extends Recipe {
 
     private static boolean allLiterals(Expression exp) {
         return isRegularStringLiteral(exp) || exp instanceof J.Binary
-                && ((J.Binary) exp).getOperator() == J.Binary.Type.Addition
-                && allLiterals(((J.Binary) exp).getLeft()) && allLiterals(((J.Binary) exp).getRight());
+                                              && ((J.Binary) exp).getOperator() == J.Binary.Type.Addition
+                                              && allLiterals(((J.Binary) exp).getLeft()) && allLiterals(((J.Binary) exp).getRight());
     }
 
     private static boolean flatAdditiveStringLiterals(Expression expression,
@@ -198,7 +198,7 @@ public class UseTextBlocks extends Recipe {
             concatenationSb.append(b.getPrefix().getWhitespace()).append("-");
             concatenationSb.append(b.getPadding().getOperator().getBefore().getWhitespace()).append("-");
             return flatAdditiveStringLiterals(b.getLeft(), stringLiterals, contentSb, concatenationSb)
-                    && flatAdditiveStringLiterals(b.getRight(), stringLiterals, contentSb, concatenationSb);
+                   && flatAdditiveStringLiterals(b.getRight(), stringLiterals, contentSb, concatenationSb);
         } else if (isRegularStringLiteral(expression)) {
             J.Literal l = (J.Literal) expression;
             stringLiterals.add(l);
@@ -214,8 +214,8 @@ public class UseTextBlocks extends Recipe {
         if (expr instanceof J.Literal) {
             J.Literal l = (J.Literal) expr;
             return TypeUtils.isString(l.getType()) &&
-                    l.getValueSource() != null &&
-                    !l.getValueSource().startsWith("\"\"\"");
+                   l.getValueSource() != null &&
+                   !l.getValueSource().startsWith("\"\"\"");
         }
         return false;
     }
@@ -237,7 +237,7 @@ public class UseTextBlocks extends Recipe {
         int spaceCount = tabAndSpaceCounts[1];
         if (useTabCharacter) {
             return StringUtils.repeat("\t", tabCount) +
-                    StringUtils.repeat(" ", spaceCount);
+                   StringUtils.repeat(" ", spaceCount);
         } else {
             // replace tab with spaces if the style is using spaces
             return StringUtils.repeat(" ", tabCount * tabSize + spaceCount);

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class UseTextBlocksTest implements RewriteTest {
 
@@ -813,6 +814,21 @@ class UseTextBlocksTest implements RewriteTest {
                           "AFTER the variable. ";
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/501")
+    void shouldNotUpdateKotlinCode() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          kotlin(
+            """
+              const val MULTI_LINE_MESSAGE =
+                 \s"This is a multi-line message and should not be updated. " +
+                         \s"This is the second sentence of such message."
               """
           )
         );


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Disables UseTextBlocks on Kotlin given that the semantics aren't the same as for Java.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes https://github.com/openrewrite/rewrite-migrate-java/issues/501

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
