### PR TITLE
refactor: Annotate methods which may return `null` with `@Nullable`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassMap.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.migrate.joda.templates;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.java.tree.JavaType;
 
 import java.util.HashMap;
@@ -48,11 +49,11 @@ public class TimeClassMap {
                 null, null, null, null, null);
     }
 
-    public static JavaType.Class getJavaTimeType(String typeFqn) {
+    public static @Nullable JavaType.Class getJavaTimeType(String typeFqn) {
         return new TimeClassMap().jodaToJavaTimeMap.get(typeFqn);
     }
 
-    public static String getJavaTimeShortName(String typeFqn) {
+    public static @Nullable String getJavaTimeShortName(String typeFqn) {
         return new TimeClassMap().jodaToJavaTimeShortName.get(typeFqn);
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/RemoveFinalizerFromZip.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.migrate.util;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -62,8 +63,9 @@ public class RemoveFinalizerFromZip extends Recipe {
                                 new UsesType<>(JAVA_UTIL_ZIP_INFLATER, false),
                                 new UsesType<>(JAVA_UTIL_ZIP_ZIP_FILE, false))),
                 new JavaVisitor<ExecutionContext>() {
+
                     @Override
-                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
                         if (METHOD_MATCHER.matches(mi)) {


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.staticanalysis.AnnotateNullableMethods?organizationId=T3BlblJld3JpdGU%3D