### PR TITLE
Joda time to Java time: Add few more templates for migration

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/AllTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/AllTemplates.java
@@ -34,6 +34,7 @@ public class AllTemplates {
     private static final MethodMatcher ANY_TIME_FORMATTER = new MethodMatcher(JODA_TIME_FORMATTER + " *(..)");
     private static final MethodMatcher ANY_NEW_DURATION = new MethodMatcher(JODA_DURATION + "<constructor>(..)");
     private static final MethodMatcher ANY_DURATION = new MethodMatcher(JODA_DURATION + " *(..)");
+    private static final MethodMatcher ANY_BASE_DURATION = new MethodMatcher(JODA_BASE_DURATION + " *(..)");
     private static final MethodMatcher ANY_ABSTRACT_INSTANT = new MethodMatcher(JODA_ABSTRACT_INSTANT + " *(..)");
     private static final MethodMatcher ANY_ABSTRACT_DATE_TIME = new MethodMatcher(JODA_ABSTRACT_DATE_TIME + " *(..)");
     private static final MethodMatcher ANY_ABSTRACT_DURATION = new MethodMatcher(JODA_ABSTRACT_DURATION + " *(..)");
@@ -41,6 +42,7 @@ public class AllTemplates {
     private static final MethodMatcher ANY_NEW_INSTANT = new MethodMatcher(JODA_INSTANT + "<constructor>(..)");
     private static final MethodMatcher ANY_NEW_INTERVAL = new MethodMatcher(JODA_INTERVAL + "<constructor>(..)");
     private static final MethodMatcher ANY_ABSTRACT_INTERVAL = new MethodMatcher(JODA_ABSTRACT_INTERVAL + " *(..)");
+    private static final MethodMatcher ANY_BASE_INTERVAL = new MethodMatcher(JODA_BASE_INTERVAL + " *(..)");
 
     private static List<MatcherAndTemplates> templates = new ArrayList<MatcherAndTemplates>() {
         {
@@ -54,11 +56,13 @@ public class AllTemplates {
             add(new MatcherAndTemplates(ANY_DATE_TIME, new DateTimeTemplates()));
             add(new MatcherAndTemplates(ANY_NEW_DURATION, new DurationTemplates()));
             add(new MatcherAndTemplates(ANY_DURATION, new DurationTemplates()));
+            add(new MatcherAndTemplates(ANY_BASE_DURATION, new BaseDurationTemplates()));
             add(new MatcherAndTemplates(ANY_DATE_TIMEZONE, new TimeZoneTemplates()));
             add(new MatcherAndTemplates(ANY_INSTANT, new InstantTemplates()));
             add(new MatcherAndTemplates(ANY_NEW_INSTANT, new InstantTemplates()));
             add(new MatcherAndTemplates(ANY_NEW_INTERVAL, new IntervalTemplates()));
             add(new MatcherAndTemplates(ANY_ABSTRACT_INTERVAL, new AbstractIntervalTemplates()));
+            add(new MatcherAndTemplates(ANY_BASE_INTERVAL, new BaseIntervalTemplates()));
         }
     };
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/BaseDurationTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/BaseDurationTemplates.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.joda.templates;
+
+import lombok.Getter;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.java.migrate.joda.templates.TimeClassNames.JAVA_DURATION;
+import static org.openrewrite.java.migrate.joda.templates.TimeClassNames.JODA_BASE_DURATION;
+
+public class BaseDurationTemplates implements Templates {
+    private final MethodMatcher getMillis = new MethodMatcher(JODA_BASE_DURATION + " getMillis()");
+
+    private final JavaTemplate getMillisTemplate = JavaTemplate.builder("#{any(" + JAVA_DURATION + ")}.toMillis()").build();
+
+    @Getter
+    private final List<MethodTemplate> templates = new ArrayList<MethodTemplate>() {
+        {
+            add(new MethodTemplate(getMillis, getMillisTemplate));
+        }
+    };
+}

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/BaseIntervalTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/BaseIntervalTemplates.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.joda.templates;
+
+import lombok.Getter;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.java.migrate.joda.templates.TimeClassNames.JODA_BASE_INTERVAL;
+import static org.openrewrite.java.migrate.joda.templates.TimeClassNames.THREE_TEN_EXTRA_INTERVAL;
+
+public class BaseIntervalTemplates implements Templates {
+    private final MethodMatcher getStartMillis = new MethodMatcher(JODA_BASE_INTERVAL + " getStartMillis()");
+    private final MethodMatcher getEndMillis = new MethodMatcher(JODA_BASE_INTERVAL + " getEndMillis()");
+
+    private final JavaTemplate getStartMillisTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.getStart().toEpochMilli()")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .build();
+    private final JavaTemplate getEndMillisTemplate = JavaTemplate.builder("#{any(" + THREE_TEN_EXTRA_INTERVAL + ")}.getEnd().toEpochMilli()")
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
+            .build();
+
+    @Getter
+    private final List<MethodTemplate> templates = new ArrayList<MethodTemplate>() {
+        {
+            add(new MethodTemplate(getStartMillis, getStartMillisTemplate));
+            add(new MethodTemplate(getEndMillis, getEndMillisTemplate));
+        }
+    };
+}

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/IntervalTemplates.java
@@ -33,15 +33,15 @@ public class IntervalTemplates implements Templates {
     private final MethodMatcher intervalWithDateTimeAndDuration = new MethodMatcher(JODA_INTERVAL + " <constructor>(" + JODA_READABLE_INSTANT + ", " + JODA_READABLE_DURATION + ")");
 
     private final JavaTemplate intervalTemplate = JavaTemplate.builder("Interval.of(Instant.ofEpochMilli(#{any(long)}), Instant.ofEpochMilli(#{any(long)}))")
-            .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
             .imports(JAVA_INSTANT, THREE_TEN_EXTRA_INTERVAL)
             .build();
     private final JavaTemplate intervalWithDateTimeTemplate = JavaTemplate.builder("Interval.of(#{any(" + JAVA_DATE_TIME + ")}.toInstant(), #{any(" + JAVA_DATE_TIME + ")}.toInstant())")
-            .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
             .imports(THREE_TEN_EXTRA_INTERVAL)
             .build();
     private final JavaTemplate intervalWithDateTimeAndDurationTemplate = JavaTemplate.builder("Interval.of(#{any(" + JAVA_DATE_TIME + ")}.toInstant(), #{any(" + JAVA_DURATION + ")})")
-            .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
+            .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
             .imports(THREE_TEN_EXTRA_INTERVAL)
             .build();
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassNames.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/TimeClassNames.java
@@ -39,10 +39,12 @@ public class TimeClassNames {
     public static final String JODA_DURATION_FIELD_TYPE = JODA_TIME_PKG + ".DurationFieldType";
     public static final String JODA_DURATION = JODA_TIME_PKG + ".Duration";
     public static final String JODA_READABLE_DURATION = JODA_TIME_PKG + ".ReadableDuration";
+    public static final String JODA_BASE_DURATION = JODA_TIME_PKG + ".base.BaseDuration";
     public static final String JODA_ABSTRACT_INSTANT = JODA_TIME_PKG + ".base.AbstractInstant";
     public static final String JODA_READABLE_INSTANT = JODA_TIME_PKG + ".ReadableInstant";
     public static final String JODA_INSTANT = JODA_TIME_PKG + ".Instant";
     public static final String JODA_INTERVAL = JODA_TIME_PKG + ".Interval";
+    public static final String JODA_BASE_INTERVAL = JODA_TIME_PKG + ".base.BaseInterval";
 
     // Java Time classes
     public static final String JAVA_TIME_PKG = "java.time";

--- a/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/templates/VarTemplates.java
@@ -68,7 +68,7 @@ public class VarTemplates {
         }
         return Optional.of(JavaTemplate.builder(template.toString())
           .imports(typeName)
-          .javaParser(JavaParser.fromJavaVersion().classpath("threeten"))
+          .javaParser(JavaParser.fromJavaVersion().classpath("threeten-extra"))
           .build());
     }
 

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
@@ -872,4 +872,66 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void migrateBaseDuration() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+                import org.joda.time.Duration;
+  
+                class A {
+                    public void foo() {
+                        Duration d = new Duration(100);
+                        d.getMillis();
+                    }
+                }
+                """,
+            """
+              import java.time.Duration;
+
+              class A {
+                  public void foo() {
+                      Duration d = Duration.ofMillis(100);
+                      d.toMillis();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateBaseInterval() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+                import org.joda.time.Interval;
+  
+                class A {
+                    public void foo() {
+                        Interval i = new Interval(50, 100);
+                        long s = i.getStartMillis();
+                        long e = i.getEndMillis();
+                    }
+                }
+                """,
+            """
+              import org.threeten.extra.Interval;
+
+              import java.time.Instant;
+
+              class A {
+                  public void foo() {
+                      Interval i = Interval.of(Instant.ofEpochMilli(50), Instant.ofEpochMilli(100));
+                      long s = i.getStart().toEpochMilli();
+                      long e = i.getEnd().toEpochMilli();
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Added migration templates for joda-time methods for the following classes:
BaseDuration
BaseInterval

Also fixed the classpath for threeten library from the previous pr 
- #617 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
