### PR TITLE
fix: add java version property only to parent pom

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -29,6 +29,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Value
@@ -88,10 +89,7 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                 Xml.Document d = super.visitDocument(document, ctx);
 
                 // Return early if the parent appears to be within the current repository, as properties defined there will be updated
-                if (d.getRoot().getChild("parent")
-                        .flatMap(parent -> parent.getChild("relativePath"))
-                        .flatMap(Xml.Tag::getValue)
-                        .isPresent()) {
+                if (isLocalParent(d)) {
                     return d;
                 }
 
@@ -141,6 +139,20 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                     });
                 }
                 return t;
+            }
+
+            private boolean isLocalParent(Xml.Document d) {
+                Optional<Xml.Tag> relativePath = d.getRoot().getChild("parent")
+                    .flatMap(parent -> parent.getChild("relativePath"));
+                if (relativePath.flatMap(Xml.Tag::getValue).isPresent()) {
+                    // specified explicitly: `<relativePath>../../pom.xml<relativePath>>`
+                    return true;
+                } else {
+                    // no relative path, maven default is used, potentially `../pom.xml`
+                    // but parent exists, so not root `pom.xml`
+                    return !relativePath.isPresent() && getResolutionResult().getParent() != null;
+                }
+
             }
         };
     }

--- a/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -195,6 +195,68 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
     }
 
     @Test
+    void doNotOverrideLocalParent() {
+        rewriteRun(
+            //language=xml
+            pomXml(
+                """
+                  <project>
+                      <groupId>com.example</groupId>
+                      <artifactId>example-parent</artifactId>
+                      <version>1.0.0</version>
+                      <modelVersion>4.0</modelVersion>
+                      <properties>
+                          <java.version>11</java.version>
+                          <jdk.version>11</jdk.version>
+                          <javaVersion>11</javaVersion>
+                          <jdkVersion>11</jdkVersion>
+                          <maven.compiler.source>11</maven.compiler.source>
+                          <maven.compiler.target>11</maven.compiler.target>
+                          <maven.compiler.release>11</maven.compiler.release>
+                          <release.version>11</release.version>
+                      </properties>
+                  </project>
+                  """,
+                """
+                <project>
+                    <groupId>com.example</groupId>
+                    <artifactId>example-parent</artifactId>
+                    <version>1.0.0</version>
+                    <modelVersion>4.0</modelVersion>
+                    <properties>
+                        <java.version>17</java.version>
+                        <jdk.version>17</jdk.version>
+                        <javaVersion>17</javaVersion>
+                        <jdkVersion>17</jdkVersion>
+                        <maven.compiler.source>17</maven.compiler.source>
+                        <maven.compiler.target>17</maven.compiler.target>
+                        <maven.compiler.release>17</maven.compiler.release>
+                        <release.version>17</release.version>
+                    </properties>
+                </project>
+                """),
+            mavenProject("example-child",
+                //language=xml
+                pomXml(
+                    """
+                      <project>
+                          <parent>
+                              <groupId>com.example</groupId>
+                              <artifactId>example-parent</artifactId>
+                              <version>1.0.0</version>
+                          </parent>
+                          <groupId>com.example</groupId>
+                          <artifactId>example-child</artifactId>
+                          <version>1.0.0</version>
+                          <modelVersion>4.0</modelVersion>
+                      </project>
+                      """
+                )
+            )
+        );
+    }
+
+    @Test
     void doNothingForExplicitPluginConfiguration() {
         // Use UseMavenCompilerPluginReleaseConfiguration for this case
         rewriteRun(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Fix bug where java version property would be add to *all* submodules of a project instead of only to the root pom

## Any additional context
I was having issues with `org.openrewrite.java.migrate.UpgradeToJava21`

Specifically, it adds the `<java.version>` property to each submodule, even if the parent module (in the same repo) already contains this property. 
I believe this is because of [this logic](https://github.com/openrewrite/rewrite-migrate-java/blob/ead663e7da49ea521341d786d25a2a903070d7e5/src/main/java/org/openrewrite/java/migrate/maven/UpdateMavenProjectPropertyJavaVersion.java#L91-L95) in `UpdateMavenProjectPropertyJavaVersion` which checks if relativePath has a value. 

But the problem is that in most cases `relativePath` is omitted completely, because if not specified, it defaults to `../pom.xml `. 
Now I realise the use case of `<relativePath/>` so it was preserved.
