### PR TITLE
Handle generics in PreferJavaUtilObjectsRequireNonNull

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
@@ -42,7 +42,7 @@ public class NoGuavaRefaster {
     }
 
     @RecipeDescriptor(
-            name = "`Preconditions.checkNotNull` to `Objects.requireNonNull`",
+            name = "`Preconditions.checkNotNull` with message to `Objects.requireNonNull`",
             description = "Migrate from Guava `Preconditions.checkNotNull` to Java 8 `java.util.Objects.requireNonNull`."
     )
     public static class PreconditionsCheckNotNullWithMessageToObjectsRequireNonNull {

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
@@ -63,6 +63,7 @@ public class NoGuavaRefaster {
     )
     public static class StringValueOfString {
         @BeforeTemplate
+        @SuppressWarnings("UnnecessaryCallToStringValueOf")
         String before(String string) {
             return String.valueOf(string);
         }

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
@@ -31,6 +31,22 @@ public class NoGuavaRefaster {
     )
     public static class PreconditionsCheckNotNullToObjectsRequireNonNull {
         @BeforeTemplate
+        Object before(Object object) {
+            return com.google.common.base.Preconditions.checkNotNull(object);
+        }
+
+        @AfterTemplate
+        Object after(Object object) {
+            return java.util.Objects.requireNonNull(object);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "`Preconditions.checkNotNull` to `Objects.requireNonNull`",
+            description = "Migrate from Guava `Preconditions.checkNotNull` to Java 8 `java.util.Objects.requireNonNull`."
+    )
+    public static class PreconditionsCheckNotNullWithMessageToObjectsRequireNonNull {
+        @BeforeTemplate
         Object before(Object object, Object message) {
             return com.google.common.base.Preconditions.checkNotNull(object, message);
         }

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -42,7 +42,6 @@ recipeList:
   - org.openrewrite.java.migrate.guava.PreferJavaUtilSupplier
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsEquals
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsHashCode
-  - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNull
   - org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsUnmodifiableNavigableMap
   - org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsSynchronizedNavigableMap
   - org.openrewrite.java.migrate.guava.PreferCharCompare
@@ -213,21 +212,6 @@ recipeList:
       newMethodName: hash
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: com.google.common.base.Objects hash(..)
-      fullyQualifiedTargetTypeName: java.util.Objects
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNull
-displayName: Prefer `java.util.Objects#requireNonNull`
-description: Prefer `java.util.Objects#requireNonNull` instead of using `com.google.common.base.Preconditions#checkNotNull`.
-tags:
-  - guava
-recipeList:
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.google.common.base.Preconditions checkNotNull(Object)
-      newMethodName: requireNonNull
-  - org.openrewrite.java.ChangeMethodTargetToStatic:
-      methodPattern: com.google.common.base.Preconditions requireNonNull(Object)
       fullyQualifiedTargetTypeName: java.util.Objects
 
 ---

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
@@ -154,11 +154,11 @@ class PreferJavaUtilObjectsTest implements RewriteTest {
               }
               """,
             """
-              import static java.util.Objects.requireNonNull;
+              import java.util.Objects;
 
               class A {
                   Object foo(Object obj) {
-                      return requireNonNull(obj);
+                      return Objects.requireNonNull(obj);
                   }
               }
               """
@@ -168,6 +168,7 @@ class PreferJavaUtilObjectsTest implements RewriteTest {
 
     @Test
     void preconditionsCheckNotNullWithTemplateArgument() {
+        // There's no direct replacement for this three arg lenient format variant
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
@@ -59,6 +59,33 @@ class PreferJavaUtilObjectsTest implements RewriteTest {
     }
 
     @Test
+    void preconditionsCheckNotNullToObjectsRequireNonNullStringArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.base.Preconditions;
+
+              class A {
+                  String foo(String str) {
+                      return Preconditions.checkNotNull(str);
+                  }
+              }
+              """,
+            """
+              import java.util.Objects;
+
+              class A {
+                  String foo(String str) {
+                      return Objects.requireNonNull(str);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void preconditionsCheckNotNullToObjectsRequireNonNullTwoArguments() {
         rewriteRun(
           //language=java
@@ -132,6 +159,24 @@ class PreferJavaUtilObjectsTest implements RewriteTest {
               class A {
                   Object foo(Object obj) {
                       return requireNonNull(obj);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preconditionsCheckNotNullWithTemplateArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.base.Preconditions;
+
+              class A {
+                  Object foo(Object obj) {
+                      return Preconditions.checkNotNull(obj, "%s", "foo");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilObjectsTest.java
@@ -26,7 +26,7 @@ import static org.openrewrite.java.Assertions.java;
 class PreferJavaUtilObjectsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/no-guava.yml", "org.openrewrite.java.migrate.guava.NoGuava")
+        spec.recipe(new NoGuavaRefasterRecipes())
           .parser(JavaParser.fromJavaVersion().classpath("rewrite-java", "guava"));
     }
 


### PR DESCRIPTION
## What's changed?
Before this patch, the `PreferJavaUtilObjectsRequireNonNull` recipe would only migrate usage of exactly `checkNotNull(Object)` but not any other (sub)types such as `checkNotNull(String)`, `checkNotNull(CustomType)` etc.

We now match invocations of checkNotNull with exactly one or two arguments which makes the recipe more broadly applicable.

Note that there is also a three argument version that doesn't have a straight-forward replacement, I skipped that for now and added a testcase.

## What's your motivation?
Migrate more usage of Preconditions.checkNotNull throughout our codebase.

## Anything in particular you'd like reviewers to focus on?
The proposed implementation using refaster doesn't deal well with preserving the static import if one was used before. I'm not sure how to best handle that.

## Anyone you would like to review specifically?
@timtebeek since you added refaster support.

## Have you considered any alternatives or workarounds?
I have also tried modifying the method pattern to be `checkNotNull(*)` in no-guava.yml but that did not work as expected. I couldn't find other examples of using a wildcard match on an argument, maybe it isn't supported?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
