### PR TITLE
Use Java 21 toolchain for rewrite-migrate-java

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21.0.2-tem
+java=21.0.5-tem

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,12 @@ dependencies {
     testRuntimeOnly(gradleApi())
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
 tasks.withType(Javadoc::class.java) {
     exclude("**/PlanJavaMigration.java")
 }

--- a/src/test/java/org/openrewrite/java/migrate/DeleteDeprecatedFinalizeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/DeleteDeprecatedFinalizeTest.java
@@ -16,12 +16,15 @@
 package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+@EnabledForJreRange(max = JRE.JAVA_17)
 class DeleteDeprecatedFinalizeTest implements RewriteTest {
 
     @Override
@@ -38,54 +41,54 @@ class DeleteDeprecatedFinalizeTest implements RewriteTest {
           java(
             """
               package java.awt.color;
-
+              
               import java.awt.color.ICC_Profile;
               import java.awt.image.ColorModel;
               import java.awt.image.IndexColorModel;
-
+              
               public class Test {
               	public static void main(String[] args) {
               		byte ff = (byte) 0xff;
               		byte[] r = { ff, 0, 0, ff, 0 };
               		byte[] g = { 0, ff, 0, ff, 0 };
               		byte[] b = { 0, 0, ff, ff, 0 };
-
+              
               		ICC_Profile profile = ICC_Profile.getInstance(ICC_Profile.CLASS_COLORSPACECONVERSION);
               		// flag
               		profile.finalize();
-
+              
               		ColorModel cm = new IndexColorModel(3, 5, r, g, b);
-
+              
               		// flag
               		cm.finalize();
-
+              
               		IndexColorModel icm = new IndexColorModel(3, 5, r, g, b);
               		// flag
               		icm.finalize();
-
+              
               	}
               }
               """,
             """
               package java.awt.color;
-
+              
               import java.awt.color.ICC_Profile;
               import java.awt.image.ColorModel;
               import java.awt.image.IndexColorModel;
-
+              
               public class Test {
               	public static void main(String[] args) {
               		byte ff = (byte) 0xff;
               		byte[] r = { ff, 0, 0, ff, 0 };
               		byte[] g = { 0, ff, 0, ff, 0 };
               		byte[] b = { 0, 0, ff, ff, 0 };
-
+              
               		ICC_Profile profile = ICC_Profile.getInstance(ICC_Profile.CLASS_COLORSPACECONVERSION);
-
+              
               		ColorModel cm = new IndexColorModel(3, 5, r, g, b);
-
+              
               		IndexColorModel icm = new IndexColorModel(3, 5, r, g, b);
-
+              
               	}
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/util/SequencedCollectionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/SequencedCollectionTest.java
@@ -17,18 +17,15 @@ package org.openrewrite.java.migrate.util;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-
 @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/243")
-@EnabledForJreRange(min = JRE.JAVA_21)
 class SequencedCollectionTest implements RewriteTest {
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResource("/META-INF/rewrite/java-version-21.yml", "org.openrewrite.java.migrate.util.SequencedCollection");
@@ -42,8 +39,8 @@ class SequencedCollectionTest implements RewriteTest {
               //language=java
               java(
                 """
-                  import java.util.*;
-
+                  import java.util.SortedSet;
+                  
                   class Foo {
                       void bar(SortedSet<String> collection) {
                           String first = collection.first();
@@ -53,7 +50,7 @@ class SequencedCollectionTest implements RewriteTest {
                   """,
                 """
                   import java.util.*;
-
+                  
                   class Foo {
                       void bar(SortedSet<String> collection) {
                           String first = collection.getFirst();
@@ -75,7 +72,7 @@ class SequencedCollectionTest implements RewriteTest {
               java(
                 """
                   import java.util.*;
-
+                  
                   class Foo {
                       void bar(NavigableSet<String> collection) {
                           NavigableSet<String> reversed = collection.descendingSet();
@@ -84,7 +81,7 @@ class SequencedCollectionTest implements RewriteTest {
                   """,
                 """
                   import java.util.*;
-
+                  
                   class Foo {
                       void bar(NavigableSet<String> collection) {
                           NavigableSet<String> reversed = collection.reversed();

--- a/src/test/java/org/openrewrite/java/migrate/util/SequencedCollectionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/SequencedCollectionTest.java
@@ -39,7 +39,7 @@ class SequencedCollectionTest implements RewriteTest {
               //language=java
               java(
                 """
-                  import java.util.SortedSet;
+                  import java.util.*;
                   
                   class Foo {
                       void bar(SortedSet<String> collection) {


### PR DESCRIPTION
## What's your motivation?
Make it easier to test Java 21 constructs, and recipes to adopt those.

## Any additional context
- Replaces earlier attempt #337
  - Unblocked by openrewrite/rewrite#4620