### PR TITLE
Temporarily remove Recipes Related to ChangeType until #4582 fixed

### DIFF
--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -37,9 +37,6 @@ recipeList:
   - org.openrewrite.java.migrate.guava.NoGuavaSetsNewLinkedHashSet
   - org.openrewrite.java.migrate.guava.PreferJavaNioCharsetStandardCharsets
   - org.openrewrite.java.migrate.guava.PreferJavaUtilOptional
-  - org.openrewrite.java.migrate.guava.PreferJavaUtilFunction
-  - org.openrewrite.java.migrate.guava.PreferJavaUtilPredicate
-  - org.openrewrite.java.migrate.guava.PreferJavaUtilSupplier
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsEquals
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsHashCode
   - org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsUnmodifiableNavigableMap

--- a/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilOptionalTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/PreferJavaUtilOptionalTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.migrate.guava;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ExpectedToFail;
@@ -135,6 +136,7 @@ class PreferJavaUtilOptionalTest implements RewriteTest {
             """));
     }
 
+    @Disabled
     @Test
     void orSupplierToOrElseGetWithSupplierArgument() {
         //language=java


### PR DESCRIPTION
## What's changed?
Removed three recipes based on ChangeType Recipe for nogauva recipe list as they incorrectly updates the type. more detail https://github.com/openrewrite/rewrite/issues/4582

## What's your motivation?
Make noguava recipe stable.


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
