### PR TITLE
Replace `Paths.get` with `Path.of`

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -50,6 +50,7 @@ recipeList:
   - org.openrewrite.java.migrate.logging.JavaLoggingAPIs
   - org.openrewrite.java.migrate.lombok.UpdateLombokToJava11
   - org.openrewrite.java.migrate.net.JavaNetAPIs
+  - org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
   - org.openrewrite.java.migrate.sql.JavaSqlAPIs
   - org.openrewrite.java.migrate.javax.JavaxLangModelUtil
   - org.openrewrite.java.migrate.javax.JavaxManagementMonitorAPIs
@@ -265,3 +266,19 @@ recipeList:
       methodPattern: java.lang.Thread destroy()
   - org.openrewrite.java.migrate.RemoveMethodInvocation:
       methodPattern: java.lang.Thread stop(java.lang.Throwable)
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
+displayName: Replace `Paths.get` with `Path.of`
+description: >-
+  The `java.nio.file.Paths.get` method was introduced in Java SE 7. The `java.nio.file.Path.of` method was introduced in
+  Java SE 11. This recipe replaces all usages of `Paths.get` with `Path.of` for consistency.
+tags:
+  - java11
+recipeList:
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: java.nio.file.Paths get(..)
+      fullyQualifiedTargetTypeName: java.nio.file.Path
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.nio.file.Path get(..)
+      newMethodName: of

--- a/src/test/java/org/openrewrite/java/migrate/nio/file/PathsGetToPathOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/nio/file/PathsGetToPathOfTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.nio.file;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class PathsGetToPathOfTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.migrate.Java8toJava11");
+    }
+
+    @Test
+    @DocumentExample
+    void convertPathsGetToPathOf() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.nio.file.Path;
+              import java.nio.file.Paths;
+              import java.net.URI;
+              class A {
+                  Path pathA = Paths.get("path");
+                  Path pathB = Paths.get("path", "subpath");
+                  Path pathC = Paths.get(URI.create("file:///path"));
+              }
+              """,
+            """
+              import java.nio.file.Path;
+              import java.net.URI;
+              class A {
+                  Path pathA = Path.of("path");
+                  Path pathB = Path.of("path", "subpath");
+                  Path pathC = Path.of(URI.create("file:///path"));
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
The `java.nio.file.Paths.get` method was introduced in Java SE 7. The `java.nio.file.Path.of` method was introduced in Java SE 11. This recipe replaces all usages of `Paths.get` with `Path.of` for consistency.

## java.nio.file.Paths:
> API Note:
It is recommended to obtain a Path via the Path. of methods instead of via the get methods defined in this class as this class may be deprecated in a future release.