### PR TITLE
Draft: Test to reproduce retention of first arg prefix in StringFormatted recipe

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
@@ -503,4 +503,32 @@ class StringFormattedTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/573")
+    void doNotRetainPrefixOfTheFirstArgument() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                class A {
+                    void foo(String bar) {
+                        String.format(
+                        "my string %s", bar);
+                    }
+                }
+                """,
+              """
+                class A {
+                    void foo(String bar) {
+                        "my string %s".formatted(bar);
+                    }
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's your motivation?
- https://github.com/openrewrite/rewrite-migrate-java/issues/573

## Any additional context
- https://github.com/openrewrite/rewrite-migrate-java/issues/573#issuecomment-2407779951
