### PR TITLE
Migrate Spring annotations to JSpecify

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
     testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
+    testRuntimeOnly("org.springframework:spring-core:6.1.13")
     testRuntimeOnly("com.google.code.findbugs:jsr305:3.0.2")
     testRuntimeOnly(gradleApi())
 }

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -26,6 +26,7 @@ recipeList:
   - org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
   - org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
   - org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
+  - org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -86,6 +87,27 @@ recipeList:
       ignoreDefinition: true
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.jetbrains.annotations.NotNull
+      newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
+      ignoreDefinition: true
+  - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
+      annotationType: org.jspecify.annotations.*
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations
+displayName: Migrate from Spring Framework annotations to JSpecify
+description: Migrate from Spring Framework annotations to JSpecify.
+recipeList:
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.jspecify
+      artifactId: jspecify
+      version: 1.0.0
+      onlyIfUsing: org.springframework.lang.*ull*
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.lang.Nullable
+      newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.lang.NonNull
       newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
       ignoreDefinition: true
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -31,7 +31,7 @@ class MigrateToJspecifyTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .recipeFromResource("/META-INF/rewrite/jspecify.yml", "org.openrewrite.java.jspecify.MigrateToJspecify")
-          .parser(JavaParser.fromJavaVersion().classpath("jsr305", "jakarta.annotation-api", "annotations"));
+          .parser(JavaParser.fromJavaVersion().classpath("jsr305", "jakarta.annotation-api", "annotations", "spring-core"));
     }
 
     @DocumentExample
@@ -45,7 +45,7 @@ class MigrateToJspecifyTest implements RewriteTest {
                 """
                   import javax.annotation.Nonnull;
                   import javax.annotation.Nullable;
-                  
+
                   public class Test {
                       @Nonnull
                       public String field1;
@@ -54,7 +54,7 @@ class MigrateToJspecifyTest implements RewriteTest {
                       @Nullable
                       public Foo.Bar foobar;
                   }
-                  
+
                   interface Foo {
                     class Bar {
                       @Nonnull
@@ -65,16 +65,16 @@ class MigrateToJspecifyTest implements RewriteTest {
                 """
                   import org.jspecify.annotations.NonNull;
                   import org.jspecify.annotations.Nullable;
-                  
+
                   public class Test {
                       @NonNull
                       public String field1;
                       @Nullable
                       public String field2;
-                  
+
                       public Foo.@Nullable Bar foobar;
                   }
-                  
+
                   interface Foo {
                     class Bar {
                       @NonNull
@@ -300,6 +300,97 @@ class MigrateToJspecifyTest implements RewriteTest {
                             <groupId>org.jspecify</groupId>
                             <artifactId>jspecify</artifactId>
                             <version>1.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void migrateFromSpringFrameworkAnnotationsToJspecify() {
+        rewriteRun(
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import org.springframework.lang.NonNull;
+                  import org.springframework.lang.Nullable;
+
+                  public class Test {
+                      @NonNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                      @Nullable
+                      public Foo.Bar foobar;
+                  }
+
+                  interface Foo {
+                    class Bar {
+                      @NonNull
+                      public String barField;
+                    }
+                  }
+                  """,
+                """
+                  import org.jspecify.annotations.NonNull;
+                  import org.jspecify.annotations.Nullable;
+
+                  public class Test {
+                      @NonNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+
+                      public Foo.@Nullable Bar foobar;
+                  }
+
+                  interface Foo {
+                    class Bar {
+                      @NonNull
+                      public String barField;
+                    }
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-core</artifactId>
+                            <version>6.1.13</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jspecify</groupId>
+                            <artifactId>jspecify</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-core</artifactId>
+                            <version>6.1.13</version>
                         </dependency>
                     </dependencies>
                 </project>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

add Spring Annotations migration recipe to jspecify.yml 

## What's your motivation?


![image](https://github.com/user-attachments/assets/6294d9cc-2df2-47ca-950c-f3abbfa38502)



## Anything in particular you'd like reviewers to focus on?

n/a

## Anyone you would like to review specifically?

n/a

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
