### PR TITLE
Recipes to replace Guava `Immutable{Set|List|Map}.copyOf()` with Java `{Set|List|Map}.copyOf()`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableCopyOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableCopyOf.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+abstract class AbstractNoGuavaImmutableCopyOf extends Recipe {
+
+    private final String guavaType;
+    private final String javaType;
+
+    AbstractNoGuavaImmutableCopyOf(String guavaType, String javaType) {
+        this.guavaType = guavaType;
+        this.javaType = javaType;
+    }
+
+    private String getShortType(String fullyQualifiedType) {
+        return fullyQualifiedType.substring(javaType.lastIndexOf(".") + 1);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Prefer `" + getShortType(javaType) + ".copyOf(..)` in Java 10 or higher";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces `" + getShortType(guavaType) + ".copyOf(..)` if the returned type is immediately down-cast.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(10);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(10),
+                new UsesType<>(guavaType, false));
+        final MethodMatcher IMMUTABLE_MATCHER = new MethodMatcher(guavaType + " copyOf(..)");
+        return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (IMMUTABLE_MATCHER.matches(method) && isParentTypeDownCast(method)) {
+                    maybeRemoveImport(guavaType);
+                    maybeAddImport(javaType);
+
+                    String template = method.getArguments().stream()
+                            .map(arg -> {
+                                if (arg.getType() instanceof JavaType.Primitive) {
+                                    String type = "";
+                                    if (JavaType.Primitive.Boolean == arg.getType()) {
+                                        type = "Boolean";
+                                    } else if (JavaType.Primitive.Byte == arg.getType()) {
+                                        type = "Byte";
+                                    } else if (JavaType.Primitive.Char == arg.getType()) {
+                                        type = "Character";
+                                    } else if (JavaType.Primitive.Double == arg.getType()) {
+                                        type = "Double";
+                                    } else if (JavaType.Primitive.Float == arg.getType()) {
+                                        type = "Float";
+                                    } else if (JavaType.Primitive.Int == arg.getType()) {
+                                        type = "Integer";
+                                    } else if (JavaType.Primitive.Long == arg.getType()) {
+                                        type = "Long";
+                                    } else if (JavaType.Primitive.Short == arg.getType()) {
+                                        type = "Short";
+                                    } else if (JavaType.Primitive.String == arg.getType()) {
+                                        type = "String";
+                                    }
+                                    return TypeUtils.asFullyQualified(JavaType.buildType("java.lang." + type));
+                                } else {
+                                    return TypeUtils.asFullyQualified(arg.getType());
+                                }
+                            })
+                            .filter(Objects::nonNull)
+                            .map(type -> "#{any(" + type.getFullyQualifiedName() + ")}")
+                            .collect(Collectors.joining(",", getShortType(javaType) + ".copyOf(", ")"));
+
+                    return JavaTemplate.builder(template)
+                            .contextSensitive()
+                            .imports(javaType)
+                            .build()
+                            .apply(getCursor(),
+                                    method.getCoordinates().replace(),
+                                    method.getArguments().get(0) instanceof J.Empty ? new Object[]{} : method.getArguments().toArray());
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+
+            private boolean isParentTypeDownCast(MethodCall immutableMethod) {
+                J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
+                boolean isParentTypeDownCast = false;
+                if (parent instanceof J.VariableDeclarations.NamedVariable) {
+                    isParentTypeDownCast = isParentTypeMatched(((J.VariableDeclarations.NamedVariable) parent).getType());
+                } else if (parent instanceof J.Assignment) {
+                    J.Assignment a = (J.Assignment) parent;
+                    if (a.getVariable() instanceof J.Identifier && ((J.Identifier) a.getVariable()).getFieldType() != null) {
+                        isParentTypeDownCast = isParentTypeMatched(((J.Identifier) a.getVariable()).getFieldType().getType());
+                    } else if (a.getVariable() instanceof J.FieldAccess) {
+                        isParentTypeDownCast = isParentTypeMatched(a.getVariable().getType());
+                    }
+                } else if (parent instanceof J.Return) {
+                    // Does not currently support returns in lambda expressions.
+                    J j = getCursor().dropParentUntil(is -> is instanceof J.MethodDeclaration || is instanceof J.CompilationUnit).getValue();
+                    if (j instanceof J.MethodDeclaration) {
+                        TypeTree returnType = ((J.MethodDeclaration) j).getReturnTypeExpression();
+                        if (returnType != null) {
+                            isParentTypeDownCast = isParentTypeMatched(returnType.getType());
+                        }
+                    }
+                } else if (parent instanceof J.MethodInvocation) {
+                    J.MethodInvocation m = (J.MethodInvocation) parent;
+                    int index = m.getArguments().indexOf(immutableMethod);
+                    if (m.getMethodType() != null && index != -1) {
+                        isParentTypeDownCast = isParentTypeMatched(m.getMethodType().getParameterTypes().get(index));
+                    }
+                } else if (parent instanceof J.NewClass) {
+                    J.NewClass c = (J.NewClass) parent;
+                    int index = 0;
+                    if (c.getConstructorType() != null) {
+                        for (Expression argument : c.getArguments()) {
+                            if (IMMUTABLE_MATCHER.matches(argument)) {
+                                break;
+                            }
+                            index++;
+                        }
+                        if (c.getConstructorType() != null) {
+                            isParentTypeDownCast = isParentTypeMatched(c.getConstructorType().getParameterTypes().get(index));
+                        }
+                    }
+                } else if (parent instanceof J.NewArray) {
+                    J.NewArray a = (J.NewArray) parent;
+                    JavaType arrayType = a.getType();
+                    while (arrayType instanceof JavaType.Array) {
+                        arrayType = ((JavaType.Array) arrayType).getElemType();
+                    }
+
+                    isParentTypeDownCast = isParentTypeMatched(arrayType);
+                }
+                return isParentTypeDownCast;
+            }
+
+            private boolean isParentTypeMatched(@Nullable JavaType type) {
+                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
+                return TypeUtils.isOfClassType(fq, javaType) ||
+                       TypeUtils.isOfClassType(fq, "java.lang.Object");
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListCopyOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListCopyOf.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+public class NoGuavaImmutableListCopyOf extends AbstractNoGuavaImmutableCopyOf {
+    public NoGuavaImmutableListCopyOf() {
+        super("com.google.common.collect.ImmutableList", "java.util.List");
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapCopyOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapCopyOf.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+public class NoGuavaImmutableMapCopyOf extends AbstractNoGuavaImmutableCopyOf {
+    public NoGuavaImmutableMapCopyOf() {
+        super("com.google.common.collect.ImmutableMap", "java.util.Map");
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetCopyOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetCopyOf.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+public class NoGuavaImmutableSetCopyOf extends AbstractNoGuavaImmutableCopyOf {
+    public NoGuavaImmutableSetCopyOf() {
+        super("com.google.common.collect.ImmutableSet", "java.util.Set");
+    }
+}

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -77,6 +77,9 @@ recipeList:
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableListOf
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableMapOf
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableSetOf
+  - org.openrewrite.java.migrate.guava.NoGuavaImmutableListCopyOf
+  - org.openrewrite.java.migrate.guava.NoGuavaImmutableMapCopyOf
+  - org.openrewrite.java.migrate.guava.NoGuavaImmutableSetCopyOf
   - org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsRequireNonNullElse
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: io.springfox

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListCopyOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListCopyOfTest.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+class NoGuavaImmutableListCopyOfTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new NoGuavaImmutableListCopyOf())
+          .parser(JavaParser.fromJavaVersion().classpath("guava"));
+    }
+
+    @Test
+    void doNotChangeReturnsImmutableList() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.collect.ImmutableList;
+
+              class Test {
+                  ImmutableList<String> getList() {
+                      return ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+
+    }
+
+    @Test
+    void doNotChangeFieldAssignmentToImmutableList() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.collect.ImmutableList;
+
+              class Test {
+                  ImmutableList<String> m;
+
+                  {
+                      this.m = ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeAssignsToImmutableList() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.collect.ImmutableList;
+
+              class Test {
+                  ImmutableList<String> m;
+
+                  void init() {
+                      m = ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNewClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.collect.ImmutableList;
+
+              public class A {
+                  ImmutableList<String> immutableList;
+                  public A(ImmutableList<String> immutableList) {
+                      this.immutableList = immutableList;
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import com.google.common.collect.ImmutableList;
+
+              class Test {
+                  A a = new A(ImmutableList.copyOf(new String[]{"A", "B", "C"}));
+              }
+              """)
+        );
+    }
+
+    @Test
+    void doNotChangeMethodInvocation() {
+        rewriteRun(
+          spec -> spec.parser(
+            JavaParser.fromJavaVersion()
+              .classpath("guava")
+              .dependsOn(
+                //language=java
+                """
+                  import com.google.common.collect.ImmutableList;
+
+                  public class A {
+                      ImmutableList<String> immutableList;
+                      public void method(ImmutableList<String> immutableList) {
+                          this.immutableList = immutableList;
+                      }
+                  }
+                  """
+              )
+          ),
+          //language=java
+          java(
+            """
+              import com.google.common.collect.ImmutableList;
+
+              class Test {
+                  void method() {
+                      A a = new A();
+                      a.method(ImmutableList.copyOf(new String[]{"A", "B", "C"}));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceArguments() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.List;
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    List<String> m = ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                }
+                """,
+              """
+                import java.util.List;
+
+                class Test {
+                    List<String> m = List.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void fieldAssignmentToList() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.List;
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    List<String> m;
+                    {
+                        this.m = ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """,
+              """
+                import java.util.List;
+
+                class Test {
+                    List<String> m;
+                    {
+                        this.m = List.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void assignmentToList() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.List;
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    List<String> m = ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                }
+                """,
+              """
+                import java.util.List;
+
+                class Test {
+                    List<String> m = List.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void returnsList() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.List;
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    List<String> list() {
+                        return ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """,
+              """
+                import java.util.List;
+
+                class Test {
+                    List<String> list() {
+                        return List.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void newClassWithListArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+
+              public class A {
+                  List<String> list;
+                  public A(List<String> list) {
+                      this.list = list;
+                  }
+              }
+              """
+          ),
+          version(
+            //language=java
+            java(
+              """
+                  import com.google.common.collect.ImmutableList;
+
+                  class Test {
+                      A a = new A(ImmutableList.copyOf(new String[]{"A", "B", "C"}));
+                  }
+                """,
+              """
+                  import java.util.List;
+
+                  class Test {
+                      A a = new A(List.copyOf(new String[]{"A", "B", "C"}));
+                  }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeMethodInvocationWithSelect() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+
+              public class A {
+                  Object[] list;
+                  public void method(Object[] list ) {
+                      this.list = list;
+                  }
+              }
+              """
+          ),
+          version(
+            //language=java
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(ImmutableList.copyOf(new String[]{"A", "B", "C"}).toArray());
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void methodInvocationWithListArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+
+              public class A {
+                  List<String> list;
+                  public void method(List<String> list) {
+                      this.list = list;
+                  }
+              }
+              """
+          ),
+          version(
+            //language=java
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(ImmutableList.copyOf(new String[]{"A", "B", "C"}));
+                    }
+                }
+                """,
+              """
+                import java.util.List;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(List.copyOf(new String[]{"A", "B", "C"}));
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/137")
+    @Test
+    void listOfInts() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.List;
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    List<Integer> list() {
+                        return ImmutableList.copyOf(new Integer[]{1, 2, 3});
+                    }
+                }
+                """,
+              """
+                import java.util.List;
+
+                class Test {
+                    List<Integer> list() {
+                        return List.copyOf(new Integer[]{1, 2, 3});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/138")
+    @Test
+    void insideAnonymousArrayInitializer() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+
+                class A {
+                    Object[] o = new Object[] {
+                            ImmutableList.copyOf(new Integer[]{1, 2, 3})
+                    };
+                }
+                """,
+              """
+                import java.util.List;
+
+                class A {
+                    Object[] o = new Object[] {
+                            List.copyOf(new Integer[]{1, 2, 3})
+                    };
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/136")
+    @Test
+    void assignToMoreGeneralType() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+
+                class A {
+                    Object o = ImmutableList.copyOf(new Integer[]{1, 2, 3});
+                }
+                """,
+              """
+                import java.util.List;
+
+                class A {
+                    Object o = List.copyOf(new Integer[]{1, 2, 3});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotChangeNestedLists() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+                import java.util.List;
+
+                class A {
+                    Object o = List.of(ImmutableList.copyOf(new Integer[]{1, 2}), ImmutableList.copyOf(new Integer[]{2, 3}));
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotchangeAssignToImmutableList() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    ImmutableList<String> l = ImmutableList.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapCopyOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapCopyOfTest.java
@@ -1,0 +1,490 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+class NoGuavaImmutableMapCopyOfTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new NoGuavaImmutableMapCopyOf())
+          .parser(JavaParser.fromJavaVersion().classpath("guava"));
+    }
+
+    @Test
+    void doNotChangeReturnsImmutableMap() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.collect.ImmutableMap;
+
+              class Test {
+                  ImmutableMap<String, String> getMap() {
+                      return ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeFieldAssignmentToImmutableMap() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.collect.ImmutableMap;
+
+              class Test {
+                  ImmutableMap<String, String> m;
+
+                  {
+                      this.m = ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeAssignsToImmutableMap() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.collect.ImmutableMap;
+
+              class Test {
+                  ImmutableMap<String, String> m;
+
+                  void init() {
+                      m = ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNewClass() {
+        rewriteRun(
+          spec -> spec.parser(
+            JavaParser.fromJavaVersion()
+              .classpath("guava")
+              .dependsOn(
+                //language=java
+                """
+                  import com.google.common.collect.ImmutableMap;
+
+                  public class A {
+                      ImmutableMap<String, String> immutableMap;
+                      public A(ImmutableMap<String, String> immutableMap) {
+                          this.immutableMap = immutableMap;
+                      }
+                  }
+                  """
+              )
+          ),
+          java(
+            """
+              import com.google.common.collect.ImmutableMap;
+
+              class Test {
+                  A a = new A(ImmutableMap.copyOf(new String[]{"A", "B", "C"}));
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeMethodInvocation() {
+        rewriteRun(
+          spec -> spec.parser(
+            JavaParser.fromJavaVersion()
+              .classpath("guava")
+              .dependsOn(
+                //language=java
+                """
+                  import com.google.common.collect.ImmutableMap;
+
+                  public class A {
+                      ImmutableMap<String, String> immutableMap;
+                      public void method(ImmutableMap<String, String> immutableMap) {
+                          this.immutableMap = immutableMap;
+                      }
+                  }
+                  """
+              )
+          ),
+          java(
+            """
+              import com.google.common.collect.ImmutableMap;
+
+              class Test {
+                  void method() {
+                      A a = new A();
+                      a.method(ImmutableMap.copyOf(new String[]{"A", "B", "C"}));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceArguments() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Map;
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    Map<String, String> m = ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    Map<String, String> m = Map.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void fieldAssignmentToMap() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Map;
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    Map<String, String> m;
+                    {
+                        this.m = ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    Map<String, String> m;
+                    {
+                        this.m = Map.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void assignmentToMap() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Map;
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    Map<String, String> m = ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    Map<String, String> m = Map.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void returnsMap() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Map;
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    Map<String, String> map() {
+                        return ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    Map<String, String> map() {
+                        return Map.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/137")
+    @Test
+    void mapOfInts() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Map;
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    Map<Integer, Integer> map() {
+                        return ImmutableMap.copyOf(new Integer[]{1, 2, 3});
+                    }
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    Map<Integer, Integer> map() {
+                        return Map.copyOf(new Integer[]{1, 2, 3});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void newClassWithMapArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Map;
+
+              public class A {
+                  Map<String, String> map;
+                  public A(Map<String, String> map) {
+                      this.map = map;
+                  }
+              }
+              """
+          ),
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    A a = new A(ImmutableMap.copyOf(new String[]{"A", "B", "C"}));
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    A a = new A(Map.copyOf(new String[]{"A", "B", "C"}));
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void methodInvocationWithMapArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Map;
+
+              public class A {
+                  Map<String, String> map;
+                  public void method(Map<String, String> map) {
+                      this.map = map;
+                  }
+              }
+              """
+          ),
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(ImmutableMap.copyOf(new String[]{"A", "B", "C"}));
+                    }
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(Map.copyOf(new String[]{"A", "B", "C"}));
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/138")
+    @Test
+    void insideAnonymousArrayInitializer() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableMap;
+
+                class A {
+                    Object[] o = new Object[] {
+                            ImmutableMap.copyOf(new Integer[]{1, 2, 3})
+                    };
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class A {
+                    Object[] o = new Object[] {
+                            Map.copyOf(new Integer[]{1, 2, 3})
+                    };
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/136")
+    @Test
+    void assignToMoreGeneralType() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableMap;
+
+                class A {
+                    Object o = ImmutableMap.copyOf(new Integer[]{1, 2, 3});
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class A {
+                    Object o = Map.copyOf(new Integer[]{1, 2, 3});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotChangeNestedMaps() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableMap;
+                import java.util.Map;
+
+                class A {
+                    Object o = Map.of(1, ImmutableMap.copyOf(new Integer[]{1, 2}));
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotchangeAssignToImmutableMap() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    ImmutableMap<String, String> m = ImmutableMap.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetCopyOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetCopyOfTest.java
@@ -1,0 +1,490 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+class NoGuavaImmutableSetCopyOfTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new NoGuavaImmutableSetCopyOf())
+          .parser(JavaParser.fromJavaVersion().classpath("guava"));
+    }
+
+    @Test
+    void doNotChangeReturnsImmutableSet() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.collect.ImmutableSet;
+
+              class Test {
+                  ImmutableSet<String> getSet() {
+                      return ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeFieldAssignmentToImmutableSet() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.collect.ImmutableSet;
+
+              class Test {
+                  ImmutableSet<String> m;
+
+                  {
+                      this.m = ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeAssignsToImmutableSet() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.collect.ImmutableSet;
+
+              class Test {
+                  ImmutableSet<String> m;
+
+                  void init() {
+                      m = ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNewClass() {
+        rewriteRun(
+          spec -> spec.parser(
+            JavaParser.fromJavaVersion()
+              .classpath("guava")
+              .dependsOn(
+                //language=java
+                """
+                  import com.google.common.collect.ImmutableSet;
+
+                  public class A {
+                      ImmutableSet<String> immutableSet;
+                      public A(ImmutableSet<String> immutableSet) {
+                          this.immutableSet = immutableSet;
+                      }
+                  }
+                  """
+              )
+          ),
+          java(
+            """
+              import com.google.common.collect.ImmutableSet;
+
+              class Test {
+                  A a = new A(ImmutableSet.copyOf(new String[]{"A", "B", "C"}));
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeMethodInvocation() {
+        rewriteRun(
+          spec -> spec.parser(
+            JavaParser.fromJavaVersion()
+              .classpath("guava")
+              .dependsOn(
+                //language=java
+                """
+                  import com.google.common.collect.ImmutableSet;
+
+                  public class A {
+                      ImmutableSet<String> immutableSet;
+                      public void method(ImmutableSet<String> immutableSet) {
+                          this.immutableSet = immutableSet;
+                      }
+                  }
+                  """
+              )
+          ),
+          java(
+            """
+              import com.google.common.collect.ImmutableSet;
+
+              class Test {
+                  void method() {
+                      A a = new A();
+                      a.method(ImmutableSet.copyOf(new String[]{"A", "B", "C"}));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceArguments() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    Set<String> m = ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class Test {
+                    Set<String> m = Set.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void fieldAssignmentToSet() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    Set<String> m;
+                    {
+                        this.m = ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class Test {
+                    Set<String> m;
+                    {
+                        this.m = Set.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void assignmentToSet() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    Set<String> m = ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class Test {
+                    Set<String> m = Set.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void returnsSet() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    Set<String> set() {
+                        return ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class Test {
+                    Set<String> set() {
+                        return Set.copyOf(new String[]{"A", "B", "C"});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/137")
+    @Test
+    void setOfInts() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.Set;
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    Set<Integer> set() {
+                        return ImmutableSet.copyOf(new Integer[]{1, 2, 3});
+                    }
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class Test {
+                    Set<Integer> set() {
+                        return Set.copyOf(new Integer[]{1, 2, 3});
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void newClassWithSetArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Set;
+
+              public class A {
+                  Set<String> set;
+                  public A(Set<String> set) {
+                      this.set = set;
+                  }
+              }
+              """
+          ),
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    A a = new A(ImmutableSet.copyOf(new String[]{"A", "B", "C"}));
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class Test {
+                    A a = new A(Set.copyOf(new String[]{"A", "B", "C"}));
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Test
+    void methodInvocationWithSetArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Set;
+
+              public class A {
+                  Set<String> set;
+                  public void method(Set<String> set) {
+                      this.set = set;
+                  }
+              }
+              """
+          ),
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(ImmutableSet.copyOf(new String[]{"A", "B", "C"}));
+                    }
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class Test {
+                    void method() {
+                        A a = new A();
+                        a.method(Set.copyOf(new String[]{"A", "B", "C"}));
+                    }
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/138")
+    @Test
+    void insideAnonymousArrayInitializer() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+
+                class A {
+                    Object[] o = new Object[] {
+                            ImmutableSet.copyOf(new Integer[]{1, 2, 3})
+                    };
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class A {
+                    Object[] o = new Object[] {
+                            Set.copyOf(new Integer[]{1, 2, 3})
+                    };
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/136")
+    @Test
+    void assignToMoreGeneralType() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+
+                class A {
+                    Object o = ImmutableSet.copyOf(new Integer[]{1, 2, 3});
+                }
+                """,
+              """
+                import java.util.Set;
+
+                class A {
+                    Object o = Set.copyOf(new Integer[]{1, 2, 3});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotChangeNestedSets() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+                import java.util.Set;
+
+                class A {
+                    Object o = Set.of(ImmutableSet.copyOf(new Integer[]{1, 2}));
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/256")
+    @Test
+    void doNotchangeAssignToImmutableSet() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    ImmutableSet<String> m = ImmutableSet.copyOf(new String[]{"A", "B", "C"});
+                }
+                """
+            ),
+            10
+          )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #584

Implement recipes to replace Guava `Immutable{Set|List|Map}.copyOf()` calls with Java `{Set|List|Map}.copyOf()` calls.

* Add `AbstractNoGuavaImmutableCopyOf` abstract class to handle the logic for replacing `copyOf()` calls.
* Add `NoGuavaImmutableSetCopyOf`, `NoGuavaImmutableListCopyOf`, and `NoGuavaImmutableMapCopyOf` classes extending `AbstractNoGuavaImmutableCopyOf`.
* Update `no-guava.yml` to include the new recipes.
* Add test cases for `NoGuavaImmutableSetCopyOf`, `NoGuavaImmutableListCopyOf`, and `NoGuavaImmutableMapCopyOf`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/openrewrite/rewrite-migrate-java/issues/584?shareId=88bd837e-28c1-4113-8d06-60950a29b039).