### PR TITLE
fix: UseEnumSetOf should ignore array and varargs parameters

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
@@ -67,6 +67,10 @@ public class UseEnumSetOf extends Recipe {
                             maybeAddImport("java.util.EnumSet");
 
                             List<Expression> args = m.getArguments();
+                            if (isArrayParameter(args)) {
+                                return m;
+                            }
+
                             StringJoiner setOf = new StringJoiner(", ", "EnumSet.of(", ")");
                             args.forEach(o -> setOf.add("#{any()}"));
 
@@ -92,6 +96,14 @@ public class UseEnumSetOf extends Recipe {
                     }
                 }
                 return false;
+            }
+
+            private boolean isArrayParameter(final List<Expression> args) {
+                if (args.size() != 1) {
+                    return false;
+                }
+                JavaType type = args.get(0).getType();
+                return TypeUtils.asArray(type) != null;
             }
         });
     }

--- a/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
@@ -39,7 +39,7 @@ class UseEnumSetOfTest implements RewriteTest {
             java(
               """
                 import java.util.Set;
-                                
+
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -52,7 +52,7 @@ class UseEnumSetOfTest implements RewriteTest {
               """
                 import java.util.EnumSet;
                 import java.util.Set;
-                                
+
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -76,7 +76,7 @@ class UseEnumSetOfTest implements RewriteTest {
             java(
               """
                 import java.util.Set;
-                                
+
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -90,7 +90,7 @@ class UseEnumSetOfTest implements RewriteTest {
               """
                 import java.util.EnumSet;
                 import java.util.Set;
-                                
+
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -122,7 +122,7 @@ class UseEnumSetOfTest implements RewriteTest {
                         RED, GREEN, BLUE
                     }
                     public void method(final Color... colors) {
-                        final Set<Color> s = Set.of(colors);
+                        Set<Color> s = Set.of(colors);
                     }
                 }
                 """
@@ -147,8 +147,8 @@ class UseEnumSetOfTest implements RewriteTest {
                         RED, GREEN, BLUE
                     }
                     public void method() {
-                        final Color[] colors = {};
-                        final Set<Color> s = Set.of(colors);
+                        Color[] colors = {};
+                        Set<Color> s = Set.of(colors);
                     }
                 }
                 """

--- a/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate.util;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -97,6 +98,57 @@ class UseEnumSetOfTest implements RewriteTest {
                     public void method() {
                         Set<Color> warm;
                         warm = EnumSet.of(Color.RED);
+                    }
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/516")
+    void dontChangeVarargs() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+
+                class Test {
+                    public enum Color {
+                        RED, GREEN, BLUE
+                    }
+                    public void method(final Color... colors) {
+                        final Set<Color> s = Set.of(colors);
+                    }
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/516")
+    void dontChangeArray() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+
+                class Test {
+                    public enum Color {
+                        RED, GREEN, BLUE
+                    }
+                    public void method() {
+                        final Color[] colors = {};
+                        final Set<Color> s = Set.of(colors);
                     }
                 }
                 """


### PR DESCRIPTION
EnumSet doesn't have the equivalent of `Set.of(arr[])`. For now, let's just skip those cases and bail out.

Fixes #516.
