### PR TITLE
`UseEnumSetOf` should rewrite `EnumSet.noneOf` from empty `Set.of()`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
@@ -22,14 +22,14 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.StringJoiner;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 public class UseEnumSetOf extends Recipe {
     private static final MethodMatcher SET_OF = new MethodMatcher("java.util.Set of(..)", true);
@@ -86,7 +86,7 @@ public class UseEnumSetOf extends Recipe {
                                     .apply(updateCursor(mi), mi.getCoordinates().replace());
                         }
 
-                        StringJoiner  setOf = new StringJoiner(", ", "EnumSet.of(", ")");
+                        StringJoiner setOf = new StringJoiner(", ", "EnumSet.of(", ")");
                         args.forEach(o -> setOf.add("#{any()}"));
                         return JavaTemplate.builder(setOf.toString())
                                 .contextSensitive()

--- a/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
@@ -20,8 +20,8 @@ import static java.util.Collections.singletonList;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
@@ -56,44 +56,47 @@ public class UseEnumSetOf extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(SET_OF)), new JavaIsoVisitor<ExecutionContext>() {
-            @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                J.MethodInvocation methodInvocation = super.visitMethodInvocation(method, ctx);
+                new UsesMethod<>(SET_OF)), new UseEnumSetOfVisitor());
+    }
 
-                if (SET_OF.matches(method) && method.getType() instanceof JavaType.Parameterized
-                    && !TypeUtils.isOfClassType(method.getType(), METHOD_TYPE)) {
-                    Cursor parent = getCursor().dropParentUntil(is -> is instanceof J.Assignment || is instanceof J.VariableDeclarations || is instanceof J.Block);
-                    if (!(parent.getValue() instanceof J.Block)) {
-                        JavaType type = parent.getValue() instanceof J.Assignment ?
-                                ((J.Assignment) parent.getValue()).getType() : ((J.VariableDeclarations) parent.getValue()).getVariables().get(0).getType();
-                        if (isAssignmentSetOfEnum(type)) {
-                            maybeAddImport(METHOD_TYPE);
+    private static class UseEnumSetOfVisitor extends JavaVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation methodInvocation = (J.MethodInvocation)  super.visitMethodInvocation(method, ctx);
 
-                            List<Expression> args = methodInvocation.getArguments();
-                            if (isArrayParameter(args)) {
-                                return methodInvocation;
-                            }
-                            StringJoiner setOf = initStringJoiner(args);
-                            args.forEach(o -> setOf.add("#{any()}"));
+            if (SET_OF.matches(method) && method.getType() instanceof JavaType.Parameterized
+                && !TypeUtils.isOfClassType(method.getType(), METHOD_TYPE)) {
+                Cursor parent = getCursor().dropParentUntil(is -> is instanceof J.Assignment || is instanceof J.VariableDeclarations || is instanceof J.Block);
+                if (!(parent.getValue() instanceof J.Block)) {
+                    JavaType type = parent.getValue() instanceof J.Assignment ?
+                        ((J.Assignment) parent.getValue()).getType() : ((J.VariableDeclarations) parent.getValue()).getVariables().get(0).getType();
+                    if (isAssignmentSetOfEnum(type)) {
+                        maybeAddImport(METHOD_TYPE);
 
-                            return createNewMethodInvocation(methodInvocation, (JavaType.Parameterized) type, setOf);
+                        List<Expression> args = methodInvocation.getArguments();
+                        if (isArrayParameter(args)) {
+                            return methodInvocation;
                         }
+                        StringJoiner setOf = initStringJoiner(args);
+                        args.forEach(o -> setOf.add("#{any()}"));
+
+                        return createNewMethodInvocation(methodInvocation, (JavaType.Parameterized) type, setOf);
                     }
                 }
-                return methodInvocation;
             }
+            return methodInvocation;
+        }
 
-            private StringJoiner initStringJoiner(List<Expression> args) {
-                if(args.get(0) instanceof J.Empty) {
-                    return new StringJoiner(", ", "EnumSet.noneOf(", ")");
-                }
-                return new StringJoiner(", ", "EnumSet.of(", ")");
+        private StringJoiner initStringJoiner(List<Expression> args) {
+            if(args.get(0) instanceof J.Empty) {
+                return new StringJoiner(", ", "EnumSet.noneOf(", ")");
             }
+            return new StringJoiner(", ", "EnumSet.of(", ")");
+        }
 
-          private J.MethodInvocation createNewMethodInvocation(J.MethodInvocation methodInvocation,
-                                                         JavaType.Parameterized type,
-                                                         StringJoiner setOf) {
+        private J.MethodInvocation createNewMethodInvocation(J.MethodInvocation methodInvocation,
+                                                             JavaType.Parameterized type,
+                                                             StringJoiner setOf) {
             J.MethodInvocation visitMethodInvocation = JavaTemplate.builder(setOf.toString())
                 .contextSensitive()
                 .imports(METHOD_TYPE)
@@ -102,37 +105,37 @@ public class UseEnumSetOf extends Recipe {
                     methodInvocation.getArguments().toArray());
 
             if (methodInvocation.getArguments().get(0) instanceof J.Empty) {
-              JavaType.Method methodType = methodInvocation.getMethodType().withName("noneOf");
-              JavaType.Class parameterType = JavaType.ShallowClass.build(
-                  type.getTypeParameters().get(0).toString());
-              return visitMethodInvocation.withMethodType(methodType)
-                  .withArguments(singletonList(new J.Identifier(
-                      Tree.randomId(), Space.EMPTY, methodInvocation.getMarkers(), emptyList(),
-                      parameterType.getClassName() + ".class", parameterType, null)));
+                JavaType.Method methodType = methodInvocation.getMethodType().withName("noneOf");
+                JavaType.Class parameterType = JavaType.ShallowClass.build(
+                    type.getTypeParameters().get(0).toString());
+                return visitMethodInvocation.withMethodType(methodType)
+                    .withArguments(singletonList(new J.Identifier(
+                        Tree.randomId(), Space.EMPTY, methodInvocation.getMarkers(), emptyList(),
+                        parameterType.getClassName() + ".class", parameterType, null)));
             }
             return visitMethodInvocation;
-          }
+        }
 
-            private boolean isAssignmentSetOfEnum(@Nullable JavaType type) {
-                if (type instanceof JavaType.Parameterized) {
-                    JavaType.Parameterized parameterized = (JavaType.Parameterized) type;
-                    if (TypeUtils.isOfClassType(parameterized.getType(), "java.util.Set")) {
-                        return ((JavaType.Parameterized) type).getTypeParameters().stream()
-                                .filter(org.openrewrite.java.tree.JavaType.Class.class::isInstance)
-                                .map(org.openrewrite.java.tree.JavaType.Class.class::cast)
-                                .anyMatch(o -> o.getKind() == JavaType.FullyQualified.Kind.Enum);
-                    }
+        private boolean isAssignmentSetOfEnum(@Nullable JavaType type) {
+            if (type instanceof JavaType.Parameterized) {
+                JavaType.Parameterized parameterized = (JavaType.Parameterized) type;
+                if (TypeUtils.isOfClassType(parameterized.getType(), "java.util.Set")) {
+                    return ((JavaType.Parameterized) type).getTypeParameters().stream()
+                        .filter(org.openrewrite.java.tree.JavaType.Class.class::isInstance)
+                        .map(org.openrewrite.java.tree.JavaType.Class.class::cast)
+                        .anyMatch(o -> o.getKind() == JavaType.FullyQualified.Kind.Enum);
                 }
+            }
+            return false;
+        }
+
+        private boolean isArrayParameter(final List<Expression> args) {
+            if (args.size() != 1) {
                 return false;
             }
-
-            private boolean isArrayParameter(final List<Expression> args) {
-                if (args.size() != 1) {
-                    return false;
-                }
-                JavaType type = args.get(0).getType();
-                return TypeUtils.asArray(type) != null;
-            }
-        });
+            JavaType type = args.get(0).getType();
+            return TypeUtils.asArray(type) != null;
+        }
     }
+
 }

--- a/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
@@ -18,8 +18,16 @@ package org.openrewrite.java.migrate.util;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.StringJoiner;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.*;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
@@ -30,10 +38,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.StringJoiner;
 
 public class UseEnumSetOf extends Recipe {
     private static final MethodMatcher SET_OF = new MethodMatcher("java.util.Set of(..)", true);
@@ -64,8 +68,9 @@ public class UseEnumSetOf extends Recipe {
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation methodInvocation = (J.MethodInvocation)  super.visitMethodInvocation(method, ctx);
 
-            if (SET_OF.matches(method) && method.getType() instanceof JavaType.Parameterized
-                && !TypeUtils.isOfClassType(method.getType(), METHOD_TYPE)) {
+            if (SET_OF.matches(method) &&
+                method.getType() instanceof JavaType.Parameterized &&
+                !TypeUtils.isOfClassType(method.getType(), METHOD_TYPE)) {
                 Cursor parent = getCursor().dropParentUntil(is -> is instanceof J.Assignment || is instanceof J.VariableDeclarations || is instanceof J.Block);
                 if (!(parent.getValue() instanceof J.Block)) {
                     JavaType type = parent.getValue() instanceof J.Assignment ?

--- a/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
@@ -157,4 +157,41 @@ class UseEnumSetOfTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/490")
+    void nonof() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+                import java.util.concurrent.TimeUnit;
+                class Test {
+                
+                    public void method() {
+                        Set<TimeUnit> warm = Set.of();
+                    }
+                }
+                """,
+              """
+                import java.util.EnumSet;
+                import java.util.Set;
+                import java.util.concurrent.TimeUnit;
+                
+                class Test {
+
+                    public void method() {
+                        Set<TimeUnit> warm = EnumSet.noneOf(TimeUnit.class);
+                    }
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+
 }

--- a/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
@@ -160,8 +160,7 @@ class UseEnumSetOfTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/490")
-    void nonof() {
-        //language=java
+    void dontHaveArgs() {
         rewriteRun(
           version(
             java(

--- a/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
@@ -39,7 +39,7 @@ class UseEnumSetOfTest implements RewriteTest {
             java(
               """
                 import java.util.Set;
-
+                
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -52,7 +52,7 @@ class UseEnumSetOfTest implements RewriteTest {
               """
                 import java.util.EnumSet;
                 import java.util.Set;
-
+                
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -76,7 +76,7 @@ class UseEnumSetOfTest implements RewriteTest {
             java(
               """
                 import java.util.Set;
-
+                
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -90,7 +90,7 @@ class UseEnumSetOfTest implements RewriteTest {
               """
                 import java.util.EnumSet;
                 import java.util.Set;
-
+                
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -116,7 +116,7 @@ class UseEnumSetOfTest implements RewriteTest {
             java(
               """
                 import java.util.Set;
-
+                
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -141,7 +141,7 @@ class UseEnumSetOfTest implements RewriteTest {
             java(
               """
                 import java.util.Set;
-
+                
                 class Test {
                     public enum Color {
                         RED, GREEN, BLUE
@@ -180,7 +180,7 @@ class UseEnumSetOfTest implements RewriteTest {
                 import java.util.concurrent.TimeUnit;
                 
                 class Test {
-
+                
                     public void method() {
                         Set<TimeUnit> warm = EnumSet.noneOf(TimeUnit.class);
                     }

--- a/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
@@ -161,6 +161,7 @@ class UseEnumSetOfTest implements RewriteTest {
     @Test
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/490")
     void dontHaveArgs() {
+        //language=java
         rewriteRun(
           version(
             java(
@@ -191,6 +192,4 @@ class UseEnumSetOfTest implements RewriteTest {
           )
         );
     }
-
-
 }


### PR DESCRIPTION
## What's changed?
Rewriting with EnumSet.noneOf from empty Set.of() by UseEnumSetOf

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
