### PR TITLE
Drop unnecessary trailing escape in UseTextBlocks

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -125,9 +125,9 @@ public class UseTextBlocks extends Recipe {
 
                 StringBuilder sb = new StringBuilder();
                 StringBuilder originalContent = new StringBuilder();
-                stringLiterals = stringLiterals.stream().filter(s -> s.getValue() != null
-                    && !s.getValue().toString().isEmpty()).collect(Collectors.toList());
-
+                stringLiterals = stringLiterals.stream()
+                        .filter(s -> s.getValue() != null && !s.getValue().toString().isEmpty())
+                        .collect(Collectors.toList());
                 for (int i = 0; i < stringLiterals.size(); i++) {
                     String s = requireNonNull(stringLiterals.get(i).getValue()).toString();
                     sb.append(s);
@@ -178,14 +178,10 @@ public class UseTextBlocks extends Recipe {
             }
 
             private boolean isEndsWithSpecialCharacters(String content) {
-                boolean isEndsWithQuotationMark = content.endsWith("\"");
-                boolean isEndsWithEqual = content.endsWith("=");
-                boolean isEndsWithCurlyBrackets = content.endsWith("}");
-                boolean isEndsWithSemicolon = content.endsWith(";");
-                return isEndsWithQuotationMark
-                    || isEndsWithEqual
-                    || isEndsWithCurlyBrackets
-                    || isEndsWithSemicolon;
+                return content.endsWith("\"") ||
+                       content.endsWith("=") ||
+                       content.endsWith("}") ||
+                       content.endsWith(";");
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -125,7 +125,9 @@ public class UseTextBlocks extends Recipe {
 
                 StringBuilder sb = new StringBuilder();
                 StringBuilder originalContent = new StringBuilder();
-                stringLiterals = stringLiterals.stream().filter(s -> s.getValue() != null && !s.getValue().toString().isEmpty()).collect(Collectors.toList());
+                stringLiterals = stringLiterals.stream().filter(s -> s.getValue() != null
+                    && !s.getValue().toString().isEmpty()).collect(Collectors.toList());
+
                 for (int i = 0; i < stringLiterals.size(); i++) {
                     String s = requireNonNull(stringLiterals.get(i).getValue()).toString();
                     sb.append(s);
@@ -139,8 +141,6 @@ public class UseTextBlocks extends Recipe {
                     }
                 }
 
-                content = sb.toString();
-
                 TabsAndIndentsStyle tabsAndIndentsStyle = Optional.ofNullable(getCursor().firstEnclosingOrThrow(SourceFile.class)
                         .getStyle(TabsAndIndentsStyle.class)).orElse(IntelliJ.tabsAndIndents());
                 boolean useTab = tabsAndIndentsStyle.getUseTabCharacter();
@@ -148,12 +148,11 @@ public class UseTextBlocks extends Recipe {
 
                 String indentation = getIndents(concatenation, useTab, tabSize);
 
-                boolean isEndsWithNewLine = content.endsWith("\n");
-
                 // references:
                 //  - https://docs.oracle.com/en/java/javase/14/docs/specs/text-blocks-jls.html
                 //  - https://javaalmanac.io/features/textblocks/
 
+                content = sb.toString();
                 // escape backslashes
                 content = content.replace("\\", "\\\\");
                 // escape triple quotes
@@ -170,12 +169,23 @@ public class UseTextBlocks extends Recipe {
 
                 // add last line to ensure the closing delimiter is in a new line to manage indentation & remove the
                 // need to escape ending quote in the content
-                if (!isEndsWithNewLine) {
+                if (isEndsWithSpecialCharacters(sb.toString())) {
                     content = content + "\\\n" + indentation;
                 }
 
                 return new J.Literal(randomId(), binary.getPrefix(), Markers.EMPTY, originalContent.toString(),
                         String.format("\"\"\"%s\"\"\"", content), null, JavaType.Primitive.String);
+            }
+
+            private boolean isEndsWithSpecialCharacters(String content) {
+                boolean isEndsWithQuotationMark = content.endsWith("\"");
+                boolean isEndsWithEqual = content.endsWith("=");
+                boolean isEndsWithCurlyBrackets = content.endsWith("}");
+                boolean isEndsWithSemicolon = content.endsWith(";");
+                return isEndsWithQuotationMark
+                    || isEndsWithEqual
+                    || isEndsWithCurlyBrackets
+                    || isEndsWithSemicolon;
             }
         });
     }

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -88,8 +88,7 @@ class UseTextBlocksTest implements RewriteTest {
                       String query = \"""
                           SELECT * FROM   \\s
                           my_table   \\s
-                          WHERE something = 1; \\
-                          \""";
+                          WHERE something = 1; \""";
               }
               """
           )
@@ -738,8 +737,7 @@ class UseTextBlocksTest implements RewriteTest {
               class Test {
                   String eightQuotes = ""\"
                                  ""\\""\"\\""\"\\
-                                 after 8 quotes\\
-                                 ""\";
+                                 after 8 quotes""\";
               }
               """
           )
@@ -859,5 +857,30 @@ class UseTextBlocksTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void textBlockTrailingEscape() {
+        rewriteRun(
+          spec -> spec.recipe(new UseTextBlocks()),
+          java(
+            """
+             package com.helloworld;
+
+             public class Main {
+                 String foo =
+                     "hello\\n"
+                         + "world";
+            }""",
+            """
+             package com.helloworld;
+
+             public class Main {
+                 String foo =
+                     \"""
+                     hello
+                     world\""";
+            }""",
+            src -> src.markers(javaVersion(17))));
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -860,6 +860,7 @@ class UseTextBlocksTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/555")
     void textBlockTrailingEscape() {
         rewriteRun(
           spec -> spec.recipe(new UseTextBlocks()),


### PR DESCRIPTION
## What's changed?
i added some control to not create unnecessary trailing escape in some cases on the other hand I leave them in the case where the text ends with Quotation Mark, Equal, Curly Brackets and Semicolon because I saw that it is more readable like that

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
