### PR TITLE
Remove parameters from java-version-11.yml for  DetectAWTGetPeerMethod recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/ReplaceAWTGetPeerMethod.java
+++ b/src/main/java/org/openrewrite/java/migrate/ReplaceAWTGetPeerMethod.java
@@ -16,6 +16,8 @@
 
 package org.openrewrite.java.migrate;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
@@ -30,17 +32,26 @@ import org.openrewrite.java.tree.TypedTree;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-class ReplaceAWTGetPeerMethod extends Recipe {
+@AllArgsConstructor
+public class ReplaceAWTGetPeerMethod extends Recipe {
 
     @Option(displayName = "Method pattern to replace",
             description = "The method pattern to match and replace.",
-            example = "java.awt.* getPeer()")
+            example = "java.awt.* getPeer()",
+            required = false)
     String getPeerMethodPattern;
 
     @Option(displayName = "The LightweightPeer interface FQCN",
             description = "The fully qualified class name of the LightweightPeer interface to replace in `instanceof`.",
-            example = "java.awt.peer.LightweightPeer")
+            example = "java.awt.peer.LightweightPeer",
+            required = false)
     String lightweightPeerFQCN;
+
+    @JsonCreator
+    public ReplaceAWTGetPeerMethod() {
+        getPeerMethodPattern = "java.awt.* getPeer()";
+        lightweightPeerFQCN = "java.awt.peer.LightweightPeer";
+    }
 
     @Override
     public String getDisplayName() {
@@ -50,8 +61,8 @@ class ReplaceAWTGetPeerMethod extends Recipe {
     @Override
     public String getDescription() {
         return "This recipe replaces the use of `getPeer()` method in `java.awt.*` classes. " +
-               "`component.getPeer() != null` is replaced with `component.isDisplayable()` and " +
-               "`component.getPeer() instanceof LightweightPeer` is replaced with `component.isLightweight()`.";
+                "`component.getPeer() != null` is replaced with `component.isDisplayable()` and " +
+                "`component.getPeer() instanceof LightweightPeer` is replaced with `component.isLightweight()`.";
     }
 
     @Override
@@ -81,10 +92,10 @@ class ReplaceAWTGetPeerMethod extends Recipe {
                 J.MethodInvocation mi = null;
                 if (binaryCondition.getOperator() == J.Binary.Type.NotEqual) {
                     if (binaryCondition.getLeft() instanceof J.MethodInvocation &&
-                        binaryCondition.getRight() instanceof J.Literal) {
+                            binaryCondition.getRight() instanceof J.Literal) {
                         mi = (J.MethodInvocation) binaryCondition.getLeft();
                     } else if (binaryCondition.getLeft() instanceof J.Literal &&
-                               binaryCondition.getRight() instanceof J.MethodInvocation) {
+                            binaryCondition.getRight() instanceof J.MethodInvocation) {
                         mi = (J.MethodInvocation) binaryCondition.getRight();
                     }
                 }

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -69,9 +69,7 @@ recipeList:
   - org.openrewrite.java.migrate.RemovedPolicy
   - org.openrewrite.java.migrate.ReferenceCloneMethod
   - org.openrewrite.java.migrate.ThreadStopDestroy
-  - org.openrewrite.java.migrate.ReplaceAWTGetPeerMethod:
-      getPeerMethodPattern: java.awt.* getPeer()
-      lightweightPeerFQCN: java.awt.peer.LightweightPeer
+  - org.openrewrite.java.migrate.ReplaceAWTGetPeerMethod
   - org.openrewrite.scala.migrate.UpgradeScala_2_12
   - org.openrewrite.java.migrate.ReplaceComSunAWTUtilitiesMethods
   - org.openrewrite.java.migrate.ReplaceLocalizedStreamMethods


### PR DESCRIPTION
## What's changed?
Remove using parameterized recipes directly on the recipe category list from the DetectAWTGetPeerMethod recipe.
This includes adding a constructor with defaults and removing the parameters in  java-version-11.yml
Attaching rewrite.patch after using the recipe:
[rewrite.patch](https://github.com/user-attachments/files/16970646/rewrite.patch)

## What's your motivation?
When recipes are parameterized on a .yml, we have no way of porting those parameters into the rewrite config we generate for users.

## Anyone you would like to review specifically?
@cjobinabo , @timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases - Not applicable
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
