### PR TITLE
Prevent breakage of usages of Spring's @Nullable

### DIFF
--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -26,7 +26,10 @@ recipeList:
   - org.openrewrite.java.jspecify.MigrateFromJavaxAnnotationApi
   - org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
   - org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
-  - org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations
+  # Running the following recipe on current versions of Spring can cause Spring to misunderstand a nullable field.
+  #   For instance, a custom Prometheus scrape endpoint with @Nullable Set<String> includedNames will fail if 
+  #   includedNames is null and if @Nullable is @org.jspecify.Nullable.
+  # - org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -28,7 +28,7 @@ recipeList:
   - org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
   # Running the following recipe on current versions of Spring can cause Spring to misunderstand a nullable field.
   #   For instance, a custom Prometheus scrape endpoint with @Nullable Set<String> includedNames will fail if 
-  #   includedNames is null and if @Nullable is @org.jspecify.Nullable.
+  #   includedNames is null and if @Nullable is @org.jspecify.annotations.Nullable.
   # - org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations
 
 ---

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/MigrateToJspecifyTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.jspecify;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -324,9 +325,13 @@ class MigrateToJspecifyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/602")
     @Test
     void migrateFromSpringFrameworkAnnotationsToJspecify() {
         rewriteRun(
+          spec -> spec.recipeFromResource(
+            "/META-INF/rewrite/jspecify.yml",
+            "org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations"),
           mavenProject("foo",
             //language=java
             srcMainJava(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
I commented out the migration from `@org.springframework.lang.Nullable` to `@org.jspecify.annotations.Nullable`. 

## What's your motivation?
Spring treats its @Nullable differently from JSpecify's @Nullable, and for custom prometheus scrape endpoints, if you pass in `@org.jspecify.annotations.Nullable Set<String> includedNames` and `includedNames` is null, the entire scrape will fail.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
The workaround considered was forking or not using the `MigrateToJSpecify` recipe, but we would prefer to use the recipe.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
