### PR TITLE
Proof that `javax.jms` is migrated to `jakarta.jms` in spring.xml

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
@@ -25,6 +25,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.xml.Assertions.xml;
 
 class JavaxToJakartaTest implements RewriteTest {
 
@@ -607,6 +608,38 @@ class JavaxToJakartaTest implements RewriteTest {
                 </project>
                 """
             )
+          )
+        );
+    }
+
+    @Test
+    void shouldRefactorSpringBeanXml() {
+        //language=java
+        rewriteRun(
+          //language=XML
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://www.springframework.org/schema/beans"
+                     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+                  <bean id="exampleBean" class="org.springframework.beans.ExampleBean">
+                      <property name="conFactory">
+                          <value>javax.jms.ConnectionFactory</value>
+                      </property>
+                  </bean>
+              </beans>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <beans xmlns="http://www.springframework.org/schema/beans"
+                     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+                  <bean id="exampleBean" class="org.springframework.beans.ExampleBean">
+                      <property name="conFactory">
+                          <value>jakarta.jms.ConnectionFactory</value>
+                      </property>
+                  </bean>
+              </beans>
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
@@ -614,7 +614,6 @@ class JavaxToJakartaTest implements RewriteTest {
 
     @Test
     void shouldRefactorSpringBeanXml() {
-        //language=java
         rewriteRun(
           //language=XML
           xml(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a testcase to prove `javax` is migrated to `jakarta` in a spring.xml beans config file

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @knutwannheden 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Uses the `Reference` trait
- https://github.com/openrewrite/rewrite/pull/4648

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
