### PR TITLE
[3/3] Implement joda to java time migration recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.openrewrite.java.migrate.joda;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.NlsRewrite;
@@ -25,7 +26,7 @@ import java.util.Set;
 public class JodaTimeRecipe extends ScanningRecipe<Set<NamedVariable>> {
     @Override
     public String getDisplayName() {
-    public String getDescription() {
+        return "Migrate Joda Time to Java Time";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -1,4 +1,18 @@
-package org.openrewrite.java.migrate.joda;
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.NlsRewrite;
@@ -10,8 +24,8 @@ import java.util.Set;
 
 public class JodaTimeRecipe extends ScanningRecipe<Set<NamedVariable>> {
     @Override
-    public @NlsRewrite.DisplayName String getDisplayName() {
-        return "Prefer java time over joda time";
+    public String getDisplayName() {
+    public String getDescription() {
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -1,0 +1,36 @@
+package org.openrewrite.java.migrate.joda;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.NlsRewrite;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.java.tree.J.VariableDeclarations.NamedVariable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class JodaTimeRecipe extends ScanningRecipe<Set<NamedVariable>> {
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Prefer java time over joda time";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Prefer the Java standard library over third-party usage of Joda Time.";
+    }
+
+    @Override
+    public Set<NamedVariable> getInitialValue(ExecutionContext ctx) {
+        return new HashSet<>();
+    }
+
+    @Override
+    public JodaTimeScanner getScanner(Set<NamedVariable> acc) {
+        return new JodaTimeScanner(acc);
+    }
+
+    @Override
+    public JodaTimeVisitor getVisitor(Set<NamedVariable> acc) {
+        return new JodaTimeVisitor(acc);
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.migrate.joda;
 
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.NlsRewrite;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.java.tree.J.VariableDeclarations.NamedVariable;
 
@@ -30,7 +29,7 @@ public class JodaTimeRecipe extends ScanningRecipe<Set<NamedVariable>> {
     }
 
     @Override
-    public @NlsRewrite.Description String getDescription() {
+    public String getDescription() {
         return "Prefer the Java standard library over third-party usage of Joda Time.";
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -122,12 +122,11 @@ public class JodaTimeVisitor extends ScopeAwareVisitor {
         if (!mayBeVar.isPresent() || unsafeVars.contains(mayBeVar.get())) {
             return assignment;
         }
-        J j = VarTemplates.getTemplate(a).apply(
+        return VarTemplates.getTemplate(a).apply(
                 updateCursor(a),
                 a.getCoordinates().replace(),
-                varName.getSimpleName(),
+                varName,
                 a.getAssignment());
-        return j;
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -122,7 +122,12 @@ public class JodaTimeVisitor extends ScopeAwareVisitor {
         if (!mayBeVar.isPresent() || unsafeVars.contains(mayBeVar.get())) {
             return assignment;
         }
-        return VarTemplates.getTemplate(a).apply(updateCursor(a), a.getCoordinates().replace(), a.getAssignment());
+        J j = VarTemplates.getTemplate(a).apply(
+                updateCursor(a),
+                a.getCoordinates().replace(),
+                varName.getSimpleName(),
+                a.getAssignment());
+        return j;
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
@@ -1,0 +1,80 @@
+package org.openrewrite.java.migrate.joda;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.VariableDeclarations.NamedVariable;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Set;
+
+@AllArgsConstructor
+public class ScopeAwareVisitor extends JavaVisitor<ExecutionContext>  {
+    protected final LinkedList<VariablesInScope> scopes;
+
+    @Override
+    public J preVisit(J j, ExecutionContext ctx) {
+        if (j instanceof J.Block) {
+            scopes.push(new VariablesInScope(getCursor()));
+        }
+        if (j instanceof J.MethodDeclaration) {
+            scopes.push(new VariablesInScope(getCursor()));
+        }
+        if (j instanceof J.VariableDeclarations.NamedVariable) {
+            assert !scopes.isEmpty();
+            NamedVariable variable = (NamedVariable) j;
+            scopes.peek().variables.add(variable);
+        }
+        return super.preVisit(j, ctx);
+    }
+
+    @Override
+    public J postVisit(J j, ExecutionContext ctx) {
+        if (j instanceof J.Block) {
+            scopes.pop();
+        }
+        return super.postVisit(j, ctx);
+    }
+
+    Cursor findScope(NamedVariable variable) {
+        for (VariablesInScope scope : scopes) {
+            if (scope.variables.contains(variable)) {
+                return scope.scope;
+            }
+        }
+        return null;
+    }
+
+    // Returns the variable in the closest scope
+    Optional<NamedVariable> findVarInScope(String varName) {
+        for (VariablesInScope scope : scopes) {
+            for (NamedVariable var : scope.variables) {
+                if (var.getSimpleName().equals(varName)) {
+                    return Optional.of(var);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    Cursor getCurrentScope() {
+        assert !scopes.isEmpty();
+        return scopes.peek().scope;
+    }
+
+    @Value
+    public static class VariablesInScope {
+        Cursor scope;
+        Set<J.VariableDeclarations.NamedVariable> variables;
+
+        public VariablesInScope(Cursor scope) {
+            this.scope = scope;
+            this.variables = new HashSet<>();
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.joda;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassMap.java
@@ -37,6 +37,12 @@ public class TimeClassMap {
         }
     };
 
+    private final Map<String, String> jodaToJavaTimeShortName = new HashMap<String, String>() {
+        {
+            put(JODA_DATE_TIME, "ZonedDateTime");
+        }
+    };
+
     private static JavaType.Class javaTypeClass(String fqn, JavaType.Class superType) {
         return new JavaType.Class(null, 0, fqn, JavaType.FullyQualified.Kind.Class, null, superType,
                 null, null, null, null, null);
@@ -44,5 +50,9 @@ public class TimeClassMap {
 
     public static JavaType.Class getJavaTimeType(String typeFqn) {
         return new TimeClassMap().jodaToJavaTimeMap.get(typeFqn);
+    }
+
+    public static String getJavaTimeShortName(String typeFqn) {
+        return new TimeClassMap().jodaToJavaTimeShortName.get(typeFqn);
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.joda.templates;
 
 import org.openrewrite.java.JavaTemplate;

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
@@ -68,14 +68,8 @@ public class VarTemplates {
     public static JavaTemplate getTemplate(J.Assignment assignment) {
         JavaType.Class type = (JavaType.Class) assignment.getAssignment().getType();
         String typeName = JodaToJavaTimeType.get(type.getFullyQualifiedName());
-        StringBuilder template = new StringBuilder();
-        assert assignment.getVariable() instanceof J.Identifier;
-        J.Identifier varName = (J.Identifier) assignment.getVariable();
-        template.append(varName.getSimpleName());
-        template.append(" = #{any(");
-        template.append(typeName);
-        template.append(")}");
-        return JavaTemplate.builder(template.toString())
+        String template = "#{} = #{any(" + typeName +")}";
+        return JavaTemplate.builder(template)
                 .build();
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
@@ -1,0 +1,80 @@
+package org.openrewrite.java.migrate.joda.templates;
+
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.openrewrite.java.migrate.joda.templates.TimeClassNames.*;
+
+public class VarTemplates {
+
+    private static Map<String, String> JodaToJavaTimeType = new HashMap<String, String>() {
+        {
+            put(JODA_DATE_TIME, JAVA_DATE_TIME);
+            put(JODA_TIME_FORMATTER, JAVA_TIME_FORMATTER);
+            put(JODA_LOCAL_DATE, JAVA_LOCAL_DATE);
+            put(JODA_LOCAL_TIME, JAVA_LOCAL_TIME);
+            put(JODA_DATE_TIME_ZONE, JAVA_ZONE_ID);
+            put(JODA_DURATION, JAVA_DURATION);
+        }
+    };
+
+    public static JavaTemplate getTemplate(J.VariableDeclarations variable) {
+        JavaType.Class type = (JavaType.Class) variable.getTypeExpression().getType();
+        String typeName = JodaToJavaTimeType.get(type.getFullyQualifiedName());
+        StringBuilder template = new StringBuilder();
+        String varName;
+        try {
+            varName = Class.forName(typeName).getSimpleName();
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Unknown type " + typeName);
+        }
+        template.append(varName);
+        template.append(" ");
+        for (int i = 0; i < variable.getVariables().size(); i++) {
+            if (i > 0) {
+                template.append(", ");
+            }
+            template.append("#{}");
+            if (variable.getVariables().get(i).getInitializer() != null) {
+                template.append(" = #{any(");
+                template.append(typeName);
+                template.append(")}");
+            }
+        }
+        return JavaTemplate.builder(template.toString())
+                .imports(typeName)
+                .build();
+    }
+
+    public static JavaTemplate getTemplate(J.Assignment assignment) {
+        JavaType.Class type = (JavaType.Class) assignment.getAssignment().getType();
+        String typeName = JodaToJavaTimeType.get(type.getFullyQualifiedName());
+        StringBuilder template = new StringBuilder();
+        assert assignment.getVariable() instanceof J.Identifier;
+        J.Identifier varName = (J.Identifier) assignment.getVariable();
+        template.append(varName.getSimpleName());
+        template.append(" = #{any(");
+        template.append(typeName);
+        template.append(")}");
+        return JavaTemplate.builder(template.toString())
+                .build();
+    }
+
+    public static Object[] getTemplateArgs(J.VariableDeclarations variable) {
+        Object[] args = new Object[variable.getVariables().size() * 2];
+        int i = 0;
+        for (J.VariableDeclarations.NamedVariable var : variable.getVariables()) {
+            args[i++] = var.getSimpleName();
+            if (var.getInitializer() != null) {
+                args[i++] = var.getInitializer();
+            }
+        }
+        Object[] args2 = new Object[i];
+        System.arraycopy(args, 0, args2, 0, i);
+        return args2;
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
@@ -67,8 +67,10 @@ public class VarTemplates {
 
     public static JavaTemplate getTemplate(J.Assignment assignment) {
         JavaType.Class type = (JavaType.Class) assignment.getAssignment().getType();
+        JavaType.Class varType = (JavaType.Class) assignment.getVariable().getType();
         String typeName = JodaToJavaTimeType.get(type.getFullyQualifiedName());
-        String template = "#{} = #{any(" + typeName +")}";
+        String varTypeName = JodaToJavaTimeType.get(varType.getFullyQualifiedName());
+        String template = "#{any(" + varTypeName + ")} = #{any(" + typeName +")}";
         return JavaTemplate.builder(template)
                 .build();
     }

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -1,0 +1,189 @@
+package org.openrewrite.java.migrate.joda;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class JodaTimeRecipeTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new JodaTimeRecipe())
+          .parser(JavaParser.fromJavaVersion().classpath("joda-time"));
+    }
+
+    @Test
+    void migrateSafeVariable() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+                            
+              class A {
+                  public void foo() {
+                      DateTime dt = new DateTime();
+                      System.out.println(dt.toDateTime());
+                  }
+              }
+              """,
+            """
+              import java.time.ZonedDateTime;
+
+              class A {
+                  public void foo() {
+                      ZonedDateTime dt = ZonedDateTime.now();
+                      System.out.println(dt);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dontChangeClassVariable() {
+        // not supported yet
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+                            
+              class A {
+                  public void foo() {
+                      DateTime dt = new DateTime();
+                      System.out.println(dt.toDateTime());
+                      System.out.println(new B().dateTime.toDateTime());
+                  }
+                  public static class B {
+                      DateTime dateTime = new DateTime();
+                  }
+              }
+              """,
+            """
+              import org.joda.time.DateTime;
+
+              import java.time.ZonedDateTime;
+                            
+              class A {
+                  public void foo() {
+                      ZonedDateTime dt = ZonedDateTime.now();
+                      System.out.println(dt);
+                      System.out.println(new B().dateTime.toDateTime());
+                  }
+                  public static class B {
+                      DateTime dateTime = new DateTime();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dontChangeIncompatibleType() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+
+              class A {
+                  public void foo() {
+                      new B().print(new DateTime()); // print is public method accepting DateTime, not handled yet
+                      System.out.println(new B().dateTime);
+                  }
+              }
+
+              class B {
+                  DateTime dateTime = new DateTime();
+                  public void print(DateTime dateTime) {
+                      System.out.println(dateTime);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noUnsafeVar() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+              import org.joda.time.DateTimeZone;
+              import java.util.Date;
+
+              class A {
+                  public void foo(String city) {
+                     DateTimeZone dtz;
+                      if ("london".equals(city)) {
+                          dtz = DateTimeZone.forID("Europe/London");
+                      } else {
+                          dtz = DateTimeZone.forID("America/New_York");
+                      }
+                      DateTime dt = new DateTime(dtz);
+                      print(dt.toDate());
+                  }
+                  private void print(Date date) {
+                      System.out.println(date);
+                  }
+              }
+              """,
+            """
+              import java.time.ZoneId;
+              import java.time.ZonedDateTime;
+              import java.util.Date;
+
+              class A {
+                  public void foo(String city) {
+                      ZoneId dtz;
+                      if ("london".equals(city)) {
+                          dtz = ZoneId.of("Europe/London");
+                      } else {
+                          dtz = ZoneId.of("America/New_York");
+                      }
+                      ZonedDateTime dt = ZonedDateTime.now(dtz);
+                      print(Date.from(dt.toInstant()));
+                  }
+                  private void print(Date date) {
+                      System.out.println(date);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void localVarUsedReferencedInReturnStatement() { // not supported yet
+        // language=java
+        rewriteRun(
+          java(
+            """
+               import org.joda.time.DateTime;
+               import org.joda.time.DateTimeZone;
+
+               class A {
+                   public DateTime foo(String city) {
+                       DateTimeZone dtz;
+                       if ("london".equals(city)) {
+                           dtz = DateTimeZone.forID("Europe/London");
+                       } else {
+                           dtz = DateTimeZone.forID("America/New_York");
+                       }
+                       DateTime dt = new DateTime(dtz);
+                       return dt.plus(2);
+                   }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.openrewrite.DocumentExample;
 package org.openrewrite.java.migrate.joda;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.openrewrite.DocumentExample;
 package org.openrewrite.java.migrate.joda;
 
 import org.junit.jupiter.api.Test;
@@ -15,6 +31,7 @@ class JodaTimeRecipeTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath("joda-time"));
     }
 
+    @DocumentExample
     @Test
     void migrateSafeVariable() {
         //language=java

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
@@ -21,6 +21,8 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.HashSet;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.java.Assertions.java;
@@ -29,14 +31,12 @@ import static org.openrewrite.test.RewriteTest.toRecipe;
 class JodaTimeScannerTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec
-          .recipe(toRecipe(JodaTimeScanner::new))
-          .parser(JavaParser.fromJavaVersion().classpath("joda-time"));
+        spec.parser(JavaParser.fromJavaVersion().classpath("joda-time"));
     }
 
     @Test
     void noUnsafeVar() {
-        JodaTimeScanner scanner = new JodaTimeScanner();
+        JodaTimeScanner scanner = new JodaTimeScanner(new HashSet<>());
         // language=java
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> scanner)),
@@ -45,7 +45,7 @@ class JodaTimeScannerTest implements RewriteTest {
                import org.joda.time.DateTime;
                import org.joda.time.DateTimeZone;
                import java.util.Date;
-              
+
                class A {
                    public void foo(String city) {
                        DateTimeZone dtz;
@@ -69,7 +69,7 @@ class JodaTimeScannerTest implements RewriteTest {
 
     @Test
     void hasUnsafeVars() {
-        JodaTimeScanner scanner = new JodaTimeScanner();
+        JodaTimeScanner scanner = new JodaTimeScanner(new HashSet<>());
         // language=java
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> scanner)),
@@ -77,7 +77,7 @@ class JodaTimeScannerTest implements RewriteTest {
             """
                import org.joda.time.DateTime;
                import org.joda.time.DateTimeZone;
-              
+
                class A {
                    DateTime dateTime;
                    public void foo(String city) {
@@ -110,7 +110,7 @@ class JodaTimeScannerTest implements RewriteTest {
 
     @Test
     void localVarReferencingClassVar() { // not supported yet
-        JodaTimeScanner scanner = new JodaTimeScanner();
+        JodaTimeScanner scanner = new JodaTimeScanner(new HashSet<>());
         // language=java
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> scanner)),
@@ -118,7 +118,7 @@ class JodaTimeScannerTest implements RewriteTest {
             """
                import org.joda.time.DateTime;
                import org.joda.time.DateTimeZone;
-              
+
                class A {
                    DateTime dateTime;
                    public void foo(String city) {
@@ -144,7 +144,7 @@ class JodaTimeScannerTest implements RewriteTest {
 
     @Test
     void localVarUsedReferencedInReturnStatement() { // not supported yet
-        JodaTimeScanner scanner = new JodaTimeScanner();
+        JodaTimeScanner scanner = new JodaTimeScanner(new HashSet<>());
         // language=java
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> scanner)),
@@ -152,7 +152,7 @@ class JodaTimeScannerTest implements RewriteTest {
             """
                import org.joda.time.DateTime;
                import org.joda.time.DateTimeZone;
-              
+
                class A {
                    public DateTime foo(String city) {
                        DateTimeZone dtz;

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
@@ -497,7 +497,7 @@ class JodaTimeVisitorTest implements RewriteTest {
 
     // Test will be removed once safe variable migration is implemented
     @Test
-    void dontChangeMethodAccessOnVariable() {
+    void migrateSafeVariable() {
         //language=java
         rewriteRun(
           java(
@@ -508,36 +508,16 @@ class JodaTimeVisitorTest implements RewriteTest {
                   public void foo() {
                       DateTime dt = new DateTime();
                       System.out.println(dt.toDateTime());
-                      System.out.println(new B().dateTime.toDateTime());
-                  }
-                  public static class B {
-                      DateTime dateTime = new DateTime();
                   }
               }
-              """
-          )
-        );
-    }
-
-    @Test
-    void dontChangeIncompatibleType() {
-        //language=java
-        rewriteRun(
-          java(
+              """,
             """
-              import org.joda.time.DateTime;
-              
+              import java.time.ZonedDateTime;
+
               class A {
                   public void foo() {
-                      new B().print(new DateTime()); // print is public method accepting DateTime, not handled yet
-                      System.out.println(new B().dateTime);
-                  }
-              }
-              
-              class B {
-                  DateTime dateTime = new DateTime();
-                  public void print(DateTime dateTime) {
-                      System.out.println(dateTime);
+                      ZonedDateTime dt = ZonedDateTime.now();
+                      System.out.println(dt);
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
This pr is the last part of implementing the migration from Joda-Time to the Java Time API. It creates a ScanningRecipe that first analyzes source files to identify variables that are unsafe to migrate. The unsafe variables are passed as accumulator to Visitor which modifies the expression 

### Key Changes:
- Created an ScanningRecipe that utilizes JodaTimeScanner and JodaTimeVisitor
- Removed the scanMode flag, instead used unsafe variables set for decide the identifier migration.
- Created `ScopeAwareVisitor` to track the scoped variables shared by both scanner and visitor.

### Not Implemented Yet:
- Support for class variables, method parameters, and other non-local variables.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
