### PR TITLE
Jspecify nullmarked

### DIFF
--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -47,6 +47,10 @@ recipeList:
       oldFullyQualifiedTypeName: javax.annotation.Nonnull
       newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
       ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.annotation.ParametersAreNonnullByDefault
+      newFullyQualifiedTypeName: org.jspecify.annotation.NullMarked
+      ignoreDefinition: true
   - org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType:
       annotationType: org.jspecify.annotations.*
 ---

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -82,6 +82,21 @@ class MigrateToJspecifyTest implements RewriteTest {
                     }
                   }
                   """
+              ),
+              // package-info.java
+              java(
+                """
+                  @ParametersAreNonnullByDefault
+                  package org.openrewrite.example;
+
+                  import javax.annotation.ParametersAreNonnullByDefault;
+                  """,
+                """
+                  @NullMarked
+                  package org.openrewrite.example;
+
+                  import org.jspecify.annotation.NullMarked;
+                  """
               )
             ),
             //language=xml
@@ -136,7 +151,7 @@ class MigrateToJspecifyTest implements RewriteTest {
                 """
                   import jakarta.annotation.Nonnull;
                   import jakarta.annotation.Nullable;
-                  
+
                   public class Test {
                       @Nonnull
                       public String field1;
@@ -145,7 +160,7 @@ class MigrateToJspecifyTest implements RewriteTest {
                       @Nullable
                       public Foo.Bar foobar;
                   }
-                  
+
                   interface Foo {
                     class Bar {
                       @Nonnull
@@ -156,16 +171,16 @@ class MigrateToJspecifyTest implements RewriteTest {
                 """
                   import org.jspecify.annotations.NonNull;
                   import org.jspecify.annotations.Nullable;
-                  
+
                   public class Test {
                       @NonNull
                       public String field1;
                       @Nullable
                       public String field2;
-                  
+
                       public Foo.@Nullable Bar foobar;
                   }
-                  
+
                   interface Foo {
                     class Bar {
                       @NonNull
@@ -228,7 +243,7 @@ class MigrateToJspecifyTest implements RewriteTest {
                 """
                   import org.jetbrains.annotations.NotNull;
                   import org.jetbrains.annotations.Nullable;
-                  
+
                   public class Test {
                       @NotNull
                       public String field1;
@@ -237,7 +252,7 @@ class MigrateToJspecifyTest implements RewriteTest {
                       @Nullable
                       public Foo.Bar foobar;
                   }
-                  
+
                   interface Foo {
                     class Bar {
                       @NotNull
@@ -248,16 +263,16 @@ class MigrateToJspecifyTest implements RewriteTest {
                 """
                   import org.jspecify.annotations.NonNull;
                   import org.jspecify.annotations.Nullable;
-                  
+
                   public class Test {
                       @NonNull
                       public String field1;
                       @Nullable
                       public String field2;
-                  
+
                       public Foo.@Nullable Bar foobar;
                   }
-                  
+
                   interface Foo {
                     class Bar {
                       @NonNull


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
ParametersAreNonnullByDefault on package-info.java files migration

## What's your motivation?
We need a replacement for the default not-null annotations.

## Anything in particular you'd like reviewers to focus on?
NA

## Anyone you would like to review specifically?
NA

## Have you considered any alternatives or workarounds?
NA

## Any additional context
NA

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
