### PR TITLE
Recipes to migrate from Javax, Jakarta and JetBrains nullability annotations to JSpecify

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
-    testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
+    testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:1.3.5")
     testRuntimeOnly("com.google.code.findbugs:jsr305:3.0.2")
     testRuntimeOnly(gradleApi())
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
-    testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:1.3.5")
+    testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
+    testRuntimeOnly("com.google.code.findbugs:jsr305:3.0.2")
     testRuntimeOnly(gradleApi())
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
-    testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:1.3.5")
+    testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
     testRuntimeOnly("com.google.code.findbugs:jsr305:3.0.2")
     testRuntimeOnly(gradleApi())
 }

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -19,7 +19,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateToJspecify
 displayName: Migrate to JSpecify
 description: >-
-  This recipe will migrate to JSpecify annotations.
+  This recipe will migrate to JSpecify annotations from various other nullability annotation standards.
 tags:
   - java
 recipeList:
@@ -51,8 +51,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
-displayName: Migrate from jakarta annotation API to JSpecify
-description: Migrate from jakarta annotation API to JSpecify.
+displayName: Migrate from Jakarta annotation API to JSpecify
+description: Migrate from Jakarta annotation API to JSpecify.
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.jspecify
@@ -72,8 +72,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
-displayName: Migrate from jetbrains annotations to JSpecify
-description: Migrate from jetbrains annotations to JSpecify.
+displayName: Migrate from JetBrains annotations to JSpecify
+description: Migrate from JetBrains annotations to JSpecify.
 recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.jspecify

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -25,6 +25,7 @@ tags:
 recipeList:
   - org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
   - org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
+  - org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -47,7 +48,6 @@ recipeList:
       onlyIfUsing: org.jspecify.annotations..*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*
-
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
@@ -60,6 +60,27 @@ recipeList:
       ignoreDefinition: true
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: jakarta.annotation.Nonnull
+      newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
+      ignoreDefinition: true
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.jspecify
+      artifactId: jspecify
+      version: latest.release
+      onlyIfUsing: org.jspecify.annotations..*
+  - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
+      annotationType: org.jspecify.annotations.*
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
+displayName: Migrate from jetbrains annotations to jspecify
+description: Migrate from jetbrains annotations to jspecify.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.jetbrains.annotations.Nullable
+      newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.jetbrains.annotations.NotNull
       newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
       ignoreDefinition: true
   - org.openrewrite.java.dependencies.AddDependency:

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -17,9 +17,9 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateToJspecify
-displayName: Migrate to jspecify
+displayName: Migrate to JSpecify
 description: >-
-  This recipe will migrate to jspecify annotations.
+  This recipe will migrate to JSpecify annotations.
 tags:
   - java
 recipeList:
@@ -30,8 +30,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
-displayName: Migrate from javax annotation API to jspecify
-description: Migrate from javax annotation API to jspecify.
+displayName: Migrate from javax annotation API to JSpecify
+description: Migrate from javax annotation API to JSpecify.
 recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Nullable
@@ -51,8 +51,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
-displayName: Migrate from jakarta annotation API to jspecify
-description: Migrate from jakarta annotation API to jspecify.
+displayName: Migrate from jakarta annotation API to JSpecify
+description: Migrate from jakarta annotation API to JSpecify.
 recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: jakarta.annotation.Nullable
@@ -72,8 +72,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
-displayName: Migrate from jetbrains annotations to jspecify
-description: Migrate from jetbrains annotations to jspecify.
+displayName: Migrate from jetbrains annotations to JSpecify
+description: Migrate from jetbrains annotations to JSpecify.
 recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.jetbrains.annotations.Nullable

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -44,7 +44,7 @@ recipeList:
       groupId: org.jspecify
       artifactId: jspecify
       version: latest.release
-      onlyIfUsing: org.jspecify.annotations.*
+      onlyIfUsing: org.jspecify.annotations..*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*
 
@@ -66,6 +66,6 @@ recipeList:
       groupId: org.jspecify
       artifactId: jspecify
       version: latest.release
-      onlyIfUsing: org.jspecify.annotations.*
+      onlyIfUsing: org.jspecify.annotations..*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -1,0 +1,69 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jspecify.MigrateToJspecify
+displayName: Migrate to jspecify
+description: >-
+  This recipe will migrate to jspecify annotations.
+tags:
+  - java
+recipeList:
+  - org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
+  - org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
+displayName: Migrate to JSpecify
+description: Migrate from javax Annotation API to JSpecify.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.annotation.Nullable
+      newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.annotation.Nonnull
+      newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
+      ignoreDefinition: true
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.jspecify
+      artifactId: jspecify
+      version: latest.release
+  - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
+      annotationType: org.jspecify.annotations.*
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
+displayName: Migrate to JSpecify
+description: Migrate from Jakarta Annotation API to JSpecify.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.annotation.Nullable
+      newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.annotation.Nonnull
+      newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
+      ignoreDefinition: true
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.jspecify
+      artifactId: jspecify
+      version: latest.release
+  - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
+      annotationType: org.jspecify.annotations.*

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -29,8 +29,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
-displayName: Migrate to JSpecify
-description: Migrate from javax Annotation API to JSpecify.
+displayName: Migrate from javax annotation API to jspecify
+description: Migrate from javax annotation API to jspecify.
 recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Nullable
@@ -51,8 +51,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
-displayName: Migrate to JSpecify
-description: Migrate from Jakarta Annotation API to JSpecify.
+displayName: Migrate from jakarta annotation API to jspecify
+description: Migrate from jakarta annotation API to jspecify.
 recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: jakarta.annotation.Nullable

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -44,6 +44,7 @@ recipeList:
       groupId: org.jspecify
       artifactId: jspecify
       version: latest.release
+      onlyIfUsing: org.jspecify.annotations.*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*
 
@@ -65,5 +66,6 @@ recipeList:
       groupId: org.jspecify
       artifactId: jspecify
       version: latest.release
+      onlyIfUsing: org.jspecify.annotations.*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -33,6 +33,11 @@ name: org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
 displayName: Migrate from javax annotation API to JSpecify
 description: Migrate from javax annotation API to JSpecify.
 recipeList:
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.jspecify
+      artifactId: jspecify
+      version: latest.release
+      onlyIfUsing: javax.annotation.*ull*
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Nullable
       newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
@@ -41,11 +46,6 @@ recipeList:
       oldFullyQualifiedTypeName: javax.annotation.Nonnull
       newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
       ignoreDefinition: true
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: org.jspecify
-      artifactId: jspecify
-      version: latest.release
-      onlyIfUsing: org.jspecify.annotations..*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*
 ---
@@ -54,6 +54,11 @@ name: org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
 displayName: Migrate from jakarta annotation API to JSpecify
 description: Migrate from jakarta annotation API to JSpecify.
 recipeList:
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.jspecify
+      artifactId: jspecify
+      version: 1.0.0
+      onlyIfUsing: jakarta.annotation.*ull*
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: jakarta.annotation.Nullable
       newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
@@ -62,11 +67,6 @@ recipeList:
       oldFullyQualifiedTypeName: jakarta.annotation.Nonnull
       newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
       ignoreDefinition: true
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: org.jspecify
-      artifactId: jspecify
-      version: latest.release
-      onlyIfUsing: org.jspecify.annotations..*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*
 ---
@@ -75,6 +75,11 @@ name: org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
 displayName: Migrate from jetbrains annotations to JSpecify
 description: Migrate from jetbrains annotations to JSpecify.
 recipeList:
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.jspecify
+      artifactId: jspecify
+      version: 1.0.0
+      onlyIfUsing: org.jetbrains.annotations.*ull*
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.jetbrains.annotations.Nullable
       newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
@@ -83,10 +88,5 @@ recipeList:
       oldFullyQualifiedTypeName: org.jetbrains.annotations.NotNull
       newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
       ignoreDefinition: true
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: org.jspecify
-      artifactId: jspecify
-      version: latest.release
-      onlyIfUsing: org.jspecify.annotations..*
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
@@ -36,14 +36,14 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
     @Test
     void addDependencyIfAnnotationJsr250Present() {
         rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("jakarta.annotation-api")),
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn("package javax.annotation; public @interface Generated {}")),
           mavenProject("my-project",
             //language=java
             srcMainJava(
               java(
                 """
                   import javax.annotation.Generated;
-
+                  
                   @Generated("Hello")
                   class A {
                   }

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -89,6 +89,15 @@ class MigrateToJspecifyTest implements RewriteTest {
                   public String field1;
                   @Nullable
                   public String field2;
+                  @Nullable
+                  public Foo.Bar foobar;
+              }
+
+              interface Foo {
+                class Bar {
+                  @Nonnull
+                  public String barField;
+                }
               }
               """,
             """
@@ -100,6 +109,15 @@ class MigrateToJspecifyTest implements RewriteTest {
                   public String field1;
                   @Nullable
                   public String field2;
+
+                  public Foo.@Nullable Bar foobar;
+              }
+
+              interface Foo {
+                class Bar {
+                  @NonNull
+                  public String barField;
+                }
               }
               """
           )
@@ -160,6 +178,15 @@ class MigrateToJspecifyTest implements RewriteTest {
                   public String field1;
                   @Nullable
                   public String field2;
+                  @Nullable
+                  public Foo.Bar foobar;
+              }
+
+              interface Foo {
+                class Bar {
+                  @Nonnull
+                  public String barField;
+                }
               }
               """,
             """
@@ -171,6 +198,15 @@ class MigrateToJspecifyTest implements RewriteTest {
                   public String field1;
                   @Nullable
                   public String field2;
+
+                  public Foo.@Nullable Bar foobar;
+              }
+
+              interface Foo {
+                class Bar {
+                  @NonNull
+                  public String barField;
+                }
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -132,24 +132,24 @@ class MigrateToJspecifyTest implements RewriteTest {
               """,
             //language=xml
             """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>jakarta.annotation</groupId>
-                          <artifactId>jakarta.annotation-api</artifactId>
-                          <version>3.0.0</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>org.jspecify</groupId>
-                          <artifactId>jspecify</artifactId>
-                          <version>1.0.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
+           <project>
+               <modelVersion>4.0.0</modelVersion>
+               <groupId>com.example.foobar</groupId>
+               <artifactId>foobar-core</artifactId>
+               <version>1.0.0</version>
+               <dependencies>
+                   <dependency>
+                       <groupId>jakarta.annotation</groupId>
+                       <artifactId>jakarta.annotation-api</artifactId>
+                       <version>3.0.0</version>
+                   </dependency>
+                   <dependency>
+                       <groupId>org.jspecify</groupId>
+                       <artifactId>jspecify</artifactId>
+                       <version>1.0.0</version>
+                   </dependency>
+               </dependencies>
+           </project>
            """),
           java(
             """

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.jspecify;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+
+class MigrateToJspecifyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(
+            Environment.builder()
+              .scanRuntimeClasspath("org.openrewrite.java.migrate.jspecify")
+              .build()
+              .activateRecipes("org.openrewrite.java.jspecify.MigrateToJspecify")
+          )
+          .parser(JavaParser.fromJavaVersion().classpath("jsr305", "jakarta.annotation-api"));
+    }
+
+    @Test
+    void migrateFromJavaxAnnotationApiToJspecify() {
+        //language=java
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.foobar</groupId>
+                  <artifactId>foobar-core</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>javax.annotation</groupId>
+                          <artifactId>javax.annotation-api</artifactId>
+                          <version>1.3.2</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.foobar</groupId>
+                  <artifactId>foobar-core</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>javax.annotation</groupId>
+                          <artifactId>javax.annotation-api</artifactId>
+                          <version>1.3.2</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.jspecify</groupId>
+                          <artifactId>jspecify</artifactId>
+                          <version>1.0.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+           """),
+          java(
+            """
+              import javax.annotation.Nonnull;
+              import javax.annotation.Nullable;
+
+              public class Test {
+                  @Nonnull
+                  public String field1;
+                  @Nullable
+                  public String field2;
+              }
+              """,
+            """
+              import org.jspecify.annotations.NonNull;
+              import org.jspecify.annotations.Nullable;
+
+              public class Test {
+                  @NonNull
+                  public String field1;
+                  @Nullable
+                  public String field2;
+              }
+              """)
+        );
+    }
+
+    @Test
+    void migrateFromJakartaAnnotationApiToJspecify() {
+        //language=java
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.foobar</groupId>
+                  <artifactId>foobar-core</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.annotation</groupId>
+                          <artifactId>jakarta.annotation-api</artifactId>
+                          <version>3.0.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.foobar</groupId>
+                  <artifactId>foobar-core</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.annotation</groupId>
+                          <artifactId>jakarta.annotation-api</artifactId>
+                          <version>3.0.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.jspecify</groupId>
+                          <artifactId>jspecify</artifactId>
+                          <version>1.0.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+           """),
+          java(
+            """
+              import jakarta.annotation.Nonnull;
+              import jakarta.annotation.Nullable;
+
+              public class Test {
+                  @Nonnull
+                  public String field1;
+                  @Nullable
+                  public String field2;
+              }
+              """,
+            """
+              import org.jspecify.annotations.NonNull;
+              import org.jspecify.annotations.Nullable;
+
+              public class Test {
+                  @NonNull
+                  public String field1;
+                  @Nullable
+                  public String field2;
+              }
+              """)
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.migrate.jspecify;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -31,12 +30,7 @@ class MigrateToJspecifyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .recipe(
-            Environment.builder()
-              .scanRuntimeClasspath("org.openrewrite.java.migrate.jspecify")
-              .build()
-              .activateRecipes("org.openrewrite.java.jspecify.MigrateToJspecify")
-          )
+          .recipeFromResource("/META-INF/rewrite/jspecify.yml", "org.openrewrite.java.jspecify.MigrateToJspecify")
           .parser(JavaParser.fromJavaVersion().classpath("jsr305", "jakarta.annotation-api"));
     }
 
@@ -64,30 +58,32 @@ class MigrateToJspecifyTest implements RewriteTest {
               """,
             //language=xml
             """
-           <project>
-               <modelVersion>4.0.0</modelVersion>
-               <groupId>com.example.foobar</groupId>
-               <artifactId>foobar-core</artifactId>
-               <version>1.0.0</version>
-               <dependencies>
-                   <dependency>
-                       <groupId>javax.annotation</groupId>
-                       <artifactId>javax.annotation-api</artifactId>
-                       <version>1.3.2</version>
-                   </dependency>
-                   <dependency>
-                       <groupId>org.jspecify</groupId>
-                       <artifactId>jspecify</artifactId>
-                       <version>1.0.0</version>
-                   </dependency>
-               </dependencies>
-           </project>
-           """),
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.foobar</groupId>
+                  <artifactId>foobar-core</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>javax.annotation</groupId>
+                          <artifactId>javax.annotation-api</artifactId>
+                          <version>1.3.2</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.jspecify</groupId>
+                          <artifactId>jspecify</artifactId>
+                          <version>1.0.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          ),
+          //language=java
           java(
             """
               import javax.annotation.Nonnull;
               import javax.annotation.Nullable;
-
+              
               public class Test {
                   @Nonnull
                   public String field1;
@@ -98,14 +94,15 @@ class MigrateToJspecifyTest implements RewriteTest {
             """
               import org.jspecify.annotations.NonNull;
               import org.jspecify.annotations.Nullable;
-
+              
               public class Test {
                   @NonNull
                   public String field1;
                   @Nullable
                   public String field2;
               }
-              """)
+              """
+          )
         );
     }
 
@@ -132,30 +129,32 @@ class MigrateToJspecifyTest implements RewriteTest {
               """,
             //language=xml
             """
-           <project>
-               <modelVersion>4.0.0</modelVersion>
-               <groupId>com.example.foobar</groupId>
-               <artifactId>foobar-core</artifactId>
-               <version>1.0.0</version>
-               <dependencies>
-                   <dependency>
-                       <groupId>jakarta.annotation</groupId>
-                       <artifactId>jakarta.annotation-api</artifactId>
-                       <version>3.0.0</version>
-                   </dependency>
-                   <dependency>
-                       <groupId>org.jspecify</groupId>
-                       <artifactId>jspecify</artifactId>
-                       <version>1.0.0</version>
-                   </dependency>
-               </dependencies>
-           </project>
-           """),
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.foobar</groupId>
+                  <artifactId>foobar-core</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.annotation</groupId>
+                          <artifactId>jakarta.annotation-api</artifactId>
+                          <version>3.0.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.jspecify</groupId>
+                          <artifactId>jspecify</artifactId>
+                          <version>1.0.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          ),
+          //language=java
           java(
             """
               import jakarta.annotation.Nonnull;
               import jakarta.annotation.Nullable;
-
+              
               public class Test {
                   @Nonnull
                   public String field1;
@@ -166,14 +165,15 @@ class MigrateToJspecifyTest implements RewriteTest {
             """
               import org.jspecify.annotations.NonNull;
               import org.jspecify.annotations.Nullable;
-
+              
               public class Test {
                   @NonNull
                   public String field1;
                   @Nullable
                   public String field2;
               }
-              """)
+              """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate.jspecify;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
+@SuppressWarnings("NotNullFieldNotInitialized")
 class MigrateToJspecifyTest implements RewriteTest {
 
     @Override

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -40,6 +40,7 @@ class MigrateToJspecifyTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath("jsr305", "jakarta.annotation-api"));
     }
 
+    @DocumentExample
     @Test
     void migrateFromJavaxAnnotationApiToJspecify() {
         //language=java

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -64,24 +64,24 @@ class MigrateToJspecifyTest implements RewriteTest {
               """,
             //language=xml
             """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>javax.annotation</groupId>
-                          <artifactId>javax.annotation-api</artifactId>
-                          <version>1.3.2</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>org.jspecify</groupId>
-                          <artifactId>jspecify</artifactId>
-                          <version>1.0.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
+           <project>
+               <modelVersion>4.0.0</modelVersion>
+               <groupId>com.example.foobar</groupId>
+               <artifactId>foobar-core</artifactId>
+               <version>1.0.0</version>
+               <dependencies>
+                   <dependency>
+                       <groupId>javax.annotation</groupId>
+                       <artifactId>javax.annotation-api</artifactId>
+                       <version>1.3.2</version>
+                   </dependency>
+                   <dependency>
+                       <groupId>org.jspecify</groupId>
+                       <artifactId>jspecify</artifactId>
+                       <version>1.0.0</version>
+                   </dependency>
+               </dependencies>
+           </project>
            """),
           java(
             """

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -21,9 +21,8 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
-
 
 class MigrateToJspecifyTest implements RewriteTest {
 
@@ -37,267 +36,274 @@ class MigrateToJspecifyTest implements RewriteTest {
     @DocumentExample
     @Test
     void migrateFromJavaxAnnotationApiToJspecify() {
-        //language=java
         rewriteRun(
-          pomXml(
+          mavenProject("foo",
+            srcMainJava(
+              //language=java
+              java(
+                """
+                  import javax.annotation.Nonnull;
+                  import javax.annotation.Nullable;
+                  
+                  public class Test {
+                      @Nonnull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                      @Nullable
+                      public Foo.Bar foobar;
+                  }
+                  
+                  interface Foo {
+                    class Bar {
+                      @Nonnull
+                      public String barField;
+                    }
+                  }
+                  """,
+                """
+                  import org.jspecify.annotations.NonNull;
+                  import org.jspecify.annotations.Nullable;
+                  
+                  public class Test {
+                      @NonNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                  
+                      public Foo.@Nullable Bar foobar;
+                  }
+                  
+                  interface Foo {
+                    class Bar {
+                      @NonNull
+                      public String barField;
+                    }
+                  }
+                  """
+              )
+            ),
             //language=xml
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>javax.annotation</groupId>
-                          <artifactId>javax.annotation-api</artifactId>
-                          <version>1.3.2</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            //language=xml
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>javax.annotation</groupId>
-                          <artifactId>javax.annotation-api</artifactId>
-                          <version>1.3.2</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>org.jspecify</groupId>
-                          <artifactId>jspecify</artifactId>
-                          <version>1.0.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
+            pomXml(
               """
-          ),
-          //language=java
-          java(
-            """
-              import javax.annotation.Nonnull;
-              import javax.annotation.Nullable;
-              
-              public class Test {
-                  @Nonnull
-                  public String field1;
-                  @Nullable
-                  public String field2;
-                  @Nullable
-                  public Foo.Bar foobar;
-              }
-
-              interface Foo {
-                class Bar {
-                  @Nonnull
-                  public String barField;
-                }
-              }
-              """,
-            """
-              import org.jspecify.annotations.NonNull;
-              import org.jspecify.annotations.Nullable;
-              
-              public class Test {
-                  @NonNull
-                  public String field1;
-                  @Nullable
-                  public String field2;
-
-                  public Foo.@Nullable Bar foobar;
-              }
-
-              interface Foo {
-                class Bar {
-                  @NonNull
-                  public String barField;
-                }
-              }
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>javax.annotation</groupId>
+                            <artifactId>javax.annotation-api</artifactId>
+                            <version>1.3.2</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
               """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>javax.annotation</groupId>
+                            <artifactId>javax.annotation-api</artifactId>
+                            <version>1.3.2</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jspecify</groupId>
+                            <artifactId>jspecify</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
           )
         );
     }
 
     @Test
     void migrateFromJakartaAnnotationApiToJspecify() {
-        //language=java
         rewriteRun(
-          pomXml(
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import jakarta.annotation.Nonnull;
+                  import jakarta.annotation.Nullable;
+                  
+                  public class Test {
+                      @Nonnull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                      @Nullable
+                      public Foo.Bar foobar;
+                  }
+                  
+                  interface Foo {
+                    class Bar {
+                      @Nonnull
+                      public String barField;
+                    }
+                  }
+                  """,
+                """
+                  import org.jspecify.annotations.NonNull;
+                  import org.jspecify.annotations.Nullable;
+                  
+                  public class Test {
+                      @NonNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                  
+                      public Foo.@Nullable Bar foobar;
+                  }
+                  
+                  interface Foo {
+                    class Bar {
+                      @NonNull
+                      public String barField;
+                    }
+                  }
+                  """
+              )
+            )
+            ,
             //language=xml
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>jakarta.annotation</groupId>
-                          <artifactId>jakarta.annotation-api</artifactId>
-                          <version>3.0.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            //language=xml
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>jakarta.annotation</groupId>
-                          <artifactId>jakarta.annotation-api</artifactId>
-                          <version>3.0.0</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>org.jspecify</groupId>
-                          <artifactId>jspecify</artifactId>
-                          <version>1.0.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
+            pomXml(
               """
-          ),
-          //language=java
-          java(
-            """
-              import jakarta.annotation.Nonnull;
-              import jakarta.annotation.Nullable;
-              
-              public class Test {
-                  @Nonnull
-                  public String field1;
-                  @Nullable
-                  public String field2;
-                  @Nullable
-                  public Foo.Bar foobar;
-              }
-
-              interface Foo {
-                class Bar {
-                  @Nonnull
-                  public String barField;
-                }
-              }
-              """,
-            """
-              import org.jspecify.annotations.NonNull;
-              import org.jspecify.annotations.Nullable;
-              
-              public class Test {
-                  @NonNull
-                  public String field1;
-                  @Nullable
-                  public String field2;
-
-                  public Foo.@Nullable Bar foobar;
-              }
-
-              interface Foo {
-                class Bar {
-                  @NonNull
-                  public String barField;
-                }
-              }
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>jakarta.annotation</groupId>
+                            <artifactId>jakarta.annotation-api</artifactId>
+                            <version>3.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
               """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>jakarta.annotation</groupId>
+                            <artifactId>jakarta.annotation-api</artifactId>
+                            <version>3.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jspecify</groupId>
+                            <artifactId>jspecify</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
           )
         );
     }
 
     @Test
     void migrateFromJetbrainsAnnotationsToJspecify() {
-        //language=java
         rewriteRun(
-          pomXml(
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import org.jetbrains.annotations.NotNull;
+                  import org.jetbrains.annotations.Nullable;
+                  
+                  public class Test {
+                      @NotNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                      @Nullable
+                      public Foo.Bar foobar;
+                  }
+                  
+                  interface Foo {
+                    class Bar {
+                      @NotNull
+                      public String barField;
+                    }
+                  }
+                  """,
+                """
+                  import org.jspecify.annotations.NonNull;
+                  import org.jspecify.annotations.Nullable;
+                  
+                  public class Test {
+                      @NonNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                  
+                      public Foo.@Nullable Bar foobar;
+                  }
+                  
+                  interface Foo {
+                    class Bar {
+                      @NonNull
+                      public String barField;
+                    }
+                  }
+                  """
+              )
+            ),
             //language=xml
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.jetbrains</groupId>
-                          <artifactId>annotations</artifactId>
-                          <version>24.1.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            //language=xml
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example.foobar</groupId>
-                  <artifactId>foobar-core</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.jetbrains</groupId>
-                          <artifactId>annotations</artifactId>
-                          <version>24.1.0</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>org.jspecify</groupId>
-                          <artifactId>jspecify</artifactId>
-                          <version>1.0.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
+            pomXml(
               """
-          ),
-          //language=java
-          java(
-            """
-              import org.jetbrains.annotations.NotNull;
-              import org.jetbrains.annotations.Nullable;
-              
-              public class Test {
-                  @NotNull
-                  public String field1;
-                  @Nullable
-                  public String field2;
-                  @Nullable
-                  public Foo.Bar foobar;
-              }
-
-              interface Foo {
-                class Bar {
-                  @NotNull
-                  public String barField;
-                }
-              }
-              """,
-            """
-              import org.jspecify.annotations.NonNull;
-              import org.jspecify.annotations.Nullable;
-              
-              public class Test {
-                  @NonNull
-                  public String field1;
-                  @Nullable
-                  public String field2;
-
-                  public Foo.@Nullable Bar foobar;
-              }
-
-              interface Foo {
-                class Bar {
-                  @NonNull
-                  public String barField;
-                }
-              }
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jetbrains</groupId>
+                            <artifactId>annotations</artifactId>
+                            <version>24.1.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
               """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jetbrains</groupId>
+                            <artifactId>annotations</artifactId>
+                            <version>24.1.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jspecify</groupId>
+                            <artifactId>jspecify</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
           )
         );
     }


### PR DESCRIPTION
## What's changed?

add recipe for jspecify annotations

## What's your motivation?

jspecify 1.0.0 was released in July 2024

https://jspecify.dev/blog/release-1.0.0/

https://www.infoq.com/news/2024/08/jspecify-java-nullability/


## Anything in particular you'd like reviewers to focus on?

n/a

## Anyone you would like to review specifically?

n/a

## Have you considered any alternatives or workarounds?

n/a

## Any additional context

jspecify mailing list 
https://groups.google.com/g/jspecify-discuss/c/h73MkdhAPew


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
