### PR TITLE
fix: Handle ImmutableOf as Select on MethodInvocation

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
@@ -115,7 +115,7 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
                 return super.visitMethodInvocation(method, ctx);
             }
 
-            private boolean isParentTypeDownCast(MethodCall method) {
+            private boolean isParentTypeDownCast(MethodCall immutableMethod) {
                 J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
                 boolean isParentTypeDownCast = false;
                 if (parent instanceof J.VariableDeclarations.NamedVariable) {
@@ -138,8 +138,7 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
                     }
                 } else if (parent instanceof J.MethodInvocation) {
                     J.MethodInvocation m = (J.MethodInvocation) parent;
-                    int index = m.getArguments().indexOf(method);
-
+                    int index = m.getArguments().indexOf(immutableMethod);
                     if (m.getMethodType() != null && index != -1) {
                         isParentTypeDownCast = isParentTypeMatched(m.getMethodType().getParameterTypes().get(index));
                     }

--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
@@ -68,7 +68,7 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                if (IMMUTABLE_MATCHER.matches(method) && isParentTypeDownCast()) {
+                if (IMMUTABLE_MATCHER.matches(method) && isParentTypeDownCast(method)) {
                     maybeRemoveImport(guavaType);
                     maybeAddImport(javaType);
 
@@ -115,7 +115,7 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
                 return super.visitMethodInvocation(method, ctx);
             }
 
-            private boolean isParentTypeDownCast() {
+            private boolean isParentTypeDownCast(MethodCall method) {
                 J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
                 boolean isParentTypeDownCast = false;
                 if (parent instanceof J.VariableDeclarations.NamedVariable) {
@@ -138,14 +138,9 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
                     }
                 } else if (parent instanceof J.MethodInvocation) {
                     J.MethodInvocation m = (J.MethodInvocation) parent;
-                    if (m.getMethodType() != null) {
-                        int index = 0;
-                        for (Expression argument : m.getArguments()) {
-                            if (IMMUTABLE_MATCHER.matches(argument)) {
-                                break;
-                            }
-                            index++;
-                        }
+                    int index = m.getArguments().indexOf(method);
+
+                    if (m.getMethodType() != null && index != -1) {
                         isParentTypeDownCast = isParentTypeMatched(m.getMethodType().getParameterTypes().get(index));
                     }
                 } else if (parent instanceof J.NewClass) {

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListOfTest.java
@@ -313,6 +313,41 @@ class NoGuavaImmutableListOfTest implements RewriteTest {
     }
 
     @Test
+    void doNotChangeMethodInvocationWithSelect() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+
+              public class A {
+                  Object[] list;
+                  public void method(Object[] list ) {
+                      this.list = list;
+                  }
+              }
+              """
+          ),
+          version(
+            //language=java
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(ImmutableList.of().toArray());
+                    }
+                }
+                """
+            ),
+            11
+          )
+        );
+    }
+
+    @Test
     void methodInvocationWithListArgument() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Fix the bug in the ImmutableOf recipe. The current implementation does not account for the scenario where ImmutableOf is the 'select' property of a MethodInvocation.

Stack trace 
```
"java.lang.IndexOutOfBoundsException: Index: 1
  java.base/java.util.Collections$EmptyList.get(Collections.java:4807)
  org.openrewrite.java.migrate.guava.AbstractNoGuavaImmutableOf$1.isParentTypeDownCast(AbstractNoGuavaImmutableOf.java:149)
  org.openrewrite.java.migrate.guava.AbstractNoGuavaImmutableOf$1.visitMethodInvocation(AbstractNoGuavaImmutableOf.java:71)
  org.openrewrite.java.migrate.guava.AbstractNoGuavaImmutableOf$1.visitMethodInvocation(AbstractNoGuavaImmutableOf.java:68)
  org.openrewrite.java.tree.J$MethodInvocation.acceptJava(J.java:3905)
  org.openrewrite.java.tree.J.accept(J.java:59)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:245)
  org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:317)
  org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1365)
  org.openrewrite.java.JavaVisitor.visitMethodInvocation(JavaVisitor.java:911)
  org.openrewrite.java.migrate.guava.AbstractNoGuavaImmutableOf$1.visitMethodInvocation(AbstractNoGuavaImmutableOf.java:115)
  org.openrewrite.java.migrate.guava.AbstractNoGuavaImmutableOf$1.visitMethodInvocation(AbstractNoGuavaImmutableOf.java:68)
  org.openrewrite.java.tree.J$MethodInvocation.acceptJava(J.java:3905)
  org.openrewrite.java.tree.J.accept(J.java:59)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:245)
  org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:317)
  ..."
````

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files


## Future Work
Ideally I would like to recipe handle the above case also. Will create another PR to handle such scenario.