### PR TITLE
`Preconditions.checkNotNull` recipes should retain unrelated `String.valueOf(String)`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
@@ -56,21 +56,4 @@ public class NoGuavaRefaster {
             return java.util.Objects.requireNonNull(object, String.valueOf(message));
         }
     }
-
-    @RecipeDescriptor(
-            name = "`String.valueof(String)` to `String`",
-            description = "Migrate from `String.valueof(String)` to `String`, mainly as a cleanup after other recipes."
-    )
-    public static class StringValueOfString {
-        @BeforeTemplate
-        @SuppressWarnings("UnnecessaryCallToStringValueOf")
-        String before(String string) {
-            return String.valueOf(string);
-        }
-
-        @AfterTemplate
-        String after(String string) {
-            return (string);
-        }
-    }
 }

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
@@ -45,7 +45,7 @@ public class NoGuavaRefaster {
 
     // Note: Order of the below two recipes are important.
     @RecipeDescriptor(
-            name = "`Preconditions.checkNotNull` with message to `Objects.requireNonNull`",
+            name = "`Preconditions.checkNotNull` with `String` message to `Objects.requireNonNull`",
             description = "Migrate from Guava `Preconditions.checkNotNull` to Java 8 `java.util.Objects.requireNonNull`."
     )
     public static class PreconditionsCheckNotNullWithMessageToObjectsRequireNonNull {
@@ -61,7 +61,7 @@ public class NoGuavaRefaster {
     }
 
     @RecipeDescriptor(
-        name = "`Preconditions.checkNotNull` with message to `Objects.requireNonNull`",
+        name = "`Preconditions.checkNotNull` with `Object` message to `Objects.requireNonNull` with `String.valueOf`",
         description = "Migrate from Guava `Preconditions.checkNotNull` to Java 8 `java.util.Objects.requireNonNull`."
     )
     public static class PreconditionsCheckNotNullWithMessageToObjectsRequireNonNullMessageTypeObject {

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
@@ -19,8 +19,6 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import org.openrewrite.java.template.RecipeDescriptor;
 
-import java.util.Objects;
-
 @RecipeDescriptor(
         name = "Refaster style Guava to Java migration recipes",
         description = "Recipes that migrate from Guava to Java, using Refaster style templates for cases beyond what declarative recipes can cover."

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaRefaster.java
@@ -19,6 +19,8 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import org.openrewrite.java.template.RecipeDescriptor;
 
+import java.util.Objects;
+
 @RecipeDescriptor(
         name = "Refaster style Guava to Java migration recipes",
         description = "Recipes that migrate from Guava to Java, using Refaster style templates for cases beyond what declarative recipes can cover."
@@ -41,11 +43,28 @@ public class NoGuavaRefaster {
         }
     }
 
+    // Note: Order of the below two recipes are important.
     @RecipeDescriptor(
             name = "`Preconditions.checkNotNull` with message to `Objects.requireNonNull`",
             description = "Migrate from Guava `Preconditions.checkNotNull` to Java 8 `java.util.Objects.requireNonNull`."
     )
     public static class PreconditionsCheckNotNullWithMessageToObjectsRequireNonNull {
+        @BeforeTemplate
+        Object before(Object object, String message) {
+            return com.google.common.base.Preconditions.checkNotNull(object, message);
+        }
+
+        @AfterTemplate
+        Object after(Object object, String message) {
+            return java.util.Objects.requireNonNull(object, message);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "`Preconditions.checkNotNull` with message to `Objects.requireNonNull`",
+        description = "Migrate from Guava `Preconditions.checkNotNull` to Java 8 `java.util.Objects.requireNonNull`."
+    )
+    public static class PreconditionsCheckNotNullWithMessageToObjectsRequireNonNullMessageTypeObject {
         @BeforeTemplate
         Object before(Object object, Object message) {
             return com.google.common.base.Preconditions.checkNotNull(object, message);


### PR DESCRIPTION
## What's changed?
String.valueOf(String) and the String itself are not equivalent, especially when the value of the String is null. When the String is null, String.valueOf(String) returns the literal "null", whereas directly referencing the String would result in a null value.
Also the intended purpose of recipe (String.ofValue) was to only update the expressions which was previously updated by "PreconditionsCheckNotNullWithMessageToObjectsRequireNonNull", in such case adding a marker to the expression and then selectively updating the marked expression is desired but it seems difficult to do with refasterstyle templates.

So deleted the refaster template for this conversion.



### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
