### PR TITLE
Joda-Time to Java time: Add templates for Joda Interval to Threeten-extra Interval

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
 
     testImplementation("com.google.guava:guava:33.0.0-jre")
     testImplementation("joda-time:joda-time:2.12.3")
+    testImplementation("org.threeten:threeten-extra:1.8.0")
 
     testRuntimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr353")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -65,6 +65,7 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         maybeRemoveImport(JODA_DURATION);
         maybeRemoveImport(JODA_ABSTRACT_INSTANT);
         maybeRemoveImport(JODA_INSTANT);
+        maybeRemoveImport(JODA_INTERVAL);
         maybeRemoveImport("java.util.Locale");
 
         maybeAddImport(JAVA_DATE_TIME);
@@ -79,6 +80,7 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         maybeAddImport(JAVA_TEMPORAL_ISO_FIELDS);
         maybeAddImport(JAVA_CHRONO_FIELD);
         maybeAddImport(JAVA_UTIL_DATE);
+        maybeAddImport(THREE_TEN_EXTRA_INTERVAL);
         return super.visitCompilationUnit(cu, ctx);
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -170,9 +170,11 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         if (!isJodaVarRef(ident)) {
             return super.visitIdentifier(ident, ctx);
         }
-        Optional<NamedVariable> mayBeVar = findVarInScope(ident.getSimpleName());
-        if (!mayBeVar.isPresent() || acc.getUnsafeVars().contains(mayBeVar.get())) {
-            return ident;
+        if (this.safeMigration) {
+            Optional<NamedVariable> mayBeVar = findVarInScope(ident.getSimpleName());
+            if (!mayBeVar.isPresent() || acc.getUnsafeVars().contains(mayBeVar.get())) {
+                return ident;
+            }
         }
 
         JavaType.FullyQualified jodaType = ((JavaType.Class) ident.getType());

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/AbstractIntervalTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/AbstractIntervalTemplates.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.joda.templates;
+
+import lombok.Getter;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.java.migrate.joda.templates.TimeClassNames.*;
+
+public class AbstractIntervalTemplates implements Templates {
+    private final MethodMatcher getStart = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " getStart()");
+    private final MethodMatcher getEnd = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " getEnd()");
+    private final MethodMatcher toDuration = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " toDuration()");
+    private final MethodMatcher toDurationMillis = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " toDurationMillis()");
+    private final MethodMatcher contains = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " contains(long)");
+    
+    private final JavaTemplate getStartTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.getStart().atZone(ZoneId.systemDefault())")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .imports(JAVA_ZONE_ID)
+            .build();
+    private final JavaTemplate getEndTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.getEnd().atZone(ZoneId.systemDefault())")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .imports(JAVA_ZONE_ID)
+            .build();
+    private final JavaTemplate toDurationTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.toDuration()")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .build();
+    private final JavaTemplate toDurationMillisTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.toDuration().toMillis()")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .build();
+    private final JavaTemplate containsTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.contains(Instant.ofEpochMilli(#{any(long)}))")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .imports(JAVA_INSTANT)
+            .build();
+    
+    @Getter
+    private final List<MethodTemplate> templates = new ArrayList<MethodTemplate>() {
+        {
+            add(new MethodTemplate(getStart, getStartTemplate));
+            add(new MethodTemplate(getEnd, getEndTemplate));
+            add(new MethodTemplate(toDuration, toDurationTemplate));
+            add(new MethodTemplate(toDurationMillis, toDurationMillisTemplate));
+            add(new MethodTemplate(contains, containsTemplate));
+        }
+    };
+}

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/AbstractIntervalTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/AbstractIntervalTemplates.java
@@ -31,7 +31,7 @@ public class AbstractIntervalTemplates implements Templates {
     private final MethodMatcher toDuration = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " toDuration()");
     private final MethodMatcher toDurationMillis = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " toDurationMillis()");
     private final MethodMatcher contains = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " contains(long)");
-    
+
     private final JavaTemplate getStartTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.getStart().atZone(ZoneId.systemDefault())")
             .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
             .imports(JAVA_ZONE_ID)
@@ -50,7 +50,7 @@ public class AbstractIntervalTemplates implements Templates {
             .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
             .imports(JAVA_INSTANT)
             .build();
-    
+
     @Getter
     private final List<MethodTemplate> templates = new ArrayList<MethodTemplate>() {
         {

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/AllTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/AllTemplates.java
@@ -39,6 +39,8 @@ public class AllTemplates {
     private static final MethodMatcher ANY_ABSTRACT_DURATION = new MethodMatcher(JODA_ABSTRACT_DURATION + " *(..)");
     private static final MethodMatcher ANY_INSTANT = new MethodMatcher(JODA_INSTANT + " *(..)");
     private static final MethodMatcher ANY_NEW_INSTANT = new MethodMatcher(JODA_INSTANT + "<constructor>(..)");
+    private static final MethodMatcher ANY_NEW_INTERVAL = new MethodMatcher(JODA_INTERVAL + "<constructor>(..)");
+    private static final MethodMatcher ANY_ABSTRACT_INTERVAL = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " *(..)");
 
     private static List<MatcherAndTemplates> templates = new ArrayList<MatcherAndTemplates>() {
         {
@@ -55,6 +57,8 @@ public class AllTemplates {
             add(new MatcherAndTemplates(ANY_DATE_TIMEZONE, new TimeZoneTemplates()));
             add(new MatcherAndTemplates(ANY_INSTANT, new InstantTemplates()));
             add(new MatcherAndTemplates(ANY_NEW_INSTANT, new InstantTemplates()));
+            add(new MatcherAndTemplates(ANY_NEW_INTERVAL, new IntervalTemplates()));
+            add(new MatcherAndTemplates(ANY_ABSTRACT_INTERVAL, new AbstractIntervalTemplates()));
         }
     };
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
@@ -33,15 +33,15 @@ public class IntervalTemplates implements Templates {
     private final MethodMatcher intervalWithDateTimeAndDuration = new MethodMatcher(JODA_INTERVAL + " <constructor>(" + JODA_READABLE_INSTANT + ", " + JODA_READABLE_DURATION + ")");
 
     private final JavaTemplate intervalTemplate = JavaTemplate.builder("Interval.of(Instant.ofEpochMilli(#{any(long)}), Instant.ofEpochMilli(#{any(long)}))")
-            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
             .imports(JAVA_INSTANT, THREE_TEN_EXTRA_INTERVAL)
             .build();
     private final JavaTemplate intervalWithDateTimeTemplate = JavaTemplate.builder("Interval.of(#{any(" + JAVA_DATE_TIME + ")}.toInstant(), #{any(" + JAVA_DATE_TIME + ")}.toInstant())")
-            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
             .imports(THREE_TEN_EXTRA_INTERVAL)
             .build();
     private final JavaTemplate intervalWithDateTimeAndDurationTemplate = JavaTemplate.builder("Interval.of(#{any(" + JAVA_DATE_TIME + ")}.toInstant(), #{any(" + JAVA_DURATION + ")})")
-            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
             .imports(THREE_TEN_EXTRA_INTERVAL)
             .build();
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
@@ -31,7 +31,7 @@ public class IntervalTemplates implements Templates {
     private final MethodMatcher intervalWithTimeZone = new MethodMatcher(JODA_INTERVAL + " <constructor>(long, long, " + JODA_DATE_TIME_ZONE + ")");
     private final MethodMatcher intervalWithDateTime = new MethodMatcher(JODA_INTERVAL + " <constructor>(" + JODA_READABLE_INSTANT + ", " + JODA_READABLE_INSTANT + ")");
     private final MethodMatcher intervalWithDateTimeAndDuration = new MethodMatcher(JODA_INTERVAL + " <constructor>(" + JODA_READABLE_INSTANT + ", " + JODA_READABLE_DURATION + ")");
-    
+
     private final JavaTemplate intervalTemplate = JavaTemplate.builder("Interval.of(Instant.ofEpochMilli(#{any(long)}), Instant.ofEpochMilli(#{any(long)}))")
             .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
             .imports(JAVA_INSTANT, THREE_TEN_EXTRA_INTERVAL)
@@ -44,7 +44,7 @@ public class IntervalTemplates implements Templates {
             .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
             .imports(THREE_TEN_EXTRA_INTERVAL)
             .build();
-    
+
     @Getter
     private final List<MethodTemplate> templates = new ArrayList<MethodTemplate>() {
         {

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.joda.templates;
+
+import lombok.Getter;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.java.migrate.joda.templates.TimeClassNames.*;
+
+public class IntervalTemplates implements Templates {
+    private final MethodMatcher interval = new MethodMatcher(JODA_INTERVAL + " <constructor>(long, long)");
+    private final MethodMatcher intervalWithTimeZone = new MethodMatcher(JODA_INTERVAL + " <constructor>(long, long, " + JODA_DATE_TIME_ZONE + ")");
+    private final MethodMatcher intervalWithDateTime = new MethodMatcher(JODA_INTERVAL + " <constructor>(" + JODA_READABLE_INSTANT + ", " + JODA_READABLE_INSTANT + ")");
+    private final MethodMatcher intervalWithDateTimeAndDuration = new MethodMatcher(JODA_INTERVAL + " <constructor>(" + JODA_READABLE_INSTANT + ", " + JODA_READABLE_DURATION + ")");
+    
+    private final JavaTemplate intervalTemplate = JavaTemplate.builder("Interval.of(Instant.ofEpochMilli(#{any(long)}), Instant.ofEpochMilli(#{any(long)}))")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .imports(JAVA_INSTANT, THREE_TEN_EXTRA_INTERVAL)
+            .build();
+    private final JavaTemplate intervalWithDateTimeTemplate = JavaTemplate.builder("Interval.of(#{any(" + JAVA_DATE_TIME + ")}.toInstant(), #{any(" + JAVA_DATE_TIME + ")}.toInstant())")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .imports(THREE_TEN_EXTRA_INTERVAL)
+            .build();
+    private final JavaTemplate intervalWithDateTimeAndDurationTemplate = JavaTemplate.builder("Interval.of(#{any(" + JAVA_DATE_TIME + ")}.toInstant(), #{any(" + JAVA_DURATION + ")})")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .imports(THREE_TEN_EXTRA_INTERVAL)
+            .build();
+    
+    @Getter
+    private final List<MethodTemplate> templates = new ArrayList<MethodTemplate>() {
+        {
+            add(new MethodTemplate(interval, intervalTemplate));
+            add(new MethodTemplate(intervalWithTimeZone, intervalTemplate,
+                    m -> new Expression[]{m.getArguments().get(0), m.getArguments().get(1)}));
+            add(new MethodTemplate(intervalWithDateTime, intervalWithDateTimeTemplate));
+            add(new MethodTemplate(intervalWithDateTimeAndDuration, intervalWithDateTimeAndDurationTemplate));
+        }
+    };
+}

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassMap.java
@@ -35,6 +35,7 @@ public class TimeClassMap {
             put(JODA_TIME_FORMATTER, javaTypeClass(JAVA_TIME_FORMATTER, object));
             put(JODA_DURATION, javaTypeClass(JAVA_DURATION, object));
             put(JODA_READABLE_DURATION, javaTypeClass(JAVA_DURATION, object));
+            put(JODA_INTERVAL, javaTypeClass(THREE_TEN_EXTRA_INTERVAL, object));
         }
     };
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassNames.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassNames.java
@@ -58,7 +58,7 @@ public class TimeClassNames {
     public static final String JAVA_LOCAL_TIME = JAVA_TIME_PKG + ".LocalTime";
     public static final String JAVA_TEMPORAL_ISO_FIELDS = JAVA_TIME_PKG + ".temporal.IsoFields";
     public static final String JAVA_CHRONO_FIELD = JAVA_TIME_PKG + ".temporal.ChronoField";
-    
+
     // ThreeTen-Extra classes
     public static final String THREE_TEN_EXTRA_PKG = "org.threeten.extra";
     public static final String THREE_TEN_EXTRA_INTERVAL = THREE_TEN_EXTRA_PKG + ".Interval";

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassNames.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassNames.java
@@ -27,6 +27,7 @@ public class TimeClassNames {
     public static final String JODA_TIME_PKG = "org.joda.time";
     public static final String JODA_ABSTRACT_DATE_TIME = JODA_TIME_PKG + ".base.AbstractDateTime";
     public static final String JODA_ABSTRACT_DURATION = JODA_TIME_PKG + ".base.AbstractDuration";
+    public static final String JODA_ABSTRACT_INTERVAL = JODA_TIME_PKG + ".base.AbstractInterval";
     public static final String JODA_BASE_DATE_TIME = JODA_TIME_PKG + ".base.BaseDateTime";
     public static final String JODA_DATE_TIME = JODA_TIME_PKG + ".DateTime";
     public static final String JODA_DATE_TIME_ZONE = JODA_TIME_PKG + ".DateTimeZone";
@@ -39,7 +40,9 @@ public class TimeClassNames {
     public static final String JODA_DURATION = JODA_TIME_PKG + ".Duration";
     public static final String JODA_READABLE_DURATION = JODA_TIME_PKG + ".ReadableDuration";
     public static final String JODA_ABSTRACT_INSTANT = JODA_TIME_PKG + ".base.AbstractInstant";
+    public static final String JODA_READABLE_INSTANT = JODA_TIME_PKG + ".ReadableInstant";
     public static final String JODA_INSTANT = JODA_TIME_PKG + ".Instant";
+    public static final String JODA_INTERVAL = JODA_TIME_PKG + ".Interval";
 
     // Java Time classes
     public static final String JAVA_TIME_PKG = "java.time";
@@ -55,4 +58,8 @@ public class TimeClassNames {
     public static final String JAVA_LOCAL_TIME = JAVA_TIME_PKG + ".LocalTime";
     public static final String JAVA_TEMPORAL_ISO_FIELDS = JAVA_TIME_PKG + ".temporal.IsoFields";
     public static final String JAVA_CHRONO_FIELD = JAVA_TIME_PKG + ".temporal.ChronoField";
+    
+    // ThreeTen-Extra classes
+    public static final String THREE_TEN_EXTRA_PKG = "org.threeten.extra";
+    public static final String THREE_TEN_EXTRA_INTERVAL = THREE_TEN_EXTRA_PKG + ".Interval";
 }

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
@@ -35,6 +35,7 @@ public class VarTemplates {
             put(JODA_LOCAL_TIME, JAVA_LOCAL_TIME);
             put(JODA_DATE_TIME_ZONE, JAVA_ZONE_ID);
             put(JODA_DURATION, JAVA_DURATION);
+            put(JODA_INTERVAL, THREE_TEN_EXTRA_INTERVAL);
         }
     };
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.migrate.joda.templates;
 
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -66,8 +67,9 @@ public class VarTemplates {
             }
         }
         return Optional.of(JavaTemplate.builder(template.toString())
-                .imports(typeName)
-                .build());
+          .imports(typeName)
+          .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
+          .build());
     }
 
     public static Optional<JavaTemplate> getTemplate(J.Assignment assignment) {

--- a/src/main/resources/META-INF/rewrite/no-joda-time.yml
+++ b/src/main/resources/META-INF/rewrite/no-joda-time.yml
@@ -16,18 +16,18 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.joda.NoJodaTime
-displayName: Prefer the Java standard library instead of JodaTime
+displayName: Prefer the Java standard library instead of Joda-Time
 description: >-
-  Before Java 8, Java lacked a robust date and time library, leading to the widespread use of Joda-Time to fill this 
-  gap. With the release of Java 8, the java.time package was introduced, incorporating most of Joda-Time's concepts. 
-  Features deemed too specialized or bulky for java.time were included in the ThreeTen-Extra library.  This recipe 
-  migrates JodaTime types to java.time and threeten-extra types.
+  Before Java 8, Java lacked a robust date and time library, leading to the widespread use of Joda-Time to fill this
+  gap. With the release of Java 8, the `java.time` package was introduced, incorporating most of Joda-Time's concepts.
+  Features deemed too specialized or bulky for `java.time` were included in the ThreeTen-Extra library.  This recipe
+  migrates Joda-Time types to `java.time` and `threeten-extra` types.
 tags:
   - joda-time
 recipeList:
-  - org.openrewrite.java.migrate.joda.JodaTimeRecipe
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.threeten
       artifactId: threeten-extra
       version: 1.8.0
       onlyIfUsing: org.joda.time.*Interval*
+  - org.openrewrite.java.migrate.joda.JodaTimeRecipe

--- a/src/main/resources/META-INF/rewrite/no-joda-time.yml
+++ b/src/main/resources/META-INF/rewrite/no-joda-time.yml
@@ -1,0 +1,33 @@
+#
+# Copyright 2021 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.joda.NoJodaTime
+displayName: Prefer the Java standard library instead of JodaTime
+description: >-
+  Before Java 8, Java lacked a robust date and time library, leading to the widespread use of Joda-Time to fill this 
+  gap. With the release of Java 8, the java.time package was introduced, incorporating most of Joda-Time's concepts. 
+  Features deemed too specialized or bulky for java.time were included in the ThreeTen-Extra library.  This recipe 
+  migrates JodaTime types to java.time and threeten-extra types.
+tags:
+  - joda-time
+recipeList:
+  - org.openrewrite.java.migrate.joda.JodaTimeRecipe
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.threeten
+      artifactId: threeten-extra
+      version: 1.8.0
+      onlyIfUsing: org.joda.time.*Interval*

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
@@ -793,7 +793,7 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
-    
+
     @Test
     void migrateInterval() {
         // language=java
@@ -833,7 +833,7 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
-    
+
     @Test
     void migrateAbstractInterval() {
         // language=java

--- a/src/test/java/org/openrewrite/java/migrate/joda/NoJodaTimeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/NoJodaTimeTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-public class NoJodaTimeTest implements RewriteTest {
+class NoJodaTimeTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/src/test/java/org/openrewrite/java/migrate/joda/NoJodaTimeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/NoJodaTimeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.joda;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+public class NoJodaTimeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipeFromResource("/META-INF/rewrite/no-joda-time.yml", "org.openrewrite.java.migrate.joda.NoJodaTime")
+          .parser(JavaParser.fromJavaVersion().classpath("joda-time", "threeten-extra"));
+    }
+    @Test
+    void migrateJodaTime() {
+        rewriteRun(
+          mavenProject("foo",
+            srcMainJava(
+              // language=java
+              java(
+                """
+                import org.joda.time.DateTime;
+                import org.joda.time.Interval;
+                
+                public class A {
+                    public void foo() {
+                        DateTime dt = new DateTime();
+                        DateTime dt1 = new DateTime().plusDays(1);
+                        Interval i = new Interval(dt, dt1);
+                        System.out.println(i.toDuration());
+                    }
+                }
+                """,
+                """
+                import org.threeten.extra.Interval;
+
+                import java.time.ZonedDateTime;
+
+                public class A {
+                    public void foo() {
+                        ZonedDateTime dt = ZonedDateTime.now();
+                        ZonedDateTime dt1 = ZonedDateTime.now().plusDays(1);
+                        Interval i = Interval.of(dt.toInstant(), dt1.toInstant());
+                        System.out.println(i.toDuration());
+                    }
+                }
+                """
+              ),
+              //language=xml
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example.foobar</groupId>
+                      <artifactId>foobar-core</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>joda-time</groupId>
+                              <artifactId>joda-time</artifactId>
+                              <version>2.12.3</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example.foobar</groupId>
+                      <artifactId>foobar-core</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>joda-time</groupId>
+                              <artifactId>joda-time</artifactId>
+                              <version>2.12.3</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>org.threeten</groupId>
+                              <artifactId>threeten-extra</artifactId>
+                              <version>1.8.0</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """
+              )
+            )
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/joda/NoJodaTimeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/NoJodaTimeTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate.joda;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -31,6 +32,8 @@ class NoJodaTimeTest implements RewriteTest {
           .recipeFromResource("/META-INF/rewrite/no-joda-time.yml", "org.openrewrite.java.migrate.joda.NoJodaTime")
           .parser(JavaParser.fromJavaVersion().classpath("joda-time", "threeten-extra"));
     }
+
+    @DocumentExample
     @Test
     void migrateJodaTime() {
         rewriteRun(
@@ -39,32 +42,32 @@ class NoJodaTimeTest implements RewriteTest {
               // language=java
               java(
                 """
-                import org.joda.time.DateTime;
-                import org.joda.time.Interval;
-                
-                public class A {
-                    public void foo() {
-                        DateTime dt = new DateTime();
-                        DateTime dt1 = new DateTime().plusDays(1);
-                        Interval i = new Interval(dt, dt1);
-                        System.out.println(i.toDuration());
-                    }
-                }
-                """,
-                """
-                import org.threeten.extra.Interval;
+                  import org.joda.time.DateTime;
+                  import org.joda.time.Interval;
 
-                import java.time.ZonedDateTime;
-
-                public class A {
-                    public void foo() {
-                        ZonedDateTime dt = ZonedDateTime.now();
-                        ZonedDateTime dt1 = ZonedDateTime.now().plusDays(1);
-                        Interval i = Interval.of(dt.toInstant(), dt1.toInstant());
-                        System.out.println(i.toDuration());
-                    }
-                }
+                  class A {
+                      void foo() {
+                          DateTime dt = new DateTime();
+                          DateTime dt1 = new DateTime().plusDays(1);
+                          Interval i = new Interval(dt, dt1);
+                          System.out.println(i.toDuration());
+                      }
+                  }
+                  """,
                 """
+                  import org.threeten.extra.Interval;
+
+                  import java.time.ZonedDateTime;
+
+                  class A {
+                      void foo() {
+                          ZonedDateTime dt = ZonedDateTime.now();
+                          ZonedDateTime dt1 = ZonedDateTime.now().plusDays(1);
+                          Interval i = Interval.of(dt.toInstant(), dt1.toInstant());
+                          System.out.println(i.toDuration());
+                      }
+                  }
+                  """
               ),
               //language=xml
               pomXml(


### PR DESCRIPTION
## What's changed?
Added migration templates to convert Joda-Time Interval classes to the [ThreeTen-extra](https://www.threeten.org/threeten-extra/) Interval.  The Interval class is not part of the JDK but is implemented in ThreeTen-extra, built on top of Java's java.time classes. This change include migration templates for methods from the following Joda-Time classes:

1. org.joda.time.Interval
2. org.joda.time.AbstractInterval

## What's your motivation?
Increase coverage for Joda-Time to Java Time migration recipe by adding support for additional classes.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
