### PR TITLE
Add `lombok-mapstruct-binding` during Java 17 migration when both lombok and mapstruct are used

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/MigrateSecurityManagerMulticast.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/MigrateSecurityManagerMulticast.java
@@ -53,7 +53,11 @@ public class MigrateSecurityManagerMulticast extends Recipe {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
                 if (MULTICAST_METHOD.matches(m) && m.getArguments().size() == 2) {
-                    return m.withArguments(Collections.singletonList(m.getArguments().get(0)));
+                    return m.withArguments(Collections.singletonList(m.getArguments().get(0)))
+                            .withMethodType(m.getMethodType()
+                                    .withParameterNames(m.getMethodType().getParameterNames().subList(0, 1))
+                                    .withParameterTypes(m.getMethodType().getParameterTypes().subList(0, 1))
+                            );
                 }
                 return m;
             }

--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -51,6 +51,7 @@ recipeList:
       groupId: com.google.inject
       artifactId: guice
       newVersion: 5.x
+  - org.openrewrite.java.migrate.AddLombokMapstructBinding
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -285,3 +286,24 @@ recipeList:
       methodPattern: 'java.lang.Runtime traceInstructions(boolean)'
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: 'java.lang.Runtime traceMethodCalls(boolean)'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.AddLombokMapstructBinding
+displayName: Add lombok-mapstruct-binding when both MapStruct and Lombok are used
+description: Add lombok-mapstruct-binding when both MapStruct and Lombok are used.
+tags:
+  - java17
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: org.projectlombok
+      artifactIdPattern: lombok
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: org.mapstruct
+      artifactIdPattern: mapstruct
+recipeList:
+  - org.openrewrite.gradle.AddDependency:
+      groupId: org.projectlombok
+      artifactId: lombok-mapstruct-binding
+      version: 0.2.0
+      configuration: annotationProcessor
+      acceptTransitive: false

--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -289,8 +289,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.AddLombokMapstructBinding
-displayName: Add lombok-mapstruct-binding when both MapStruct and Lombok are used
-description: Add lombok-mapstruct-binding when both MapStruct and Lombok are used.
+displayName: Add `lombok-mapstruct-binding` when both MapStruct and Lombok are used
+description: Add the `lombok-mapstruct-binding` annotation processor as needed when both MapStruct and Lombok are used.
 tags:
   - java17
 preconditions:


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Added declarative recipe that adds `lombok-mapstruct-binding` when both MapStruct and Lombok are used

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
This Annotation processor is required from Java 17 for the combination to work

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @sambsnyd 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
