### PR TITLE
StringFormatted should not leave trailing whitespace after replacement

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -66,7 +66,6 @@ public class StringFormatted extends Recipe {
             if (!STRING_FORMAT.matches(methodInvocation) || methodInvocation.getMethodType() == null) {
                 return methodInvocation;
             }
-            methodInvocation = makeFirstArgumentPrefixAsEmpty(methodInvocation);
             List<Expression> arguments = methodInvocation.getArguments();
 
             maybeRemoveImport("java.lang.String.format");
@@ -80,7 +79,7 @@ public class StringFormatted extends Recipe {
                 mi = mi.withName(mi.getName().withType(mi.getMethodType()));
             }
             boolean wrapperNotNeeded = wrapperNotNeeded(arguments.get(0));
-            Expression select = wrapperNotNeeded ? arguments.get(0) :
+            Expression select = wrapperNotNeeded ? arguments.get(0).withPrefix(Space.EMPTY) :
                     new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY,
                             JRightPadded.build(arguments.get(0)));
             mi = mi.withSelect(select);
@@ -92,12 +91,6 @@ public class StringFormatted extends Recipe {
             }
 
             return maybeAutoFormat(methodInvocation, mi, ctx);
-        }
-
-        private static J.MethodInvocation makeFirstArgumentPrefixAsEmpty(J.MethodInvocation m) {
-            List<Expression> newArgs = m.getArguments();
-            newArgs.set(0, m.getArguments().get(0).withPrefix(Space.EMPTY));
-            return m.withArguments(newArgs);
         }
 
         private static boolean wrapperNotNeeded(Expression expression) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -64,23 +64,20 @@ public class StringFormatted extends Recipe {
             if (!STRING_FORMAT.matches(methodInvocation) || methodInvocation.getMethodType() == null) {
                 return methodInvocation;
             }
-            List<Expression> arguments = methodInvocation.getArguments();
 
             maybeRemoveImport("java.lang.String.format");
             J.MethodInvocation mi = methodInvocation.withName(methodInvocation.getName().withSimpleName("formatted"));
-            JavaType.Method formatted = methodInvocation.getMethodType().getDeclaringType().getMethods().stream()
+            mi = mi.withMethodType(methodInvocation.getMethodType().getDeclaringType().getMethods().stream()
                     .filter(it -> it.getName().equals("formatted"))
                     .findAny()
-                    .orElse(null);
-            mi = mi.withMethodType(formatted);
+                    .orElse(null));
             if (mi.getName().getType() != null) {
                 mi = mi.withName(mi.getName().withType(mi.getMethodType()));
             }
-            boolean wrapperNotNeeded = wrapperNotNeeded(arguments.get(0));
-            Expression select = wrapperNotNeeded ? arguments.get(0).withPrefix(Space.EMPTY) :
+            List<Expression> arguments = methodInvocation.getArguments();
+            mi = mi.withSelect(wrapperNotNeeded(arguments.get(0)) ? arguments.get(0).withPrefix(Space.EMPTY) :
                     new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY,
-                            JRightPadded.build(arguments.get(0)));
-            mi = mi.withSelect(select);
+                            JRightPadded.build(arguments.get(0))));
             mi = mi.withArguments(arguments.subList(1, arguments.size()));
             if (mi.getArguments().isEmpty()) {
                 // To store spaces between the parenthesis of a method invocation argument list

--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.openrewrite.java.migrate.lang;
 
 import lombok.EqualsAndHashCode;
@@ -39,8 +38,7 @@ import static org.openrewrite.Tree.randomId;
 @EqualsAndHashCode(callSuper = false)
 public class StringFormatted extends Recipe {
 
-    private static final MethodMatcher STRING_FORMAT =
-            new MethodMatcher("java.lang.String format(String, ..)");
+    private static final MethodMatcher STRING_FORMAT = new MethodMatcher("java.lang.String format(String, ..)");
 
     @Override
     public String getDisplayName() {
@@ -89,7 +87,6 @@ public class StringFormatted extends Recipe {
                 // Ensures formatting recipes chained together with this one will still work as expected
                 mi = mi.withArguments(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)));
             }
-
             return maybeAutoFormat(methodInvocation, mi, ctx);
         }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.openrewrite.java.migrate.lang;
 
 import lombok.EqualsAndHashCode;
@@ -38,74 +39,77 @@ import static org.openrewrite.Tree.randomId;
 @EqualsAndHashCode(callSuper = false)
 public class StringFormatted extends Recipe {
 
-    private static final MethodMatcher STRING_FORMAT = new MethodMatcher("java.lang.String format(String, ..)");
+  private static final MethodMatcher STRING_FORMAT =
+      new MethodMatcher("java.lang.String format(String, ..)");
 
+  @Override
+  public String getDisplayName() {
+    return "Prefer `String.formatted(Object...)`";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Prefer `String.formatted(Object...)` over `String.format(String, Object...)` in Java 17 or higher.";
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getVisitor() {
+    return Preconditions.check(
+        Preconditions.and(new UsesJavaVersion<>(17), new UsesMethod<>(STRING_FORMAT)),
+        new StringFormattedVisitor());
+  }
+
+  private static class StringFormattedVisitor extends JavaVisitor<ExecutionContext> {
     @Override
-    public String getDisplayName() {
-        return "Prefer `String.formatted(Object...)`";
+    public J visitMethodInvocation(J.MethodInvocation m, ExecutionContext ctx) {
+      m = (J.MethodInvocation) super.visitMethodInvocation(m, ctx);
+      if (!STRING_FORMAT.matches(m) || m.getMethodType() == null) {
+        return m;
+      }
+      m = makeFirstArgumentPrefixAsEmpty(m);
+      List<Expression> arguments = m.getArguments();
+
+      maybeRemoveImport("java.lang.String.format");
+      J.MethodInvocation mi = m.withName(m.getName().withSimpleName("formatted"));
+      JavaType.Method formatted = m.getMethodType().getDeclaringType().getMethods().stream()
+          .filter(it -> it.getName().equals("formatted"))
+          .findAny()
+          .orElse(null);
+      mi = mi.withMethodType(formatted);
+      if (mi.getName().getType() != null) {
+        mi = mi.withName(mi.getName().withType(mi.getMethodType()));
+      }
+      boolean wrapperNotNeeded = wrapperNotNeeded(arguments.get(0));
+      Expression select = wrapperNotNeeded ? arguments.get(0) :
+          new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY,
+              JRightPadded.build(arguments.get(0)));
+      mi = mi.withSelect(select);
+      mi = mi.withArguments(arguments.subList(1, arguments.size()));
+      if (mi.getArguments().isEmpty()) {
+        // To store spaces between the parenthesis of a method invocation argument list
+        // Ensures formatting recipes chained together with this one will still work as expected
+        mi = mi.withArguments(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)));
+      }
+
+      return maybeAutoFormat(m, mi, ctx);
     }
 
-    @Override
-    public String getDescription() {
-        return "Prefer `String.formatted(Object...)` over `String.format(String, Object...)` in Java 17 or higher.";
+    private static J.MethodInvocation makeFirstArgumentPrefixAsEmpty(J.MethodInvocation m) {
+      List<Expression> newArgs = m.getArguments();
+      newArgs.set(0, m.getArguments().get(0).withPrefix(Space.EMPTY));
+      return m.withArguments(newArgs);
     }
 
-    @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(
-            Preconditions.and(new UsesJavaVersion<>(17), new UsesMethod<>(STRING_FORMAT)),
-            new StringFormattedVisitor());
+    private static boolean wrapperNotNeeded(Expression expression) {
+      return expression instanceof J.Identifier
+          || expression instanceof J.Literal
+          || expression instanceof J.MethodInvocation
+          || expression instanceof J.FieldAccess;
     }
+  }
 
-    private static class StringFormattedVisitor extends JavaVisitor<ExecutionContext> {
-        @Override
-        public J visitMethodInvocation(J.MethodInvocation m, ExecutionContext ctx) {
-            m = (J.MethodInvocation) super.visitMethodInvocation(m, ctx);
-            if (!STRING_FORMAT.matches(m) || m.getMethodType() == null) {
-                return m;
-            }
-            m = makeFirstArgumentPrefixAsEmpty(m);
-            List<Expression> arguments = m.getArguments();
-
-            maybeRemoveImport("java.lang.String.format");
-            J.MethodInvocation mi = m.withName(m.getName().withSimpleName("formatted"));
-            JavaType.Method formatted = m.getMethodType().getDeclaringType().getMethods().stream()
-                .filter(it -> it.getName().equals("formatted"))
-                .findAny()
-                .orElse(null);
-            mi = mi.withMethodType(formatted);
-            if (mi.getName().getType() != null) {
-                mi = mi.withName(mi.getName().withType(mi.getMethodType()));
-            }
-            boolean wrapperNotNeeded = wrapperNotNeeded(arguments.get(0));
-            Expression select = wrapperNotNeeded ? arguments.get(0) :
-                new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(arguments.get(0)));
-            mi = mi.withSelect(select);
-            mi = mi.withArguments(arguments.subList(1, arguments.size()));
-            if(mi.getArguments().isEmpty()) {
-                // To store spaces between the parenthesis of a method invocation argument list
-                // Ensures formatting recipes chained together with this one will still work as expected
-                mi = mi.withArguments(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)));
-            }
-
-            return maybeAutoFormat(m, mi, ctx);
-        }
-
-        private static J.MethodInvocation makeFirstArgumentPrefixAsEmpty(J.MethodInvocation m) {
-            List<Expression> newArgs = m.getArguments();
-            newArgs.set(0, m.getArguments().get(0).withPrefix(Space.EMPTY));
-            return m.withArguments(newArgs);
-        }
-        private static boolean wrapperNotNeeded(Expression expression) {
-            return expression instanceof J.Identifier
-                || expression instanceof J.Literal
-                || expression instanceof J.MethodInvocation
-                || expression instanceof J.FieldAccess;
-        }
-    }
-
-    @Override
-    public Duration getEstimatedEffortPerOccurrence() {
-        return Duration.ofMinutes(1);
-    }
+  @Override
+  public Duration getEstimatedEffortPerOccurrence() {
+    return Duration.ofMinutes(1);
+  }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -61,17 +61,17 @@ public class StringFormatted extends Recipe {
 
     private static class StringFormattedVisitor extends JavaVisitor<ExecutionContext> {
         @Override
-        public J visitMethodInvocation(J.MethodInvocation m, ExecutionContext ctx) {
-            m = (J.MethodInvocation) super.visitMethodInvocation(m, ctx);
-            if (!STRING_FORMAT.matches(m) || m.getMethodType() == null) {
-                return m;
+        public J visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
+            methodInvocation = (J.MethodInvocation) super.visitMethodInvocation(methodInvocation, ctx);
+            if (!STRING_FORMAT.matches(methodInvocation) || methodInvocation.getMethodType() == null) {
+                return methodInvocation;
             }
-            m = makeFirstArgumentPrefixAsEmpty(m);
-            List<Expression> arguments = m.getArguments();
+            methodInvocation = makeFirstArgumentPrefixAsEmpty(methodInvocation);
+            List<Expression> arguments = methodInvocation.getArguments();
 
             maybeRemoveImport("java.lang.String.format");
-            J.MethodInvocation mi = m.withName(m.getName().withSimpleName("formatted"));
-            JavaType.Method formatted = m.getMethodType().getDeclaringType().getMethods().stream()
+            J.MethodInvocation mi = methodInvocation.withName(methodInvocation.getName().withSimpleName("formatted"));
+            JavaType.Method formatted = methodInvocation.getMethodType().getDeclaringType().getMethods().stream()
                     .filter(it -> it.getName().equals("formatted"))
                     .findAny()
                     .orElse(null);
@@ -91,7 +91,7 @@ public class StringFormatted extends Recipe {
                 mi = mi.withArguments(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)));
             }
 
-            return maybeAutoFormat(m, mi, ctx);
+            return maybeAutoFormat(methodInvocation, mi, ctx);
         }
 
         private static J.MethodInvocation makeFirstArgumentPrefixAsEmpty(J.MethodInvocation m) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/StringFormatted.java
@@ -39,77 +39,77 @@ import static org.openrewrite.Tree.randomId;
 @EqualsAndHashCode(callSuper = false)
 public class StringFormatted extends Recipe {
 
-  private static final MethodMatcher STRING_FORMAT =
-      new MethodMatcher("java.lang.String format(String, ..)");
+    private static final MethodMatcher STRING_FORMAT =
+            new MethodMatcher("java.lang.String format(String, ..)");
 
-  @Override
-  public String getDisplayName() {
-    return "Prefer `String.formatted(Object...)`";
-  }
-
-  @Override
-  public String getDescription() {
-    return "Prefer `String.formatted(Object...)` over `String.format(String, Object...)` in Java 17 or higher.";
-  }
-
-  @Override
-  public TreeVisitor<?, ExecutionContext> getVisitor() {
-    return Preconditions.check(
-        Preconditions.and(new UsesJavaVersion<>(17), new UsesMethod<>(STRING_FORMAT)),
-        new StringFormattedVisitor());
-  }
-
-  private static class StringFormattedVisitor extends JavaVisitor<ExecutionContext> {
     @Override
-    public J visitMethodInvocation(J.MethodInvocation m, ExecutionContext ctx) {
-      m = (J.MethodInvocation) super.visitMethodInvocation(m, ctx);
-      if (!STRING_FORMAT.matches(m) || m.getMethodType() == null) {
-        return m;
-      }
-      m = makeFirstArgumentPrefixAsEmpty(m);
-      List<Expression> arguments = m.getArguments();
-
-      maybeRemoveImport("java.lang.String.format");
-      J.MethodInvocation mi = m.withName(m.getName().withSimpleName("formatted"));
-      JavaType.Method formatted = m.getMethodType().getDeclaringType().getMethods().stream()
-          .filter(it -> it.getName().equals("formatted"))
-          .findAny()
-          .orElse(null);
-      mi = mi.withMethodType(formatted);
-      if (mi.getName().getType() != null) {
-        mi = mi.withName(mi.getName().withType(mi.getMethodType()));
-      }
-      boolean wrapperNotNeeded = wrapperNotNeeded(arguments.get(0));
-      Expression select = wrapperNotNeeded ? arguments.get(0) :
-          new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY,
-              JRightPadded.build(arguments.get(0)));
-      mi = mi.withSelect(select);
-      mi = mi.withArguments(arguments.subList(1, arguments.size()));
-      if (mi.getArguments().isEmpty()) {
-        // To store spaces between the parenthesis of a method invocation argument list
-        // Ensures formatting recipes chained together with this one will still work as expected
-        mi = mi.withArguments(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)));
-      }
-
-      return maybeAutoFormat(m, mi, ctx);
+    public String getDisplayName() {
+        return "Prefer `String.formatted(Object...)`";
     }
 
-    private static J.MethodInvocation makeFirstArgumentPrefixAsEmpty(J.MethodInvocation m) {
-      List<Expression> newArgs = m.getArguments();
-      newArgs.set(0, m.getArguments().get(0).withPrefix(Space.EMPTY));
-      return m.withArguments(newArgs);
+    @Override
+    public String getDescription() {
+        return "Prefer `String.formatted(Object...)` over `String.format(String, Object...)` in Java 17 or higher.";
     }
 
-    private static boolean wrapperNotNeeded(Expression expression) {
-      return expression instanceof J.Identifier
-          || expression instanceof J.Literal
-          || expression instanceof J.MethodInvocation
-          || expression instanceof J.FieldAccess;
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                Preconditions.and(new UsesJavaVersion<>(17), new UsesMethod<>(STRING_FORMAT)),
+                new StringFormattedVisitor());
     }
-  }
 
-  @Override
-  public Duration getEstimatedEffortPerOccurrence() {
-    return Duration.ofMinutes(1);
-  }
+    private static class StringFormattedVisitor extends JavaVisitor<ExecutionContext> {
+        @Override
+        public J visitMethodInvocation(J.MethodInvocation m, ExecutionContext ctx) {
+            m = (J.MethodInvocation) super.visitMethodInvocation(m, ctx);
+            if (!STRING_FORMAT.matches(m) || m.getMethodType() == null) {
+                return m;
+            }
+            m = makeFirstArgumentPrefixAsEmpty(m);
+            List<Expression> arguments = m.getArguments();
+
+            maybeRemoveImport("java.lang.String.format");
+            J.MethodInvocation mi = m.withName(m.getName().withSimpleName("formatted"));
+            JavaType.Method formatted = m.getMethodType().getDeclaringType().getMethods().stream()
+                    .filter(it -> it.getName().equals("formatted"))
+                    .findAny()
+                    .orElse(null);
+            mi = mi.withMethodType(formatted);
+            if (mi.getName().getType() != null) {
+                mi = mi.withName(mi.getName().withType(mi.getMethodType()));
+            }
+            boolean wrapperNotNeeded = wrapperNotNeeded(arguments.get(0));
+            Expression select = wrapperNotNeeded ? arguments.get(0) :
+                    new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY,
+                            JRightPadded.build(arguments.get(0)));
+            mi = mi.withSelect(select);
+            mi = mi.withArguments(arguments.subList(1, arguments.size()));
+            if (mi.getArguments().isEmpty()) {
+                // To store spaces between the parenthesis of a method invocation argument list
+                // Ensures formatting recipes chained together with this one will still work as expected
+                mi = mi.withArguments(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)));
+            }
+
+            return maybeAutoFormat(m, mi, ctx);
+        }
+
+        private static J.MethodInvocation makeFirstArgumentPrefixAsEmpty(J.MethodInvocation m) {
+            List<Expression> newArgs = m.getArguments();
+            newArgs.set(0, m.getArguments().get(0).withPrefix(Space.EMPTY));
+            return m.withArguments(newArgs);
+        }
+
+        private static boolean wrapperNotNeeded(Expression expression) {
+            return expression instanceof J.Identifier
+                   || expression instanceof J.Literal
+                   || expression instanceof J.MethodInvocation
+                   || expression instanceof J.FieldAccess;
+        }
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
@@ -480,7 +480,7 @@ class StringFormattedTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/453")
-    void shouldNotReturnNewLineWhenWeHasNewLineAfterTheOpenParenparenthesis() {
+    void doNotRetainTrailingWhitespaceWhenFirstArgumentOnNewLine() {
         //language=java
         rewriteRun(
           version(

--- a/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
@@ -28,8 +27,7 @@ import static org.openrewrite.java.Assertions.version;
 class StringFormattedTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new StringFormatted())
-          .typeValidationOptions(new TypeValidation().methodInvocations(false));
+        spec.recipe(new StringFormatted());
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.openrewrite.java.migrate.lang;
 
 import org.junit.jupiter.api.Test;
@@ -95,10 +94,10 @@ class StringFormattedTest implements RewriteTest {
             java(
               """
                 package com.example.app;
-
+                
                 class A {
                     String str = String.format(getTemplateString(), "a");
-
+                
                     private String getTemplateString() {
                         return "foo %s";
                     }
@@ -106,10 +105,10 @@ class StringFormattedTest implements RewriteTest {
                 """,
               """
                 package com.example.app;
-
+                
                 class A {
                     String str = getTemplateString().formatted("a");
-
+                
                     private String getTemplateString() {
                         return "foo %s";
                     }
@@ -485,7 +484,8 @@ class StringFormattedTest implements RewriteTest {
         //language=java
         rewriteRun(
           version(
-            java("""
+            java(
+              """
                 class A {
                     String str = String.format(
                     "foo %s %s",

--- a/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
@@ -477,4 +477,31 @@ class StringFormattedTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/453")
+    void shouldNotReturnNewLineWhenWeHasNewLineAfterTheOpenParenparenthesis() {
+        //language=java
+        rewriteRun(
+          version(
+            java("""
+                class A {
+                    String str = String.format(
+                    "foo %s %s",
+                        "a",
+                        "b");
+                }
+                """,
+              """
+                class A {
+                    String str = "foo %s %s".formatted(
+                            "a",
+                            "b");
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.openrewrite.java.migrate.lang;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
I updated the StringFormattedVisitor class to remove return line for the first argument

## What's your motivation?
Integrating openRewitre team

- #453

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
