### PR TITLE
Correctly override parent property to set Java version

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -23,14 +23,12 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.maven.AddProperty;
 import org.openrewrite.maven.MavenIsoVisitor;
-import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Value

--- a/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -65,15 +65,15 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
     public String getDescription() {
         //language=markdown
         return "The Java version is determined by several project properties, including:\n\n" +
-                " * `java.version`\n" +
-                " * `jdk.version`\n" +
-                " * `javaVersion`\n" +
-                " * `jdkVersion`\n" +
-                " * `maven.compiler.source`\n" +
-                " * `maven.compiler.target`\n" +
-                " * `maven.compiler.release`\n" +
-                " * `release.version`\n\n" +
-                "If none of these properties are in use and the maven compiler plugin is not otherwise configured, adds the `maven.compiler.release` property.";
+               " * `java.version`\n" +
+               " * `jdk.version`\n" +
+               " * `javaVersion`\n" +
+               " * `jdkVersion`\n" +
+               " * `maven.compiler.source`\n" +
+               " * `maven.compiler.target`\n" +
+               " * `maven.compiler.release`\n" +
+               " * `release.version`\n\n" +
+               "If none of these properties are in use and the maven compiler plugin is not otherwise configured, adds the `maven.compiler.release` property.";
     }
 
     @Override
@@ -137,8 +137,8 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                     Optional<Xml.Tag> maybeCompilerPlugin = t.getChildren().stream()
                             .filter(plugin ->
                                     "plugin".equals(plugin.getName()) &&
-                                            "org.apache.maven.plugins".equals(plugin.getChildValue("groupId").orElse("org.apache.maven.plugins")) &&
-                                            "maven-compiler-plugin".equals(plugin.getChildValue("artifactId").orElse(null)))
+                                    "org.apache.maven.plugins".equals(plugin.getChildValue("groupId").orElse("org.apache.maven.plugins")) &&
+                                    "maven-compiler-plugin".equals(plugin.getChildValue("artifactId").orElse(null)))
                             .findAny();
                     Optional<Xml.Tag> maybeCompilerPluginConfig = maybeCompilerPlugin
                             .flatMap(it -> it.getChild("configuration"));
@@ -149,9 +149,9 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                     Optional<String> source = compilerPluginConfig.getChildValue("source");
                     Optional<String> target = compilerPluginConfig.getChildValue("target");
                     Optional<String> release = compilerPluginConfig.getChildValue("release");
-                    if (source.isPresent()
-                            || target.isPresent()
-                            || release.isPresent()) {
+                    if (source.isPresent() ||
+                        target.isPresent() ||
+                        release.isPresent()) {
                         compilerPluginConfiguredExplicitly = true;
                     }
                 }

--- a/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -106,6 +106,7 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                                 d = (Xml.Document) new AddProperty(property, String.valueOf(version), null, false)
                                         .getVisitor()
                                         .visitNonNull(d, ctx);
+                                maybeUpdateModel();
                             }
                         } catch (NumberFormatException ex) {
                             // either an expression or something else, don't touch
@@ -120,11 +121,7 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                     d = (Xml.Document) new AddProperty("maven.compiler.release", String.valueOf(version), null, false)
                             .getVisitor()
                             .visitNonNull(d, ctx);
-                    HashMap<String, String> updatedProps = new HashMap<>(mrr.getPom().getRequested().getProperties());
-                    updatedProps.put("maven.compiler.release", version.toString());
-                    mrr = mrr.withPom(mrr.getPom().withRequested(mrr.getPom().getRequested().withProperties(updatedProps)));
-
-                    d = d.withMarkers(d.getMarkers().setByType(mrr));
+                    maybeUpdateModel();
                 }
                 return d;
             }

--- a/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -143,12 +143,9 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                         return t;
                     }
                     Xml.Tag compilerPluginConfig = maybeCompilerPluginConfig.get();
-                    Optional<String> source = compilerPluginConfig.getChildValue("source");
-                    Optional<String> target = compilerPluginConfig.getChildValue("target");
-                    Optional<String> release = compilerPluginConfig.getChildValue("release");
-                    if (source.isPresent() ||
-                        target.isPresent() ||
-                        release.isPresent()) {
+                    if (compilerPluginConfig.getChildValue("source").isPresent() ||
+                        compilerPluginConfig.getChildValue("target").isPresent() ||
+                        compilerPluginConfig.getChildValue("release").isPresent()) {
                         compilerPluginConfiguredExplicitly = true;
                     }
                 }

--- a/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -78,7 +78,7 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
     }
 
     @Test
-    void bringsDownExplicitlyUsedPropertyFromRemoteParent() {
+    void overrideRemoteParent() {
         rewriteRun(
           //language=xml
           pomXml(
@@ -116,18 +116,6 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                     <artifactId>example-child</artifactId>
                     <version>1.0.0</version>
                     <modelVersion>4.0</modelVersion>
-                    <build>
-                      <plugins>
-                        <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
-                          <artifactId>maven-compiler-plugin</artifactId>
-                          <version>3.8.0</version>
-                          <configuration>
-                            <release>${java.version}</release>
-                          </configuration>
-                        </plugin>
-                      </plugins>
-                    </build>
                 </project>
                 """,
               """
@@ -145,19 +133,14 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                     <modelVersion>4.0</modelVersion>
                     <properties>
                         <java.version>17</java.version>
+                        <javaVersion>17</javaVersion>
+                        <jdk.version>17</jdk.version>
+                        <jdkVersion>17</jdkVersion>
+                        <maven.compiler.release>17</maven.compiler.release>
+                        <maven.compiler.source>17</maven.compiler.source>
+                        <maven.compiler.target>17</maven.compiler.target>
+                        <release.version>17</release.version>
                     </properties>
-                    <build>
-                      <plugins>
-                        <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
-                          <artifactId>maven-compiler-plugin</artifactId>
-                          <version>3.8.0</version>
-                          <configuration>
-                            <release>${java.version}</release>
-                          </configuration>
-                        </plugin>
-                      </plugins>
-                    </build>
                 </project>
                 """)
           )

--- a/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -78,6 +78,50 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
     }
 
     @Test
+    void basicWithVariables() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <groupId>com.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0.0</version>
+                  <modelVersion>4.0</modelVersion>
+                  <properties>
+                      <java.version>${release.version}</java.version>
+                      <jdk.version>11</jdk.version>
+                      <javaVersion>${release.version}</javaVersion>
+                      <jdkVersion>${jdk.version}</jdkVersion>
+                      <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+                      <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+                      <maven.compiler.release>11</maven.compiler.release>
+                      <release.version>11</release.version>
+                  </properties>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>com.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0.0</version>
+                  <modelVersion>4.0</modelVersion>
+                  <properties>
+                      <java.version>${release.version}</java.version>
+                      <jdk.version>17</jdk.version>
+                      <javaVersion>${release.version}</javaVersion>
+                      <jdkVersion>${jdk.version}</jdkVersion>
+                      <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+                      <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+                      <maven.compiler.release>17</maven.compiler.release>
+                      <release.version>17</release.version>
+                  </properties>
+              </project>
+              """)
+        );
+    }
+
+    @Test
     void overrideRemoteParent() {
         rewriteRun(
           //language=xml
@@ -148,6 +192,36 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
     }
 
     @Test
+    void doNothingForExplicitPluginConfiguration() {
+        // Use UseMavenCompilerPluginReleaseConfiguration for this case
+        rewriteRun(
+          //language=xml
+          pomXml("""
+            <project>
+              <groupId>com.example</groupId>
+              <artifactId>example-child</artifactId>
+              <version>1.0.0</version>
+              <modelVersion>4.0</modelVersion>
+              <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                      <release>11</release>
+                      <source>11</source>
+                      <target>11</target>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """)
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/514")
     void addReleaseIfNoOtherChangeIsMade() {
         rewriteRun(
@@ -177,24 +251,69 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
     }
 
     @Test
-    void mavenUpgradeShouldUseDeclaredVersionInParent() {
+    void springBoot3ParentToJava17() {
+        // Spring Boot Starter Parent already enforces Java 17
         rewriteRun(
           pomXml(
             //language=xml
             """
-               <project>
-              <modelVersion>4.0.0</modelVersion>
-              <parent>
-              	<groupId>org.springframework.boot</groupId>
-              	<artifactId>spring-boot-starter-parent</artifactId>
-              	<version>3.3.3</version>
-              	<relativePath/> <!-- lookup parent from repository -->
-              </parent>
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.3.3</version>
+                  <relativePath/> <!-- lookup parent from repository -->
+                </parent>
               
-              <groupId>com.mycompany.app</groupId>
-              <artifactId>my-app</artifactId>
-              <version>1</version>
-               </project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void springBoot3ParentToJava21() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateMavenProjectPropertyJavaVersion(21)),
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.3.3</version>
+                  <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+              
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            //language=xml
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.3.3</version>
+                  <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+              
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <properties>
+                  <java.version>21</java.version>
+                </properties>
+              </project>
               """
           )
         );

--- a/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -73,7 +73,8 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                       <release.version>17</release.version>
                   </properties>
               </project>
-              """)
+              """
+          )
         );
     }
 
@@ -147,7 +148,8 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
             SourceSpec::skip),
           mavenProject("example-child",
             //language=xml
-            pomXml("""
+            pomXml(
+              """
                 <project>
                     <parent>
                         <groupId>com.example</groupId>
@@ -186,7 +188,8 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                         <release.version>17</release.version>
                     </properties>
                 </project>
-                """)
+                """
+            )
           )
         );
     }
@@ -197,28 +200,29 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
         rewriteRun(
           //language=xml
           pomXml(
-                """
-            <project>
-              <groupId>com.example</groupId>
-              <artifactId>example-child</artifactId>
-              <version>1.0.0</version>
-              <modelVersion>4.0</modelVersion>
-              <build>
-                <plugins>
-                  <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
-                    <configuration>
-                      <release>11</release>
-                      <source>11</source>
-                      <target>11</target>
-                    </configuration>
-                  </plugin>
-                </plugins>
-              </build>
-            </project>
-            """)
+            """
+              <project>
+                <groupId>com.example</groupId>
+                <artifactId>example-child</artifactId>
+                <version>1.0.0</version>
+                <modelVersion>4.0</modelVersion>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.8.0</version>
+                      <configuration>
+                        <release>11</release>
+                        <source>11</source>
+                        <target>11</target>
+                      </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
         );
     }
 

--- a/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -196,7 +196,8 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
         // Use UseMavenCompilerPluginReleaseConfiguration for this case
         rewriteRun(
           //language=xml
-          pomXml("""
+          pomXml(
+                """
             <project>
               <groupId>com.example</groupId>
               <artifactId>example-child</artifactId>

--- a/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -192,4 +192,28 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void mavenUpgradeShouldUseDeclaredVersionInParent() {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+               <project>
+              <modelVersion>4.0.0</modelVersion>
+              <parent>
+              	<groupId>org.springframework.boot</groupId>
+              	<artifactId>spring-boot-starter-parent</artifactId>
+              	<version>3.3.3</version>
+              	<relativePath/> <!-- lookup parent from repository -->
+              </parent>
+              
+              <groupId>com.mycompany.app</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+               </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
* Added a test case on `UpdateMavenProjectPropertyJavaVersionTest` expecting no change when upgrading to Java 17 but parent is already spring-boot 3.3 (declares `java.version` and `maven.compiler.release` with value 17 already) .
* Partially reverted 12c8f372d77f2b4612e18d1e420816612106fdc8
* Implemented a fix to only override properties that actually parse to a number, and to add `maven.release.plugin` only when no release property is found

## What's your motivation?
- Reproduce & fix #523

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
