### PR TITLE
Johnzon upgrade for Jakarta 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr353")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
+    testRuntimeOnly("org.apache.johnzon:johnzon-core:1.2.18")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
     testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
     testRuntimeOnly("org.springframework:spring-core:6.1.13")

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -957,6 +957,7 @@ recipeList:
       artifactId: jakarta.json-api
       scope: provided
       version: 2.1.X
+      onlyIfUsing: org.apache.johnzon..*
 ---
 # Currently this recipe is only updating the artifacts to a version that is compatible with J2EE 9. There still may be
 # breaking changes to the Rest Assured API that need to be addressed.

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -952,10 +952,11 @@ recipeList:
       groupId: org.apache.johnzon
       artifactId: "*"
       newVersion: latest.release
-  - org.openrewrite.maven.ChangeDependencyClassifier:
-      groupId: org.apache.johnzon
-      artifactId: "*"
-      newClassifier: jakarta
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: jakarta.json
+      artifactId: jakarta.json-api
+      scope: provided
+      version: 2.1.X
 ---
 # Currently this recipe is only updating the artifacts to a version that is compatible with J2EE 9. There still may be
 # breaking changes to the Rest Assured API that need to be addressed.

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JohnzonJavaxtoJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JohnzonJavaxtoJakartaTest.java
@@ -63,25 +63,34 @@ class JohnzonJavaxtoJakartaTest implements RewriteTest {
                 assertThat(actual).isNotNull();
                 Matcher version = Pattern.compile("<johnzon.version>([0-9]+\\.[0-9]+\\.[0-9]+)</johnzon.version>")
                   .matcher(actual);
+
+                Matcher jsonApiVersion = Pattern.compile("2.1.\\d+").matcher(actual);
+                assertThat(jsonApiVersion.find()).describedAs("Expected jakarta.json-api 2.1.x version in %s", actual).isTrue();
+
                 assertThat(version.find()).isTrue();
                 return """
-                  <project>
-                      <groupId>com.example.ehcache</groupId>
-                      <artifactId>johnzon-legacy</artifactId>
-                      <version>1.0.0</version>
-                      <properties>
-                          <johnzon.version>%s</johnzon.version>
-                      </properties>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.apache.johnzon</groupId>
-                              <artifactId>johnzon-core</artifactId>
-                              <version>${johnzon.version}</version>
-                              <classifier>jakarta</classifier>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """.formatted(version.group(1));
+                <project>
+                    <groupId>com.example.ehcache</groupId>
+                    <artifactId>johnzon-legacy</artifactId>
+                    <version>1.0.0</version>
+                    <properties>
+                        <johnzon.version>%s</johnzon.version>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.johnzon</groupId>
+                            <artifactId>johnzon-core</artifactId>
+                            <version>${johnzon.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>jakarta.json</groupId>
+                            <artifactId>jakarta.json-api</artifactId>
+                            <version>%s</version>
+                            <scope>provided</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """.formatted(version.group(1), jsonApiVersion.group(0));
             })
           )
         );


### PR DESCRIPTION
Current implementation moves up the version of all `org.apachae.johnzon` artifacts as well as adds `jakarta` classifier to each artifact.
I saw https://johnzon.apache.org/download.html and figured that this is exactly what needs to be done. However, after running the Boot 3.x upgrade recipe (part of which is Johnzon lib migration) I saw errors in the POM that the dependency with the classifier cannot be found (at least on the Maven Central perhaps?).

I looked at https://johnzon.apache.org/ and having dependencies without the classifier and adding:
```xml
    <dependency>
      <groupId>jakarta.json</groupId>
      <artifactId>jakarta.json-api</artifactId>
      <version>2.1.2</version>
      <scope>provided</scope> <!-- or compile if your environment doesn't provide it -->
    </dependency>
```
as the docs suggested makes everything compile.