### PR TITLE
Joda-Time to Java time: Add support for Method Return Statement Migration

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -54,6 +54,7 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
     @Getter
     public static class Accumulator {
         private final Set<NamedVariable> unsafeVars = new HashSet<>();
+        private final Map<JavaType.Method, Boolean> safeMethodMap = new HashMap<>();
         private final VarTable varTable = new VarTable();
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -165,8 +165,8 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
         // internal method with Joda class as return type
-        if (!method.getMethodType().getDeclaringType().isAssignableFrom(JODA_CLASS_PATTERN)
-                && method.getType().isAssignableFrom(JODA_CLASS_PATTERN)) {
+        if (!method.getMethodType().getDeclaringType().isAssignableFrom(JODA_CLASS_PATTERN) &&
+                method.getType().isAssignableFrom(JODA_CLASS_PATTERN)) {
             return migrateNonJodaMethod(method, m);
         }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -85,6 +85,22 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
     }
 
     @Override
+    public @NonNull J visitMethodDeclaration(@NonNull J.MethodDeclaration method, @NonNull ExecutionContext ctx) {
+        J.MethodDeclaration m = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+        if (m.getReturnTypeExpression() == null || !m.getType().isAssignableFrom(JODA_CLASS_PATTERN)) {
+            return m;
+        }
+        if (safeMigration && !acc.getSafeMethodMap().getOrDefault(m.getMethodType(), false)) {
+            return m;
+        }
+
+        JavaType.Class returnType = TimeClassMap.getJavaTimeType(((JavaType.Class) m.getType()).getFullyQualifiedName());
+        J.Identifier returnExpr = TypeTree.build(returnType.getClassName()).withType(returnType).withPrefix(Space.format(" "));
+        return m.withReturnTypeExpression(returnExpr)
+          .withMethodType(m.getMethodType().withReturnType(returnType));
+    }
+
+    @Override
     public @NonNull J visitVariableDeclarations(@NonNull J.VariableDeclarations multiVariable, @NonNull ExecutionContext ctx) {
         if (multiVariable.getTypeExpression() == null || !multiVariable.getType().isAssignableFrom(JODA_CLASS_PATTERN)) {
             return super.visitVariableDeclarations(multiVariable, ctx);
@@ -147,6 +163,13 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
     @Override
     public @NonNull J visitMethodInvocation(@NonNull J.MethodInvocation method, @NonNull ExecutionContext ctx) {
         J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+
+        // internal method with Joda class as return type
+        if (!method.getMethodType().getDeclaringType().isAssignableFrom(JODA_CLASS_PATTERN)
+                && method.getType().isAssignableFrom(JODA_CLASS_PATTERN)) {
+            return migrateNonJodaMethod(method, m);
+        }
+
         if (hasJodaType(m.getArguments()) || isJodaVarRef(m.getSelect())) {
             return method;
         }
@@ -179,7 +202,9 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
 
         JavaType.FullyQualified jodaType = ((JavaType.Class) ident.getType());
         JavaType.FullyQualified fqType = TimeClassMap.getJavaTimeType(jodaType.getFullyQualifiedName());
-
+        if (fqType == null) {
+            return ident;
+        }
         return ident.withType(fqType)
                 .withFieldType(ident.getFieldType().withType(fqType));
     }
@@ -216,6 +241,18 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
             return updatedExpr;
         }
         return original;
+    }
+
+    private MethodCall migrateNonJodaMethod(MethodCall original, MethodCall updated) {
+        if (safeMigration && !acc.getSafeMethodMap().getOrDefault(updated.getMethodType(), false)) {
+            return original;
+        }
+        JavaType.Class returnType = (JavaType.Class) updated.getMethodType().getReturnType();
+        JavaType.Class updatedReturnType = TimeClassMap.getJavaTimeType(returnType.getFullyQualifiedName());
+        if (updatedReturnType == null) {
+            return original; // unhandled case
+        }
+        return updated.withMethodType(updated.getMethodType().withReturnType(updatedReturnType));
     }
 
     private boolean hasJodaType(List<Expression> exprs) {

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeVisitor.java
@@ -243,7 +243,7 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         return original;
     }
 
-    private MethodCall migrateNonJodaMethod(MethodCall original, MethodCall updated) {
+    private J.MethodInvocation migrateNonJodaMethod(J.MethodInvocation original, J.MethodInvocation updated) {
         if (safeMigration && !acc.getSafeMethodMap().getOrDefault(updated.getMethodType(), false)) {
             return original;
         }
@@ -252,7 +252,8 @@ class JodaTimeVisitor extends ScopeAwareVisitor {
         if (updatedReturnType == null) {
             return original; // unhandled case
         }
-        return updated.withMethodType(updated.getMethodType().withReturnType(updatedReturnType));
+        return updated.withMethodType(updated.getMethodType().withReturnType(updatedReturnType))
+                .withName(updated.getName().withType(updatedReturnType));
     }
 
     private boolean hasJodaType(List<Expression> exprs) {

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -198,13 +198,13 @@ class JodaTimeRecipeTest implements RewriteTest {
     }
 
     @Test
-    void localVarUsedReferencedInReturnStatement() { // not supported yet
+    void localVarUsedReferencedInReturnStatement() {
         // language=java
         rewriteRun(
           java(
             """
-               import org.joda.time.DateTime;
-               import org.joda.time.DateTimeZone;
+              import org.joda.time.DateTime;
+              import org.joda.time.DateTimeZone;
 
                class A {
                    public DateTime foo(String city) {
@@ -216,6 +216,24 @@ class JodaTimeRecipeTest implements RewriteTest {
                        }
                        DateTime dt = new DateTime(dtz);
                        return dt.plus(2);
+                   }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.ZoneId;
+              import java.time.ZonedDateTime;
+              
+              class A {
+                   public ZonedDateTime foo(String city) {
+                       ZoneId dtz;
+                       if ("london".equals(city)) {
+                           dtz = ZoneId.of("Europe/London");
+                       } else {
+                           dtz = ZoneId.of("America/New_York");
+                       }
+                       ZonedDateTime dt = ZonedDateTime.now(dtz);
+                       return dt.plus(Duration.ofMillis(2));
                    }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
@@ -934,4 +934,31 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void foo() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.Duration;
+              
+              class A {
+                  public void foo() {
+                      System.out.println(new Duration(1000L).getStandardDays());
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              
+              class A {
+                  public void foo() {
+                      System.out.println(Duration.ofMillis(1000L).toDays());
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeVisitorTest.java
@@ -934,31 +934,4 @@ class JodaTimeVisitorTest implements RewriteTest {
           )
         );
     }
-
-    @Test
-    void foo() {
-        // language=java
-        rewriteRun(
-          java(
-            """
-              import org.joda.time.Duration;
-              
-              class A {
-                  public void foo() {
-                      System.out.println(new Duration(1000L).getStandardDays());
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              class A {
-                  public void foo() {
-                      System.out.println(Duration.ofMillis(1000L).toDays());
-                  }
-              }
-              """
-          )
-        );
-    }
 }


### PR DESCRIPTION
## What's changed?
- Added support for safely migrating method return statements of the Joda type.
- Migration Safety Criteria: A method return statement is considered safe to migrate if:
   - The return statement itself can be safely migrated.
   - All invocations of the method are safe to migrate.

### Key Changes:
1. Used a map of methodReferencedVars to track the referenced variables during assignment and in return expression. (A method invocation is unsafe for migration if any of referenced var is unsafe)
2. Added a safeMethodMap to track the safe methods
3. Added new test cases and updated existing ones to reflect the changes.

### Not Implemented Yet:
1. Migration of class variables.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
