### PR TITLE
Adding all org.glassfish.main migrations to jakarta

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -332,12 +332,6 @@ recipeList:
       newArtifactId: jakarta.ejb-api
       newVersion: latest.release
   - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: javax.ejb
-      oldArtifactId: javax.ejb
-      newGroupId: jakarta.ejb
-      newArtifactId: jakarta.ejb-api
-      newVersion: latest.release
-  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.glassfish.main
       oldArtifactId: javax.ejb
       newGroupId: jakarta.ejb

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -397,6 +397,12 @@ recipeList:
       newGroupId: jakarta.faces
       newArtifactId: jakarta.faces-api
       newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish
+      oldArtifactId: javax.faces
+      newGroupId: org.glassfish
+      newArtifactId: jakarta.faces
+      newVersion: latest.release
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.faces
       artifactId: jakarta.faces-api

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -104,6 +104,12 @@ recipeList:
       newGroupId: jakarta.annotation
       newArtifactId: jakarta.annotation-api
       newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.annotation
+      newGroupId: jakarta.annotation
+      newArtifactId: jakarta.annotation-api
+      newVersion: latest.release
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Generated
       newFullyQualifiedTypeName: jakarta.annotation.Generated
@@ -192,6 +198,12 @@ recipeList:
       newGroupId: jakarta.authentication
       newArtifactId: jakarta.authentication-api
       newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.security.auth.message
+      newGroupId: jakarta.authentication
+      newArtifactId: jakarta.authentication-api
+      newVersion: latest.release
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.authentication
       artifactId: jakarta.authentication-api
@@ -215,6 +227,12 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: javax.security.jacc
       oldArtifactId: javax.security.jacc-api
+      newGroupId: jakarta.authorization
+      newArtifactId: jakarta.authorization-api
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.security.jacc
       newGroupId: jakarta.authorization
       newArtifactId: jakarta.authorization-api
       newVersion: latest.release
@@ -319,7 +337,12 @@ recipeList:
       newGroupId: jakarta.ejb
       newArtifactId: jakarta.ejb-api
       newVersion: latest.release
-
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.ejb
+      newGroupId: jakarta.ejb
+      newArtifactId: jakarta.ejb-api
+      newVersion: latest.release
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.ejb
       artifactId: jakarta.ejb-api
@@ -377,12 +400,6 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: javax.faces
       oldArtifactId: javax.faces-api
-      newGroupId: jakarta.faces
-      newArtifactId: jakarta.faces-api
-      newVersion: latest.release
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.glassfish
-      oldArtifactId: javax.faces
       newGroupId: jakarta.faces
       newArtifactId: jakarta.faces-api
       newVersion: latest.release
@@ -456,6 +473,12 @@ recipeList:
       newGroupId: jakarta.jms
       newArtifactId: jakarta.jms-api
       newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.jms
+      newGroupId: jakarta.jms
+      newArtifactId: jakarta.jms-api
+      newVersion: latest.release
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.jms
       artifactId: jakarta.jms-api
@@ -493,6 +516,12 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: javax.jws
       oldArtifactId: javax.jws-api
+      newGroupId: jakarta.jws
+      newArtifactId: jakarta.jws-api
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.jws
       newGroupId: jakarta.jws
       newArtifactId: jakarta.jws-api
       newVersion: latest.release
@@ -562,6 +591,12 @@ recipeList:
       newGroupId: jakarta.resource
       newArtifactId: jakarta.resource-api
       newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.resource
+      newGroupId: jakarta.resource
+      newArtifactId: jakarta.resource-api
+      newVersion: latest.release
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.resource
       artifactId: jakarta.resource-api
@@ -623,6 +658,12 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: javax.transaction
       oldArtifactId: javax.transaction-api
+      newGroupId: jakarta.transaction
+      newArtifactId: jakarta.transaction-api
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.glassfish.main
+      oldArtifactId: javax.transaction
       newGroupId: jakarta.transaction
       newArtifactId: jakarta.transaction-api
       newVersion: latest.release

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -313,6 +313,13 @@ recipeList:
       newGroupId: jakarta.ejb
       newArtifactId: jakarta.ejb-api
       newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.ejb
+      oldArtifactId: javax.ejb
+      newGroupId: jakarta.ejb
+      newArtifactId: jakarta.ejb-api
+      newVersion: latest.release
+
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.ejb
       artifactId: jakarta.ejb-api


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added migrations for all Java EE APIs under the organization org.glassfish.main. Added a migration for java.ejb:javax.ejb to jakarta.ejb. These changes are implemented in the org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta Recipe.

## What's your motivation?
https://rewriteoss.slack.com/archives/C01A843MWG5/p1721228381110469

## Any additional context
Should I implement tests for each case? As far as I see the other migrations of this recipe don't have tests and I'm not sure what for I would be testing other than typos anyways.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
