### PR TITLE
Remove wrong namespace-change of package javax.transaction.xa

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -606,7 +606,7 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.transaction
       newPackageName: jakarta.transaction
-      recursive: true
+      recursive: false
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxWebsocketToJakartaWebsocket

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxTransactionMigrationToJakartaTransactionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxTransactionMigrationToJakartaTransactionTest.java
@@ -1,0 +1,82 @@
+package org.openrewrite.java.migrate.jakarta;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+
+public class JavaxTransactionMigrationToJakartaTransactionTest implements RewriteTest {
+    @Language("java")
+    private static final String javax_transaction =
+      """
+        package javax.transaction;
+        public @interface Transactional {}
+        """;
+
+    @Language("java")
+    private static final String javax_transaction_xa =
+      """
+        package javax.transaction.xa;
+        public class XAResource {
+            public static void stat() {}
+            public void foo() {}
+        }
+        """;
+
+    @Language("java")
+    private static final String jakarta_transaction =
+      """
+        package jakarta.transaction;
+        public @interface Transactional {}
+        """;
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(
+          Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite.java.migrate.jakarta")
+            .build()
+            .activateRecipes("org.openrewrite.java.migrate.jakarta.JavaxTransactionMigrationToJakartaTransaction")
+        );
+    }
+
+    @Test
+    void doNotChangeImportWhenPackageFromJavaSE() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javax_transaction_xa)),
+          //language=java
+          java("""
+            import javax.transaction.xa.*;
+            public class A {
+                XAResource xa;
+            }
+            """)
+        );
+    }
+
+    @Test
+    void changeImportWhenPackageFromJakartaTransaction() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javax_transaction, jakarta_transaction)),
+          //language=java
+          java("""
+              import javax.transaction.Transactional;
+              @Transactional
+              public class A {
+                  public void foo() {}
+              }
+              """,
+            """
+              import jakarta.transaction.Transactional;
+              @Transactional
+              public class A {
+                  public void foo() {}
+              }
+              """)
+        );
+    }
+}


### PR DESCRIPTION
This change removes a wrongly made namespace-change of a package in jakarta-ee-9.yml. 

Previously, the package `javax.transaction.xa` (from [Java SE 8](https://docs.oracle.com/javase/8/docs/api/javax/transaction/xa/package-summary.html)) was wrongly changed to `jakarta.transaction.xa`, which does not exist because it did not change.
This was probably done because the namespace change did affect all sub-packages for other packages of javax.* namespace. With `javax.transaction` however, there is only this single package in Jakarta EE which has change to `jakarta.transaction`. The namespace of the package `javax.transaction.xa` (from [Java SE 8](https://docs.oracle.com/javase/8/docs/api/javax/transaction/xa/package-summary.html)) did not change though, which is why my solution would be to just turn the recursive attribute to 'false'.

## What's changed?
Changed the value of the recursive attribute in the recipe org.openrewrite.java.migrate.jakarta.JavaxTransactionMigrationToJakartaTransaction from `true` to `false` and added a testclass.

## What's your motivation?
Months ago I was mentioning this bug in slack [here](https://rewriteoss.slack.com/archives/C01A843MWG5/p1720782175961369) and I forgot to make the MR until now.

## Anything in particular you'd like reviewers to focus on?
There is only this single package that has been renamed from javax.transaction to jakarta.transaction as shown [here](https://github.com/jakartaee/transactions/commit/16dad7ca3280073c9112aeeb05f72d505afbee8c), so i don't think we need the recursive change, especially if it causes unwanted side-effects.

## Anyone you would like to review specifically?
I was talking with @timtebeek on slack, so he would probably be the best here.

## Have you considered any alternatives or workarounds?
As @timtebeek suggested, I could have excluded the `javax.transaction.xa` namespace, but I think my solution is more simple. I am open to discussion though :)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
