### PR TITLE
Fix UseMapOf double brace init for non-string types

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -48,40 +48,41 @@ public class UseMapOf extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.and(new UsesJavaVersion<>(10), new UsesMethod<>(NEW_HASH_MAP)), new JavaVisitor<ExecutionContext>() {
-            @Override
-            public J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
-                J.NewClass n = (J.NewClass) super.visitNewClass(newClass, ctx);
-                J.Block body = n.getBody();
-                if (NEW_HASH_MAP.matches(n) && body != null) {
-                    if (body.getStatements().size() == 1) {
-                        Statement statement = body.getStatements().get(0);
-                        if (statement instanceof J.Block) {
-                            List<Expression> args = new ArrayList<>();
-                            StringJoiner mapOf = new StringJoiner(", ", "Map.of(", ")");
-                            for (Statement stat : ((J.Block) statement).getStatements()) {
-                                if (stat instanceof J.MethodInvocation && MAP_PUT.matches((Expression) stat)) {
-                                    J.MethodInvocation put = (J.MethodInvocation) stat;
-                                    args.addAll(put.getArguments());
-                                    mapOf.add("#{}");
-                                    mapOf.add("#{}");
-                                } else {
-                                    return n;
-                                }
-                            }
+        return Preconditions.check(Preconditions.and(new UsesJavaVersion<>(10),
+            new UsesMethod<>(NEW_HASH_MAP)), new UseMapOfVisitor());
+    }
 
-                            maybeRemoveImport("java.util.HashMap");
-                            maybeAddImport("java.util.Map");
-                            return JavaTemplate.builder(mapOf.toString())
-                                    .contextSensitive()
-                                    .imports("java.util.Map")
-                                    .build()
-                                    .apply(updateCursor(n), n.getCoordinates().replace(), args.toArray());
+    private static class UseMapOfVisitor extends JavaVisitor<ExecutionContext> {
+        @Override
+        public J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+            J.NewClass n = (J.NewClass) super.visitNewClass(newClass, ctx);
+            J.Block body = n.getBody();
+            if (NEW_HASH_MAP.matches(n) && body != null && body.getStatements().size() == 1) {
+                Statement statement = body.getStatements().get(0);
+                if (statement instanceof J.Block) {
+                    List<Expression> args = new ArrayList<>();
+                    StringJoiner mapOf = new StringJoiner(", ", "Map.of(", ")");
+                    for (Statement stat : ((J.Block) statement).getStatements()) {
+                        if (!(stat instanceof J.MethodInvocation) || !MAP_PUT.matches((Expression) stat)) {
+                            return n;
                         }
+                        J.MethodInvocation put = (J.MethodInvocation) stat;
+                        args.addAll(put.getArguments());
+                        mapOf.add("#{any()}");
+                        mapOf.add("#{any()}");
                     }
+
+                    maybeRemoveImport("java.util.HashMap");
+                    maybeAddImport("java.util.Map");
+                    return JavaTemplate.builder(mapOf.toString())
+                        .contextSensitive()
+                        .imports("java.util.Map")
+                        .build()
+                        .apply(updateCursor(n), n.getCoordinates().replace(), args.toArray());
                 }
-                return n;
             }
-        });
+
+            return n;
+        }
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.util;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -53,6 +54,41 @@ class UseMapOfTest implements RewriteTest {
 
               class Test {
                   Map<String, String> m = Map.of("stru", "menta", "mod", "erne");
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/566")
+    @Test
+    void changeDoubleBraceInitForNonStringTypes() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+              private static final String BLAH ="ss";
+              
+              void foo() {
+                        new HashMap<>() {{
+                          put(BLAH, "foo");
+                      }};
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class Test {
+              private static final String BLAH ="ss";
+              
+              void foo() {
+                  Map.of(BLAH, "foo");
+                  }
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Fix org.openrewrite.java.migrate.util.UseMapOf fails on double brace init for non-string types
- Fixes #566

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
