### PR TITLE
Fix multiple issues in JodaTime to JavaTime migration recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -43,7 +43,7 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         this.acc = acc;
         this.safeMigration = safeMigration;
     }
-    
+
     @Override
     protected JavadocVisitor<ExecutionContext> getJavadocVisitor() {
         return new JavadocVisitor<ExecutionContext>(this) {

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
@@ -733,4 +733,64 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
+    
+    @Test
+    void lambdaVarDeclaration() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+              import java.util.List;
+              import java.util.ArrayList;
+
+              class A {
+                  public void foo() {
+                      List<Long> list = new ArrayList<>();
+                      list.add(100L);
+                      list.add(200L);
+                        list.forEach(millis -> {
+                            System.out.println(new DateTime().withMillis(millis));
+                        });
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              import java.time.Instant;
+              import java.time.ZonedDateTime;
+              import java.util.ArrayList;
+
+              class A {
+                  public void foo() {
+                      List<Long> list = new ArrayList<>();
+                      list.add(100L);
+                      list.add(200L);
+                        list.forEach(millis -> {
+                            System.out.println(ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZonedDateTime.now().getZone()));
+                        });
+                  }
+              }
+              """
+          )
+        );
+    }
+    
+    @Test
+    void unhandledVarDeclaration() {
+        //language=java
+        rewriteRun(
+          java(
+              """
+              import org.joda.time.Interval;
+
+              class A {
+                  public void foo(Interval interval) {
+                      interval = new Interval(100, 50);
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
@@ -733,7 +733,7 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
-    
+
     @Test
     void lambdaVarDeclaration() {
         //language=java
@@ -775,7 +775,7 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
-    
+
     @Test
     void unhandledVarDeclaration() {
         //language=java


### PR DESCRIPTION
## What's changed?
Fixed these bugs in JodaTime to JavaTime migration recipe..
1. Updated the code to handle scenarios where variable declarations, such as lambda parameters, might lack a type expression.
2. Recipe was throwing NPE for any variable declaration of unimplemented type. 
4. Fixed an issue where the updated assignment expression was incorrectly passed instead of the original one to fetch the migration template.
5. Javadoc may not always have valid method reference. Skipped migration of reference in javadoc.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
