### PR TITLE
Recipe ReplaceLocalizedStreamMethods

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -61,7 +61,7 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
     @Override
     public String getDescription() {
         return "Replaces `Runtime.getLocalizedInputStream(InputStream)` and `Runtime.getLocalizedOutputStream(OutputStream)` with their direct arguments. " +
-               "This modification is made because the previous implementation of `getLocalizedInputStream` and `getLocalizedOutputStream` merely returned the arguments provided";
+               "This modification is made because the previous implementation of `getLocalizedInputStream` and `getLocalizedOutputStream` merely returned the arguments provided.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -1,0 +1,55 @@
+package org.openrewrite.java.migrate;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ReplaceLocalizedStreamMethods extends Recipe {
+
+    @Option(displayName = "Method pattern to replace",
+            description = "The method pattern to match and replace.",
+            example = "java.lang.Runtime getLocalizedInputStream(java.io.InputStream)")
+    String localizedInputStreamMethodMatcher = "java.lang.Runtime getLocalizedInputStream(java.io.InputStream)";
+
+    @Option(displayName = "Method pattern to replace",
+            description = "The method pattern to match and replace.",
+            example = "java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)")
+    String localizedOutputStreamMethodMatcher = "java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)";
+
+    @Override
+    public String getDisplayName() {
+        return "Replace getLocalizedInputStream with direct assignment";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces `InputStream new = rt.getLocalizedInputStream(in);` with `InputStream new = in;`.";
+    }
+
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+            private final MethodMatcher LocalizedInputStreamMethod = new MethodMatcher(localizedInputStreamMethodMatcher, false);
+            private final MethodMatcher localizedOutputStreamMethod = new MethodMatcher(localizedOutputStreamMethodMatcher, false);
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+                if (LocalizedInputStreamMethod.matches(mi) || localizedOutputStreamMethod.matches(mi)) {
+                    Expression parameter = mi.getArguments().get(0);
+                    parameter = parameter.withPrefix(Space.SINGLE_SPACE);
+                    return parameter;
+                }
+                return super.visitMethodInvocation(mi, ctx);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -60,8 +60,8 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Replaces `Runtime.getLocalizedInputStream(InputStream)` and `Runtime.getLocalizedOutputStream(OutputStream)` with their direct arguments." +
-                "This modification is made because the previous implementation of `getLocalizedInputStream` and `getLocalizedOutputStream` merely returned the arguments provided";
+        return "Replaces `Runtime.getLocalizedInputStream(InputStream)` and `Runtime.getLocalizedOutputStream(OutputStream)` with their direct arguments. " +
+               "This modification is made because the previous implementation of `getLocalizedInputStream` and `getLocalizedOutputStream` merely returned the arguments provided";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -60,7 +60,8 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Replace `Runtime.getLocalizedInputStream(InputStream)` and `Runtime.getLocalizedOutputStream(with the argument)` with their direct arguments.";
+        return "Replaces `Runtime.getLocalizedInputStream(InputStream)` and `Runtime.getLocalizedOutputStream(OutputStream)` with their direct arguments." +
+                "This modification is made because the previous implementation of `getLocalizedInputStream` and `getLocalizedOutputStream` merely returned the arguments provided";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -63,6 +63,7 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
         return "Replaces `InputStream new = rt.getLocalizedInputStream(in);` with `InputStream new = in;`.";
     }
 
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
             private final MethodMatcher LocalizedInputStreamMethod = new MethodMatcher(localizedInputStreamMethodMatcher, false);

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -71,9 +71,7 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
                 if (LocalizedInputStreamMethod.matches(mi) || localizedOutputStreamMethod.matches(mi)) {
-                    Expression parameter = mi.getArguments().get(0);
-                    parameter = parameter.withPrefix(Space.SINGLE_SPACE);
-                    return parameter;
+                    return mi.getArguments().get(0).withPrefix(mi.getPrefix());
                 }
                 return super.visitMethodInvocation(mi, ctx);
             }

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
@@ -19,12 +36,22 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
     @Option(displayName = "Method pattern to replace",
             description = "The method pattern to match and replace.",
             example = "java.lang.Runtime getLocalizedInputStream(java.io.InputStream)")
-    String localizedInputStreamMethodMatcher = "java.lang.Runtime getLocalizedInputStream(java.io.InputStream)";
+    String localizedInputStreamMethodMatcher;
 
     @Option(displayName = "Method pattern to replace",
             description = "The method pattern to match and replace.",
             example = "java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)")
-    String localizedOutputStreamMethodMatcher = "java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)";
+    String localizedOutputStreamMethodMatcher;
+
+    @JsonCreator
+    public ReplaceLocalizedStreamMethods(
+            @Nullable String localizedInputStreamMethodMatcher,
+            @Nullable String localizedOutputStreamMethodMatcher) {
+        this.localizedInputStreamMethodMatcher = localizedInputStreamMethodMatcher == null ?
+                "java.lang.Runtime getLocalizedInputStream(java.io.InputStream)" : localizedInputStreamMethodMatcher;
+        this.localizedOutputStreamMethodMatcher = localizedOutputStreamMethodMatcher == null ?
+                "java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)" : localizedOutputStreamMethodMatcher;
+    }
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -55,12 +55,12 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Replace getLocalizedInputStream with direct assignment";
+        return "Replace getLocalizedInputStream and getLocalizedOutputStream with direct assignment";
     }
 
     @Override
     public String getDescription() {
-        return "Replaces `InputStream new = rt.getLocalizedInputStream(in);` with `InputStream new = in;`.";
+        return "Replaces `InputStream new = rt.getLocalizedInputStream(in);` with `InputStream new = in;` and `OutputStream new = rt.getLocalizedOutputStream(out);` with `OutputStream new = out;`.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethods.java
@@ -55,12 +55,12 @@ public class ReplaceLocalizedStreamMethods extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Replace getLocalizedInputStream and getLocalizedOutputStream with direct assignment";
+        return "Replace `getLocalizedInputStream` and `getLocalizedOutputStream` with direct assignment";
     }
 
     @Override
     public String getDescription() {
-        return "Replaces `InputStream new = rt.getLocalizedInputStream(in);` with `InputStream new = in;` and `OutputStream new = rt.getLocalizedOutputStream(out);` with `OutputStream new = out;`.";
+        return "Replace `Runtime.getLocalizedInputStream(InputStream)` and `Runtime.getLocalizedOutputStream(with the argument)` with their direct arguments.";
     }
 
     @Override

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -73,9 +73,7 @@ recipeList:
       getPeerMethodPattern: java.awt.* getPeer()
       lightweightPeerFQCN: java.awt.peer.LightweightPeer
   - org.openrewrite.scala.migrate.UpgradeScala_2_12
-  - org.openrewrite.java.migrate.ReplaceLocalizedStreamMethods:
-      localizedInputStreamMethodMatcher: java.lang.Runtime getLocalizedInputStream(java.io.InputStream)
-      localizedOutputStreamMethodMatcher: java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)
+  - org.openrewrite.java.migrate.ReplaceLocalizedStreamMethods
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -73,7 +73,6 @@ recipeList:
       getPeerMethodPattern: java.awt.* getPeer()
       lightweightPeerFQCN: java.awt.peer.LightweightPeer
   - org.openrewrite.scala.migrate.UpgradeScala_2_12
-  - org.openrewrite.java.migrate.RemovedLogManagerPropertyChangeListenerMethods
   - org.openrewrite.java.migrate.ReplaceLocalizedStreamMethods:
       localizedInputStreamMethodMatcher: java.lang.Runtime getLocalizedInputStream(java.io.InputStream)
       localizedOutputStreamMethodMatcher: java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -73,6 +73,11 @@ recipeList:
       getPeerMethodPattern: java.awt.* getPeer()
       lightweightPeerFQCN: java.awt.peer.LightweightPeer
   - org.openrewrite.scala.migrate.UpgradeScala_2_12
+  - org.openrewrite.java.migrate.RemovedLogManagerPropertyChangeListenerMethods
+  - org.openrewrite.java.migrate.ReplaceLocalizedStreamMethods:
+      localizedInputStreamMethodMatcher: java.lang.Runtime getLocalizedInputStream(java.io.InputStream)
+      localizedOutputStreamMethodMatcher: java.lang.Runtime getLocalizedOutputStream(java.io.OutputStream)
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.UpgradeBuildToJava11

--- a/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
@@ -1,36 +1,52 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
-    //language=java
-    String LocalizedStreamMethodsClass = """
-           
-            package com.test;
-            import java.io.InputStream;
-            import java.io.OutputStream;
-
-            public class Runtime1 {
-
-             public InputStream getLocalizedInputStream1(InputStream in) {
-                return in;
-             }
-            
-            public OutputStream getLocalizedOutputStream1(OutputStream out) {
-                return out;
-           }
-            
-      }
-           """;
+class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new ReplaceLocalizedStreamMethods("com.test.Runtime1 getLocalizedInputStream1(java.io.InputStream)", "com.test.Runtime1 getLocalizedOutputStream1(java.io.OutputStream)"));
+        spec
+          .parser(JavaParser.fromJavaVersion().dependsOn(
+            //language=java
+            """
+              package com.test;
+              import java.io.InputStream;
+              import java.io.OutputStream;
+              public class Runtime1 {
+                  public InputStream getLocalizedInputStream1(InputStream in) {
+                      return in;
+                  }
+                  public OutputStream getLocalizedOutputStream1(OutputStream out) {
+                      return out;
+                  }
+              }
+              """
+          ))
+          .recipe(new ReplaceLocalizedStreamMethods(
+            "com.test.Runtime1 getLocalizedInputStream1(java.io.InputStream)",
+            "com.test.Runtime1 getLocalizedOutputStream1(java.io.OutputStream)"));
     }
 
     @Test
@@ -38,12 +54,11 @@ public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
     void replaceGetLocalizedInputStream() {
         rewriteRun(
           //language=java
-          java(LocalizedStreamMethodsClass),
           java(
             """
               package com.test;
               import java.io.InputStream;
-                                
+
               class Test {
                   void exampleMethod(InputStream in) {
                       Runtime1 rt = null;
@@ -54,7 +69,7 @@ public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
             """
               package com.test;
               import java.io.InputStream;
-                                
+
               class Test {
                   void exampleMethod(InputStream in) {
                       Runtime1 rt = null;
@@ -70,12 +85,11 @@ public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
     void replaceGetLocalizedOutputStream() {
         rewriteRun(
           //language=java
-          java(LocalizedStreamMethodsClass),
           java(
             """
               package com.test;
               import java.io.OutputStream;
-                        
+
               class Test {
                   void exampleMethod(OutputStream out) {
                       Runtime1 rt = null;
@@ -86,7 +100,7 @@ public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
             """
               package com.test;
               import java.io.OutputStream;
-                        
+
               class Test {
                   void exampleMethod(OutputStream out) {
                       Runtime1 rt = null;
@@ -98,4 +112,3 @@ public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
         );
     }
 }
-

--- a/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
@@ -1,0 +1,100 @@
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceLocalizedStreamMethods("com.test.Runtime1 getLocalizedInputStream1(java.io.InputStream)", "com.test.Runtime1 getLocalizedOutputStream1(java.io.OutputStream)"));
+    }
+
+    //language=java
+    String LocalizedStreamMethodsClass = """
+      
+       package com.test;
+       import java.io.InputStream;
+       import java.io.OutputStream;
+
+       public class Runtime1 {
+
+        public InputStream getLocalizedInputStream1(InputStream in) {
+           return in;
+        }
+       
+       public OutputStream getLocalizedOutputStream1(OutputStream out) {
+           return out;
+      }
+       
+ }
+      """;
+
+        @Test
+        @DocumentExample
+        void replaceGetLocalizedInputStream() {
+            rewriteRun(
+              //language=java
+              java(LocalizedStreamMethodsClass),
+              java(
+                """
+                  package com.test;
+                  import java.io.InputStream;
+                  
+                  class Test {
+                      void exampleMethod(InputStream in) {
+                          Runtime1 rt = null;
+                          InputStream newStream = rt.getLocalizedInputStream1(in);
+                      }
+                  }
+                  """,
+                """
+                  package com.test;
+                  import java.io.InputStream;
+                  
+                  class Test {
+                      void exampleMethod(InputStream in) {
+                          Runtime1 rt = null;
+                          InputStream newStream = in;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+@Test
+void replaceGetLocalizedOutputStream() {
+    rewriteRun(
+      //language=java
+      java(LocalizedStreamMethodsClass),
+      java(
+        """
+          package com.test;
+          import java.io.OutputStream;
+          
+          class Test {
+              void exampleMethod(OutputStream out) {
+                  Runtime1 rt = null;
+                  OutputStream newStream = rt.getLocalizedOutputStream1(out);
+              }
+          }
+          """,
+        """
+          package com.test;
+          import java.io.OutputStream;
+          
+          class Test {
+              void exampleMethod(OutputStream out) {
+                  Runtime1 rt = null;
+                  OutputStream newStream = out;
+              }
+          }
+          """
+      )
+    );
+}
+}

--- a/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
@@ -8,93 +8,94 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 public class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
+    //language=java
+    String LocalizedStreamMethodsClass = """
+           
+            package com.test;
+            import java.io.InputStream;
+            import java.io.OutputStream;
+
+            public class Runtime1 {
+
+             public InputStream getLocalizedInputStream1(InputStream in) {
+                return in;
+             }
+            
+            public OutputStream getLocalizedOutputStream1(OutputStream out) {
+                return out;
+           }
+            
+      }
+           """;
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceLocalizedStreamMethods("com.test.Runtime1 getLocalizedInputStream1(java.io.InputStream)", "com.test.Runtime1 getLocalizedOutputStream1(java.io.OutputStream)"));
     }
 
-    //language=java
-    String LocalizedStreamMethodsClass = """
-      
-       package com.test;
-       import java.io.InputStream;
-       import java.io.OutputStream;
-
-       public class Runtime1 {
-
-        public InputStream getLocalizedInputStream1(InputStream in) {
-           return in;
-        }
-       
-       public OutputStream getLocalizedOutputStream1(OutputStream out) {
-           return out;
-      }
-       
- }
-      """;
-
-        @Test
-        @DocumentExample
-        void replaceGetLocalizedInputStream() {
-            rewriteRun(
-              //language=java
-              java(LocalizedStreamMethodsClass),
-              java(
-                """
-                  package com.test;
-                  import java.io.InputStream;
-                  
-                  class Test {
-                      void exampleMethod(InputStream in) {
-                          Runtime1 rt = null;
-                          InputStream newStream = rt.getLocalizedInputStream1(in);
-                      }
+    @Test
+    @DocumentExample
+    void replaceGetLocalizedInputStream() {
+        rewriteRun(
+          //language=java
+          java(LocalizedStreamMethodsClass),
+          java(
+            """
+              package com.test;
+              import java.io.InputStream;
+                                
+              class Test {
+                  void exampleMethod(InputStream in) {
+                      Runtime1 rt = null;
+                      InputStream newStream = rt.getLocalizedInputStream1(in);
                   }
-                  """,
-                """
-                  package com.test;
-                  import java.io.InputStream;
-                  
-                  class Test {
-                      void exampleMethod(InputStream in) {
-                          Runtime1 rt = null;
-                          InputStream newStream = in;
-                      }
+              }
+              """,
+            """
+              package com.test;
+              import java.io.InputStream;
+                                
+              class Test {
+                  void exampleMethod(InputStream in) {
+                      Runtime1 rt = null;
+                      InputStream newStream = in;
                   }
-                  """
-              )
-            );
-        }
+              }
+              """
+          )
+        );
+    }
 
-@Test
-void replaceGetLocalizedOutputStream() {
-    rewriteRun(
-      //language=java
-      java(LocalizedStreamMethodsClass),
-      java(
-        """
-          package com.test;
-          import java.io.OutputStream;
-          
-          class Test {
-              void exampleMethod(OutputStream out) {
-                  Runtime1 rt = null;
-                  OutputStream newStream = rt.getLocalizedOutputStream1(out);
+    @Test
+    void replaceGetLocalizedOutputStream() {
+        rewriteRun(
+          //language=java
+          java(LocalizedStreamMethodsClass),
+          java(
+            """
+              package com.test;
+              import java.io.OutputStream;
+                        
+              class Test {
+                  void exampleMethod(OutputStream out) {
+                      Runtime1 rt = null;
+                      OutputStream newStream = rt.getLocalizedOutputStream1(out);
+                  }
               }
-          }
-          """,
-        """
-          package com.test;
-          import java.io.OutputStream;
-          
-          class Test {
-              void exampleMethod(OutputStream out) {
-                  Runtime1 rt = null;
-                  OutputStream newStream = out;
+              """,
+            """
+              package com.test;
+              import java.io.OutputStream;
+                        
+              class Test {
+                  void exampleMethod(OutputStream out) {
+                      Runtime1 rt = null;
+                      OutputStream newStream = out;
+                  }
               }
-          }
-          """
-      )
-    );
+              """
+          )
+        );
+    }
 }
-}
+

--- a/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ReplaceLocalizedStreamMethodsTest.java
@@ -60,8 +60,7 @@ class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
               import java.io.InputStream;
 
               class Test {
-                  void exampleMethod(InputStream in) {
-                      Runtime1 rt = null;
+                  void exampleMethod(Runtime1 rt, InputStream in) {
                       InputStream newStream = rt.getLocalizedInputStream1(in);
                   }
               }
@@ -71,8 +70,7 @@ class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
               import java.io.InputStream;
 
               class Test {
-                  void exampleMethod(InputStream in) {
-                      Runtime1 rt = null;
+                  void exampleMethod(Runtime1 rt, InputStream in) {
                       InputStream newStream = in;
                   }
               }
@@ -91,8 +89,7 @@ class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
               import java.io.OutputStream;
 
               class Test {
-                  void exampleMethod(OutputStream out) {
-                      Runtime1 rt = null;
+                  void exampleMethod(Runtime1 rt, OutputStream out) {
                       OutputStream newStream = rt.getLocalizedOutputStream1(out);
                   }
               }
@@ -102,8 +99,7 @@ class ReplaceLocalizedStreamMethodsTest implements RewriteTest {
               import java.io.OutputStream;
 
               class Test {
-                  void exampleMethod(OutputStream out) {
-                      Runtime1 rt = null;
+                  void exampleMethod(Runtime1 rt, OutputStream out) {
                       OutputStream newStream = out;
                   }
               }


### PR DESCRIPTION
## What's changed?
This PR contains recipe - org.openrewrite.java.migrate.ReplaceLocalizedStreamMethods
Rule:
![image](https://github.com/user-attachments/assets/cf33bcec-ce26-4c8a-b994-1b454bf56e9e)

## What's your motivation?
This custom recipe replaces the occurrences of Runtime.getLocalizedInputStream and Runtime.getLocalizedOutputStream methods. The occurrence of **getLocalizedInputStream**(in) is replaced with **in** parameter and **getLocalizedOutputStream**(out) is replaced with **out** parameter.


## Anyone you would like to review specifically?
@timtebeek @cjobinabo 

## Have you considered any alternatives or workarounds?
I created sample files, created a local plugin using
./gradlew publishToMavenLocal then ran it in the Java8 Sample App using mvn rewrite:dryRun

Attaching the rewrite.patch file
[rewrite.patch](https://github.com/user-attachments/files/16617170/rewrite.patch)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
