### PR TITLE
Remove `Thread.destroy()` and `Thread.stop(Throwable)`

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -67,6 +67,7 @@ recipeList:
   - org.openrewrite.java.migrate.RemovedSecurityManagerMethods
   - org.openrewrite.java.migrate.UpgradePluginsForJava11
   - org.openrewrite.java.migrate.RemovedPolicy
+  - org.openrewrite.java.migrate.ThreadStopDestroy
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -249,3 +250,16 @@ recipeList:
       oldFullyQualifiedTypeName: javax.security.auth.Policy
       newFullyQualifiedTypeName: java.security.Policy
       ignoreDefinition: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.ThreadStopDestroy
+displayName: Remove `java.lang.Thread.destroy()` and `java.lang.Thread.stop(java.lang.Throwable)` methods
+description: The `java.lang.Thread.destroy()` method was never implemented, and the `java.lang.Thread.stop(java.lang.Throwable)` method has been unusable since Java SE 8.
+  This recipe removes the usage of this methods in your application.
+tags:
+  - java11
+recipeList:
+  - org.openrewrite.java.migrate.RemoveMethodInvocation:
+      methodPattern: java.lang.Thread destroy()
+  - org.openrewrite.java.migrate.RemoveMethodInvocation:
+      methodPattern: java.lang.Thread stop(java.lang.Throwable)

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -253,9 +253,10 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.ThreadStopDestroy
-displayName: Remove `java.lang.Thread.destroy()` and `java.lang.Thread.stop(java.lang.Throwable)` methods
-description: The `java.lang.Thread.destroy()` method was never implemented, and the `java.lang.Thread.stop(java.lang.Throwable)` method has been unusable since Java SE 8.
-  This recipe removes the usage of this methods in your application.
+displayName: Remove `Thread.destroy()` and `Thread.stop(Throwable)`
+description: |
+  The `java.lang.Thread.destroy()` method was never implemented, and the `java.lang.Thread.stop(java.lang.Throwable)`
+  method has been unusable since Java SE 8. This recipe removes any usage of these methods from your application.
 tags:
   - java11
 recipeList:

--- a/src/test/java/org/openrewrite/java/migrate/ThreadStopDestroy.java
+++ b/src/test/java/org/openrewrite/java/migrate/ThreadStopDestroy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+class ThreadStopDestroy implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.migrate.ThreadStopDestroy")
+          .allSources(src -> src.markers(javaVersion(8)));
+    }
+
+    @Test
+    @DocumentExample
+    void retainCommentIfPresent() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Foo {
+                  void bar() {
+                      Thread.currentThread().stop();
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/ThreadStopDestroyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ThreadStopDestroyTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
 
-class ThreadStopDestroy implements RewriteTest {
+class ThreadStopDestroyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.migrate.ThreadStopDestroy")
@@ -32,7 +32,7 @@ class ThreadStopDestroy implements RewriteTest {
 
     @Test
     @DocumentExample
-    void retainCommentIfPresent() {
+    void retainThreadStop() {
         rewriteRun(
           //language=java
           java(
@@ -40,6 +40,7 @@ class ThreadStopDestroy implements RewriteTest {
               class Foo {
                   void bar() {
                       Thread.currentThread().stop();
+                      // We can't test removal of Thread.destroy() or stop(Throwable) on Java 17
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
![image](https://github.com/openrewrite/rewrite-migrate-java/assets/61456973/5bc174e6-83e8-41c1-9b3e-cfe202bfc9c2)

## What's your motivation?
I used org.openrewrite.java.migrate.RemoveMethodInvocation for the recipe ThreadStopDestroy

## Anyone you would like to review specifically?
@cjobinabo @timtebeek 

## Have you considered any alternatives or workarounds?
Since it was not possible to test the recipe completely. I created sample files, created a local plugin using
./gradlew publishToMavenLocal then ran it in the Java8 Sample App using mvn rewrite:dryRun

Attaching the rewrite.patch file
[rewrite.patch](https://github.com/user-attachments/files/15934411/rewrite.patch)


### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
