### PR TITLE
StringFormatted should not wrap first argument by default in Java 17 upgrade

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -28,7 +28,6 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.Java8toJava11
   - org.openrewrite.java.migrate.UpgradeBuildToJava17
-  - org.openrewrite.java.migrate.lang.StringFormatted
   - org.openrewrite.staticanalysis.InstanceOfPatternMatch
   - org.openrewrite.staticanalysis.AddSerialAnnotationToSerialVersionUID
   - org.openrewrite.java.migrate.RemovedRuntimeTraceMethods
@@ -36,6 +35,8 @@ recipeList:
   - org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors
   - org.openrewrite.java.migrate.lang.UseTextBlocks:
       convertStringsWithoutNewlines: false
+  - org.openrewrite.java.migrate.lang.StringFormatted:
+      addParentheses: false
   - org.openrewrite.java.migrate.DeprecatedJavaxSecurityCert
   - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
   - org.openrewrite.java.migrate.RemovedLegacySunJSSEProviderName

--- a/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/StringFormattedTest.java
@@ -27,7 +27,7 @@ import static org.openrewrite.java.Assertions.version;
 class StringFormattedTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new StringFormatted());
+        spec.recipe(new StringFormatted(null));
     }
 
     @Test
@@ -72,12 +72,36 @@ class StringFormattedTest implements RewriteTest {
                 class A {
                     String str = String.format("foo"
                             + "%s", "a");
-                }""", """
+                }
+                """,
+              """
                 package com.example.app;
                 class A {
                     String str = ("foo"
                             + "%s").formatted("a");
-                }"""
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/616")
+    @Test
+    void concatenatedFormatStringNotConvertedIfIndicated() {
+        //language=java
+        rewriteRun(
+          spec -> spec.recipe(new StringFormatted(false)),
+          version(
+            java(
+              """
+                package com.example.app;
+                class A {
+                    String str = String.format("foo"
+                            + "%s", "a");
+                }
+                """
             ),
             17
           )
@@ -92,10 +116,10 @@ class StringFormattedTest implements RewriteTest {
             java(
               """
                 package com.example.app;
-                
+
                 class A {
                     String str = String.format(getTemplateString(), "a");
-                
+
                     private String getTemplateString() {
                         return "foo %s";
                     }
@@ -103,10 +127,10 @@ class StringFormattedTest implements RewriteTest {
                 """,
               """
                 package com.example.app;
-                
+
                 class A {
                     String str = getTemplateString().formatted("a");
-                
+
                     private String getTemplateString() {
                         return "foo %s";
                     }


### PR DESCRIPTION
## What's changed?
Made the wrapping optional but enabled when run directly, but disabled in the Java 17 upgrade recipe.
Also moved this recipe to after the change that introduces text blocks, such that we can pick those up still.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-migrate-java/issues/616

## Have you considered any alternatives or workarounds?
We could have made the optional false by default, but then it's harder for folks to discover and run.

## Any additional context
We use the same pattern for introducing text blocks; with a flag set to false when included in the Java 17 migration.