### PR TITLE
Add recipe to upgrade `jakarta.annotation-api` to 2.1.x version

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -36,6 +36,7 @@ recipeList:
   - org.openrewrite.java.migrate.jakarta.JavaxBeanValidationXmlToJakartaBeanValidationXml
   - org.openrewrite.java.migrate.jakarta.JavaxToJakartaCdiExtensions
   - org.openrewrite.java.migrate.jakarta.UpdateJakartaPlatform10
+  - org.openrewrite.java.migrate.jakarta.UpdateJakartaAnnotations2
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.ServletCookieBehaviorChangeRFC6265
@@ -289,3 +290,13 @@ recipeList:
       groupId: jakarta.platform
       artifactId: "*"
       newVersion: 10.0.0
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.UpdateJakartaAnnotations2
+displayName: Update Jakarta EE annotation Dependencies to 2.1.x.
+description: Update Jakarta EE annotation Dependencies to 2.1.x.
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.annotations
+      artifactId: jakarta.annotation-api
+      newVersion: 2.1.*

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -299,4 +299,4 @@ recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.annotations
       artifactId: jakarta.annotation-api
-      newVersion: 2.1.*
+      newVersion: 2.1.x


### PR DESCRIPTION
## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Jakarta annotations 2.1 is intended to be used with JEE 10 as mentioned here: https://jakarta.ee/specifications/annotations/2.1/

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
