### PR TITLE
Upgrade Scala dependencies as part of Java 11 upgrade

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -72,6 +72,7 @@ recipeList:
   - org.openrewrite.java.migrate.ReplaceAWTGetPeerMethod:
       getPeerMethodPattern: java.awt.* getPeer()
       lightweightPeerFQCN: java.awt.peer.LightweightPeer
+  - org.openrewrite.scala.migrate.UpgradeScala_2_12
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.UpgradeBuildToJava11

--- a/src/main/resources/META-INF/rewrite/scala.yml
+++ b/src/main/resources/META-INF/rewrite/scala.yml
@@ -1,0 +1,30 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# As per: https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.scala.migrate.UpgradeScala_2_12
+displayName: Migrate to Scala 2.12.+
+description: >-
+  Upgrade the Scala version for compatibility with newer Java versions.
+tags:
+  - scala
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.scala-lang
+      artifactId: scala-*
+      newVersion: 2.12.x

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeScalaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeScalaTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class UpgradeScalaTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource(
+          "/META-INF/rewrite/scala.yml",
+          "org.openrewrite.scala.migrate.UpgradeScala_2_12");
+    }
+
+    @DocumentExample
+    @Test
+    void upgradeScalaDependencies() {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                    <version>2.12.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            after -> after.after(str -> str).afterRecipe(
+              doc -> assertThat(doc.getRoot()
+                .getChild("dependencies").get()
+                .getChild("dependency").get()
+                .getChildValue("version").get())
+                .matches("2.12.[1-9]\\d"))
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's your motivation?
Necessary as per the compatibility matrix for Scala and current Java versions.
https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html

