### PR TITLE
Fix bugs in JodaTime to JavaTime migration recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
@@ -63,7 +63,7 @@ class JodaTimeScanner extends ScopeAwareVisitor {
     @Override
     public NamedVariable visitVariable(NamedVariable variable, ExecutionContext ctx) {
         if (!variable.getType().isAssignableFrom(JODA_CLASS_PATTERN)) {
-            return variable;
+            return (NamedVariable) super.visitVariable(variable, ctx);
         }
         // TODO: handle class variables
         if (isClassVar(variable)) {

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -249,6 +249,9 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         if (expr instanceof J.Identifier) {
             return ((J.Identifier) expr).getFieldType() != null;
         }
+        if (expr instanceof MethodCall) {
+            return expr.getType().isAssignableFrom(JODA_CLASS_PATTERN);
+        }
         return false;
     }
 

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -285,4 +285,30 @@ class JodaTimeRecipeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void dontMigrateMethodInvocationIfSelectExprIsNotMigrated() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+             import org.joda.time.Interval;
+
+             class A {
+                 private Query query = new Query();
+                 public void foo() {
+                     query.interval().getEndMillis();
+                 }
+                 static class Query {
+                     private Interval interval;
+
+                     public Interval interval() {
+                         return interval;
+                     }
+                 }
+             }
+             """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
@@ -242,7 +242,7 @@ class JodaTimeScannerTest implements RewriteTest {
     }
 
     @Test
-    // remove when https://github.com/openrewrite/rewrite-analysis/issues/72 is fixed
+    // TODO remove when https://github.com/openrewrite/rewrite-analysis/issues/72 is fixed
     void dataFlowBug() {
         JodaTimeScanner scanner = new JodaTimeScanner(new JodaTimeRecipe.Accumulator());
         // language=java

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
@@ -242,8 +242,7 @@ class JodaTimeScannerTest implements RewriteTest {
     }
 
     @Test
-    // TODO remove when https://github.com/openrewrite/rewrite-analysis/issues/72 is fixed
-    void dataFlowBug() {
+    void detectUnsafeVarsInChainedLambdaExpressions() {
         JodaTimeScanner scanner = new JodaTimeScanner(new JodaTimeRecipe.Accumulator());
         // language=java
         rewriteRun(
@@ -280,9 +279,7 @@ class JodaTimeScannerTest implements RewriteTest {
           )
         );
         assertThat(scanner.getAcc().getUnsafeVars().stream().map(J.VariableDeclarations.NamedVariable::getSimpleName))
-          .hasSize(2)
-          // i3 and i4 are also unsafe but there is a bug in the data flow analysis. due to which it
-          // skips the second peek.
-          .containsExactlyInAnyOrder("i1", "i2");
+          .hasSize(4)
+          .containsExactlyInAnyOrder("i1", "i2", "i3", "i4");
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeScannerTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.java.Assertions.java;
@@ -202,5 +203,86 @@ class JodaTimeScannerTest implements RewriteTest {
         for (J.VariableDeclarations.NamedVariable var : scanner.getAcc().getUnsafeVars()) {
             assertEquals("dt", var.getSimpleName());
         }
+    }
+
+    @Test
+    void detectUnsafeVarsInInitializer() {
+        JodaTimeScanner scanner = new JodaTimeScanner(new JodaTimeRecipe.Accumulator());
+        // language=java
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> scanner)),
+          java(
+            """
+              import org.joda.time.Interval;
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+              import java.util.List;
+              
+              class A {
+                  public Interval interval() {
+                      return new Interval(10, 20);
+                  }
+              
+                  public void foo() {
+                      List<Integer> list = Stream.of(1, 2, 3).peek(i -> {
+                            Interval i1 = interval();
+                            Interval i2 = new Interval(i, 100);
+                            if (i1 != null && !i1.contains(i2)) {
+                                System.out.println("i1 does not contain i2");
+                            }
+                      }).toList();
+                  }
+              }
+              """
+          )
+        );
+        assertThat(scanner.getAcc().getUnsafeVars().stream().map(J.VariableDeclarations.NamedVariable::getSimpleName))
+          .hasSize(2)
+          .containsExactlyInAnyOrder("i1", "i2");
+    }
+
+    @Test
+    // remove when https://github.com/openrewrite/rewrite-analysis/issues/72 is fixed
+    void dataFlowBug() {
+        JodaTimeScanner scanner = new JodaTimeScanner(new JodaTimeRecipe.Accumulator());
+        // language=java
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> scanner)),
+          java(
+            """
+              import org.joda.time.Interval;
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+              import java.util.List;
+              
+              class A {
+                  public Interval interval() {
+                      return new Interval(10, 20);
+                  }
+              
+                  public void foo() {
+                      List<Integer> list = Stream.of(1, 2, 3).peek(i -> {
+                            Interval i1 = interval();
+                            Interval i2 = new Interval(i, 100);
+                            if (i1 != null && !i1.contains(i2)) {
+                                System.out.println("i1 does not contain i2");
+                            }
+                      }).peek(i -> {
+                            Interval i3 = interval();
+                            Interval i4 = new Interval(i, 100);
+                            if (i3 != null && !i3.contains(i4)) {
+                                System.out.println("i3 does not contain i4");
+                            }
+                      }).toList();
+                  }
+              }
+              """
+          )
+        );
+        assertThat(scanner.getAcc().getUnsafeVars().stream().map(J.VariableDeclarations.NamedVariable::getSimpleName))
+          .hasSize(2)
+          // i3 and i4 are also unsafe but there is a bug in the data flow analysis. due to which it
+          // skips the second peek.
+          .containsExactlyInAnyOrder("i1", "i2");
     }
 }


### PR DESCRIPTION
## What's changed?
Fixed following bugs in JodaTime to JavaTime migration recipe..

1. **MethodInvocation Migration**: When the select of a [MethodInvocation](https://github.com/openrewrite/rewrite/blob/e536ed273fda87ce6857b06f200488130b3ef5f3/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java#L3825) is a MethodCall and the select has not been migrated, the migration template is no longer incorrectly applied to the MethodInvocation.
2. **Variable Initializer Handling:** Variables declared inside variable initializers of **non-joda type** were previously skipped by the [JodaTimeScanner](https://github.com/openrewrite/rewrite-migrate-java/blob/39507e5c647d8459ac6fd1917d1795649d94a568/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java#L66). Due to which scanner failed to mark unsafe variables in such contexts. Fixed it.

Note: During debugging also found [issue](https://github.com/openrewrite/rewrite-analysis/issues/72) with FlowPath Analysis added unit test for the same

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
