### PR TITLE
Fixed version Typo in JavaxWsToJakartaWs Recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -652,7 +652,7 @@ recipeList:
       oldArtifactId: javax.ws.rs-api
       newGroupId: jakarta.ws.rs
       newArtifactId: jakarta.ws.rs-api
-      version: latest.release
+      newVersion: latest.release
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.ws.rs
       artifactId: jakarta.ws.rs-api


### PR DESCRIPTION
# Typo in JavaxWsToJakartaWs recipe
## What's changed?
The version option changed to newVersion in the org.openrewrite.java.migrate.jakarta.JavaxWsToJakartaWs recipe.

## What's your motivation?
While migrating to Jakarta with the org.openrewrite.java.migrate.jakarta.JakartaEE10 recipe I noticed something strange. The version of my previously used dependency javax.ws.rs didn't change. So I started looking around and found probably a typo.
