### PR TITLE
Fix 

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -18,6 +18,8 @@ package org.openrewrite.java.migrate.lang.var;
 import org.openrewrite.Cursor;
 import org.openrewrite.java.tree.*;
 
+import javax.annotation.Nullable;
+
 import static java.util.Objects.requireNonNull;
 
 final class DeclarationCheck {
@@ -197,5 +199,31 @@ final class DeclarationCheck {
         }
 
         return isInsideInitializer(requireNonNull(cursor.getParent()), nestedBlockLevel);
+    }
+
+    /**
+     * Checks whether the initializer {@linkplain Expression} is a {@linkplain J.MethodInvocation} targeting a static method.
+     *
+     * @param initializer {@linkplain J.VariableDeclarations.NamedVariable#getInitializer()} value
+     * @return true iff is initialized by static method
+     */
+    public static boolean initializedByStaticMethod(@Nullable Expression initializer) {
+        if (initializer == null) {
+            return false;
+        }
+        initializer = initializer.unwrap();
+
+        if (!(initializer instanceof J.MethodInvocation)) {
+            // no MethodInvocation -> false
+            return false;
+        }
+
+        J.MethodInvocation invocation = (J.MethodInvocation) initializer;
+        if (invocation.getMethodType() == null) {
+            // not a static method -> false
+            return false;
+        }
+
+        return invocation.getMethodType().getFlags().contains(Flag.Static);
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -75,8 +75,10 @@ public class UseVarForObject extends Recipe {
             boolean isPrimitive = DeclarationCheck.isPrimitive(vd);
             boolean usesGenerics = DeclarationCheck.useGenerics(vd);
             boolean usesTernary = DeclarationCheck.initializedByTernary(vd);
-            boolean usesArrayInitializer = vd.getVariables().get(0).getInitializer() instanceof J.NewArray;
-            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer) {
+            Expression initializer = vd.getVariables().get(0).getInitializer();
+            boolean usesArrayInitializer = initializer instanceof J.NewArray;
+            boolean initializedByStaticMethod = DeclarationCheck.initializedByStaticMethod(initializer);
+            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer || initializedByStaticMethod) {
                 return vd;
             }
 

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
@@ -32,35 +32,6 @@ class UseVarForObjectsTest extends VarBaseTest {
           .allSources(s -> s.markers(javaVersion(10)));
     }
 
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/550")
-    void genericType() {
-        rewriteRun(
-          java(
-            """
-              import java.io.Serializable;
-              
-              abstract class Outer<T extends Serializable> {
-                  abstract T doIt();
-                  void trigger() {
-                      T x = doIt();
-                  }
-              }
-              """,
-            """
-              import java.io.Serializable;
-              
-              abstract class Outer<T extends Serializable> {
-                  abstract T doIt();
-                  void trigger() {
-                      var x = doIt();
-                  }
-              }
-              """
-          )
-        );
-    }
-
     @Nested
     class Applicable {
         @DocumentExample
@@ -336,11 +307,85 @@ class UseVarForObjectsTest extends VarBaseTest {
                   )
                 );
             }
+
+            @Test
+            @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/550")
+            void genericType() {
+                rewriteRun(
+                  java(
+                    """
+                      import java.io.Serializable;
+
+                      abstract class Outer<T extends Serializable> {
+                          abstract T doIt();
+                          void trigger() {
+                              T x = doIt();
+                          }
+                      }
+                      """,
+                    """
+                      import java.io.Serializable;
+
+                      abstract class Outer<T extends Serializable> {
+                          abstract T doIt();
+                          void trigger() {
+                              var x = doIt();
+                          }
+                      }
+                      """
+                  )
+                );
+            }
         }
     }
 
     @Nested
     class NotApplicable {
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/608")
+        void genericTypeInStaticMethod() {
+            /*
+                         * This can be migrated from `String string = Global.cast(o)` to `var string = Global.<String>cast(o)`.
+                         * But we decided to not migrate, because it is very unconventional Java.
+            */
+            rewriteRun(
+              java(
+                """
+                  package example;
+
+                  class Global {
+                      static <T> T cast(Object o) {
+                          return (T) o;
+                      }
+                  }
+                  class User {
+                      public String test() {
+                          Object o = "Hello";
+                          String string = Global.cast(o);
+                          return string;
+                      }
+                  }
+                  """,
+                """
+                  package example;
+
+                  class Global {
+                      static <T> T cast(Object o) {
+                          return (T) o;
+                      }
+                  }
+                  class User {
+                      public String test() {
+                          var o = "Hello";
+                          String string = Global.cast(o);
+                          return string;
+                      }
+                  }
+                  """
+              )
+            );
+        }
 
         @Test
         @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/551")
@@ -350,7 +395,7 @@ class UseVarForObjectsTest extends VarBaseTest {
               java(
                 """
                   package com.example.app;
-                  
+
                   class A {
                     void m() {
                         String[] dictionary = {"aa", "b", "aba", "ba"};

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
@@ -270,6 +270,7 @@ class UseVarForObjectsTest extends VarBaseTest {
             }
 
             @Test
+            @Disabled("in favor to https://github.com/openrewrite/rewrite-migrate-java/issues/608 we skip all static methods ATM")
             void staticMethods() {
                 //language=java
                 rewriteRun(
@@ -345,10 +346,7 @@ class UseVarForObjectsTest extends VarBaseTest {
         @Test
         @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/608")
         void genericTypeInStaticMethod() {
-            /*
-                         * This can be migrated from `String string = Global.cast(o)` to `var string = Global.<String>cast(o)`.
-                         * But we decided to not migrate, because it is very unconventional Java.
-            */
+            // ATM the recipe skips all static method initialized variables
             rewriteRun(
               java(
                 """


### PR DESCRIPTION
## What's changed?
Disables migration to `var` for variables initilized by static methods.

## What's your motivation?
(Hot) Fix #608

## Have you considered any alternatives or workarounds?
Skipping only those that are initialized by static *generic* Methods, but they are not sufficient identifiable.

## Any additional context
I'll recheck with the JLS and my contacts, afterward I may file a follow-up bug.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
