### PR TITLE
Replace `Reference.clone()` with new constructor in Java 11 migration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,12 @@ develocity {
             fileFingerprints = true
         }
 
+        publishing {
+            onlyIf {
+                authenticated
+            }
+        }
+
         uploadInBackground = !isCiServer
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/ReferenceCloneMethod.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReferenceCloneMethod.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.*;
+
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+class ReferenceCloneMethod extends Recipe {
+    private static final MethodMatcher REFERENCE_CLONE = new MethodMatcher("java.lang.ref.Reference clone()", true);
+
+    @Override
+    public String getDisplayName() {
+        return "Remove the use of `java.lang.ref.Reference.clone()` method";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The recipe replaces any clone calls that may resolve to a `java.lang.ref.Reference.clone()` " +
+                "or any of its known subclasses: `java.lang.ref.PhantomReference`, `java.lang.ref.SoftReference`, and `java.lang.ref.WeakReference` " +
+                "with a constructor call passing in the referent and reference queue as parameters.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check( new UsesMethod<>(REFERENCE_CLONE), new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        super.visitMethodInvocation(method, ctx);
+                        if (REFERENCE_CLONE.matches(method)) {
+                            Expression methodRef = method.getSelect();
+                            assert method.getSelect() != null;
+                            String argumentName = ((J.Identifier) method.getSelect()).getSimpleName();
+                            if(methodRef.getType().toString()!=null) {
+                                String templateBuilder = "new " + methodRef.getType().toString() + "(" + argumentName + ", new ReferenceQueue<>())";
+                                JavaTemplate newReference = JavaTemplate.builder(templateBuilder)
+                                        .contextSensitive()
+                                        .imports("java.lang.ref.ReferenceQueue")
+                                        .build();
+                                return newReference.apply(getCursor(), method.getCoordinates().replace());
+                            }
+                        }
+                        return method;
+                    }
+                }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -67,7 +67,7 @@ recipeList:
   - org.openrewrite.java.migrate.RemovedSecurityManagerMethods
   - org.openrewrite.java.migrate.UpgradePluginsForJava11
   - org.openrewrite.java.migrate.RemovedPolicy
-
+  - org.openrewrite.java.migrate.ReferenceCloneMethod
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.UpgradeBuildToJava11
@@ -249,3 +249,4 @@ recipeList:
       oldFullyQualifiedTypeName: javax.security.auth.Policy
       newFullyQualifiedTypeName: java.security.Policy
       ignoreDefinition: true
+

--- a/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
@@ -28,6 +28,7 @@ class ReferenceCloneMethodTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
     }
 
+    @DocumentExample
     @Test
     void referenceCloneRemoval() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ReferenceCloneMethodTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+    }
+
+    @Test
+    void referenceCloneRemoval() {
+        rewriteRun(
+          spec -> spec.recipe(new ReferenceCloneMethod()),
+          //language=java
+          java(
+            """         
+              import java.lang.ref.WeakReference;
+              import java.lang.ref.SoftReference;
+              import java.lang.ref.PhantomReference;
+                           
+              public class TestReference<T>{       
+                  public static void main(String[] args)throws InterruptedException,CloneNotSupportedException{
+                      WeakReference<Object> ref = new WeakReference<Object>(null);
+                      WeakReference<Object> ref1 = (WeakReference<Object>) ref.clone();
+                      SoftReference<Object> ref3 = new SoftReference<Object>(null);
+                      SoftReference<Object> ref4 = (SoftReference<Object>) ref3.clone();
+                      PhantomReference<Object> ref5 = new PhantomReference<Object>(null,null);
+                      PhantomReference<Object> ref6 = (PhantomReference<Object>) ref5.clone();
+                  }
+               }
+              """,
+            """           
+              import java.lang.ref.WeakReference;
+              import java.lang.ref.SoftReference;
+              import java.lang.ref.PhantomReference;
+              
+              public class TestReference<T>{      \s
+                  public static void main(String[] args)throws InterruptedException,CloneNotSupportedException{
+                      WeakReference<Object> ref = new WeakReference<Object>(null);
+                      WeakReference<Object> ref1 = (WeakReference<Object>) new java.lang.ref.WeakReference<java.lang.Object>(ref, new ReferenceQueue<>());
+                      SoftReference<Object> ref3 = new SoftReference<Object>(null);
+                      SoftReference<Object> ref4 = (SoftReference<Object>) new java.lang.ref.SoftReference<java.lang.Object>(ref3, new ReferenceQueue<>());
+                      PhantomReference<Object> ref5 = new PhantomReference<Object>(null,null);
+                      PhantomReference<Object> ref6 = new PhantomReference<Object>(ref5, new ReferenceQueue<>());
+                  }
+               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noCloneRemoval() {
+        rewriteRun(
+          spec -> spec.recipe(new ReferenceCloneMethod()),
+          //language=java
+          java(
+            """                   
+              public class ClonableClass implements Cloneable {
+                	public ClonableClass(int id) {      		
+                	}         
+                	@Override
+                	public Object clone() throws CloneNotSupportedException {
+                		return super.clone();
+                	}
+              }                
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 

--- a/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
@@ -54,14 +54,14 @@ class ReferenceCloneMethodTest implements RewriteTest {
               import java.lang.ref.SoftReference;
               import java.lang.ref.PhantomReference;
               
-              public class TestReference<T>{      \s
+              public class TestReference<T>{      
                   public static void main(String[] args)throws InterruptedException,CloneNotSupportedException{
                       WeakReference<Object> ref = new WeakReference<Object>(null);
                       WeakReference<Object> ref1 = (WeakReference<Object>) new java.lang.ref.WeakReference<java.lang.Object>(ref, new ReferenceQueue<>());
                       SoftReference<Object> ref3 = new SoftReference<Object>(null);
                       SoftReference<Object> ref4 = (SoftReference<Object>) new java.lang.ref.SoftReference<java.lang.Object>(ref3, new ReferenceQueue<>());
                       PhantomReference<Object> ref5 = new PhantomReference<Object>(null,null);
-                      PhantomReference<Object> ref6 = new PhantomReference<Object>(ref5, new ReferenceQueue<>());
+                      PhantomReference<Object> ref6 = (PhantomReference<Object>) new java.lang.ref.PhantomReference<java.lang.Object>(ref5, new ReferenceQueue<>());
                   }
                }
               """

--- a/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
@@ -26,13 +26,13 @@ class ReferenceCloneMethodTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReferenceCloneMethod());
     }
 
     @DocumentExample
     @Test
     void referenceCloneRemoval() {
         rewriteRun(
-          spec -> spec.recipe(new ReferenceCloneMethod()),
           //language=java
           java(
             """
@@ -59,11 +59,11 @@ class ReferenceCloneMethodTest implements RewriteTest {
               class Foo {
                   void foo() throws Exception{
                       WeakReference<Object> ref = new WeakReference<Object>(null);
-                      WeakReference<Object> ref1 = (WeakReference<Object>) new java.lang.ref.WeakReference<java.lang.Object>(ref, new ReferenceQueue<>());
+                      WeakReference<Object> ref1 = new WeakReference<Object>(ref, new ReferenceQueue<>());
                       SoftReference<Object> ref3 = new SoftReference<Object>(null);
-                      SoftReference<Object> ref4 = (SoftReference<Object>) new java.lang.ref.SoftReference<java.lang.Object>(ref3, new ReferenceQueue<>());
+                      SoftReference<Object> ref4 = new SoftReference<Object>(ref3, new ReferenceQueue<>());
                       PhantomReference<Object> ref5 = new PhantomReference<Object>(null,null);
-                      PhantomReference<Object> ref6 = (PhantomReference<Object>) new java.lang.ref.PhantomReference<java.lang.Object>(ref5, new ReferenceQueue<>());
+                      PhantomReference<Object> ref6 = new PhantomReference<Object>(ref5, new ReferenceQueue<>());
                   }
                }
               """
@@ -74,7 +74,6 @@ class ReferenceCloneMethodTest implements RewriteTest {
     @Test
     void noCloneRemoval() {
         rewriteRun(
-          spec -> spec.recipe(new ReferenceCloneMethod()),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReferenceCloneMethodTest.java
@@ -35,13 +35,13 @@ class ReferenceCloneMethodTest implements RewriteTest {
           spec -> spec.recipe(new ReferenceCloneMethod()),
           //language=java
           java(
-            """         
+            """
               import java.lang.ref.WeakReference;
               import java.lang.ref.SoftReference;
               import java.lang.ref.PhantomReference;
-                           
-              public class TestReference<T>{       
-                  public static void main(String[] args)throws InterruptedException,CloneNotSupportedException{
+
+              class Foo {
+                  void foo() throws Exception{
                       WeakReference<Object> ref = new WeakReference<Object>(null);
                       WeakReference<Object> ref1 = (WeakReference<Object>) ref.clone();
                       SoftReference<Object> ref3 = new SoftReference<Object>(null);
@@ -51,13 +51,13 @@ class ReferenceCloneMethodTest implements RewriteTest {
                   }
                }
               """,
-            """           
+            """
               import java.lang.ref.WeakReference;
               import java.lang.ref.SoftReference;
               import java.lang.ref.PhantomReference;
-              
-              public class TestReference<T>{      
-                  public static void main(String[] args)throws InterruptedException,CloneNotSupportedException{
+
+              class Foo {
+                  void foo() throws Exception{
                       WeakReference<Object> ref = new WeakReference<Object>(null);
                       WeakReference<Object> ref1 = (WeakReference<Object>) new java.lang.ref.WeakReference<java.lang.Object>(ref, new ReferenceQueue<>());
                       SoftReference<Object> ref3 = new SoftReference<Object>(null);
@@ -77,15 +77,16 @@ class ReferenceCloneMethodTest implements RewriteTest {
           spec -> spec.recipe(new ReferenceCloneMethod()),
           //language=java
           java(
-            """                   
-              public class ClonableClass implements Cloneable {
-                	public ClonableClass(int id) {      		
-                	}         
-                	@Override
-                	public Object clone() throws CloneNotSupportedException {
-                		return super.clone();
-                	}
-              }                
+            """
+              class ClonableClass implements Cloneable {
+                public ClonableClass(int id) {
+                }
+
+                @Override
+                public Object clone() throws CloneNotSupportedException {
+                  return super.clone();
+                }
+              }
               """
           )
         );


### PR DESCRIPTION

## What's changed?

This PR contains recipe:
org.openrewrite.java.migrate.ReferenceCloneMethod
This rule:
![image](https://github.com/openrewrite/rewrite-migrate-java/assets/93149514/d2234933-4aa3-49d9-a977-a082d8894a00)

## What's your motivation?
The custom recipe, replaces the calls to `java.lang.ref.Reference.clone()` with a constructor call passing in the referent and reference queue as parameters.

## Anyone you would like to review specifically?
@timtebeek 
@cjobinabo 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
