### PR TITLE
Skip adding var to local variables initialized by array initializer

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -75,7 +75,8 @@ public class UseVarForObject extends Recipe {
             boolean isPrimitive = DeclarationCheck.isPrimitive(vd);
             boolean usesGenerics = DeclarationCheck.useGenerics(vd);
             boolean usesTernary = DeclarationCheck.initializedByTernary(vd);
-            if (isPrimitive || usesGenerics || usesTernary) {
+            boolean usesArrayInitializer = vd.getVariables().get(0).getInitializer() instanceof J.NewArray;
+            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer) {
                 return vd;
             }
 

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.java.Assertions.*;
@@ -58,6 +59,7 @@ class UseVarForObjectsTest extends VarBaseTest {
                   """)
             );
         }
+
 
         @Test
         void reassignment() {
@@ -310,6 +312,25 @@ class UseVarForObjectsTest extends VarBaseTest {
 
     @Nested
     class NotApplicable {
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/551")
+        void arrayInitializer() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+                  
+                  class A {
+                    void m() {
+                        String[] dictionary = {"aa", "b", "aba", "ba"};
+                    }
+                  }
+                  """)
+            );
+        }
+
         @Test
         void fieldInAnonymousSubclass() {
             //language=java


### PR DESCRIPTION
## What's changed?
`String[] dictionary = {"aa", "b", "aba", "ba"};` will no longer be transformed to `var dictionary = {"aa", "b", "aba", "ba"};`

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-migrate-java/issues/551

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?
Move type attribution like: `int[] x = {1, 2}` to `var x = new int[]{1, 2}` but that's way more complicated and adds nothing special. 

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
