### PR TITLE
Recipe to migrate from `Math.random` to `ThreadLocalRandom`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
@@ -19,8 +19,9 @@ package org.openrewrite.java.migrate.util;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.concurrent.ThreadLocalRandom;
-import org.openrewrite.java.template.RecipeDescriptor;
 
+        name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",
+        description = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`."
 
 @RecipeDescriptor(
     name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",

--- a/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
@@ -19,9 +19,8 @@ package org.openrewrite.java.migrate.util;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.concurrent.ThreadLocalRandom;
+import org.openrewrite.java.template.RecipeDescriptor;
 
-        name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",
-        description = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`."
 
 @RecipeDescriptor(
     name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",

--- a/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openrewrite.java.migrate.util;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.concurrent.ThreadLocalRandom;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+
+@RecipeDescriptor(
+    name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",
+    description = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`."
+)
+public class ReplaceMathRandomWithThreadLocalRandom {
+    @BeforeTemplate
+    double javaMathRandom() {
+      return Math.random();
+    }
+
+    @AfterTemplate
+    double threadLocalRandomNextDouble() {
+      return ThreadLocalRandom.current().nextDouble();
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
@@ -18,9 +18,9 @@ package org.openrewrite.java.migrate.util;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import java.util.concurrent.ThreadLocalRandom;
 import org.openrewrite.java.template.RecipeDescriptor;
 
+import java.util.concurrent.ThreadLocalRandom;
 
 @RecipeDescriptor(
     name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",

--- a/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandom.java
@@ -23,17 +23,17 @@ import org.openrewrite.java.template.RecipeDescriptor;
 import java.util.concurrent.ThreadLocalRandom;
 
 @RecipeDescriptor(
-    name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",
-    description = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`."
+        name = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()`",
+        description = "Replace `java.lang.Math random()` with `ThreadLocalRandom nextDouble()` to reduce contention."
 )
 public class ReplaceMathRandomWithThreadLocalRandom {
     @BeforeTemplate
     double javaMathRandom() {
-      return Math.random();
+        return Math.random();
     }
 
     @AfterTemplate
     double threadLocalRandomNextDouble() {
-      return ThreadLocalRandom.current().nextDouble();
+        return ThreadLocalRandom.current().nextDouble();
     }
 }

--- a/src/main/resources/META-INF/rewrite/java-version-7.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-7.yml
@@ -26,6 +26,7 @@ recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava6
   - org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods
   - org.openrewrite.java.migrate.JREThrowableFinalMethods
+  - org.openrewrite.java.migrate.util.ReplaceMathRandomWithThreadLocalRandomRecipe
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods

--- a/src/test/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandomRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandomRecipeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.util;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+
+class ReplaceMathRandomWithThreadLocalRandomRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new ReplaceMathRandomWithThreadLocalRandomRecipe());
+    }
+
+    @Test
+    @DocumentExample
+    void replacesMathRandom() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+
+              class Example {
+                  double test() {
+                      return Math.random();
+                  }
+              }
+              """,
+            """
+              import java.util.concurrent.ThreadLocalRandom;
+
+              class Example {
+                  double test() {
+                      return ThreadLocalRandom.current().nextDouble();
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandomRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/ReplaceMathRandomWithThreadLocalRandomRecipeTest.java
@@ -22,13 +22,11 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-
 class ReplaceMathRandomWithThreadLocalRandomRecipeTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec
-          .recipe(new ReplaceMathRandomWithThreadLocalRandomRecipe());
+        spec.recipe(new ReplaceMathRandomWithThreadLocalRandomRecipe());
     }
 
     @Test
@@ -38,7 +36,6 @@ class ReplaceMathRandomWithThreadLocalRandomRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-
               class Example {
                   double test() {
                       return Math.random();
@@ -47,7 +44,7 @@ class ReplaceMathRandomWithThreadLocalRandomRecipeTest implements RewriteTest {
               """,
             """
               import java.util.concurrent.ThreadLocalRandom;
-
+              
               class Example {
                   double test() {
                       return ThreadLocalRandom.current().nextDouble();


### PR DESCRIPTION
## What's changed?

Add new recipe that will migrate Math.random to ThreadLocalRandom nextDouble

## What's your motivation?

ThreadLocalRandom nextDouble outperforms Math.random


## Anything in particular you'd like reviewers to focus on?

n/a

## Anyone you would like to review specifically?

n/a

## Have you considered any alternatives or workarounds?

n/a

## Any additional context

JMH microbenchmark that compares Math.random() with ThreadLocalRandom nextDouble()

https://github.com/sullis/microbenchmarks-java/blob/main/src/jmh/java/io/github/sullis/microbenchmarks/NextDoubleBenchmark.java

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/db1ff8d9-3da3-4b7f-bb4f-e30ecaa2e15e">




### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
