### PR TITLE
fix NPE for records

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
@@ -34,6 +34,9 @@ class ScopeAwareVisitor extends JavaVisitor<ExecutionContext> {
 
     @Override
     public J preVisit(J j, ExecutionContext ctx) {
+        if (j instanceof J.ClassDeclaration) {
+            scopes.push(new VariablesInScope(getCursor()));
+        }
         if (j instanceof J.Block) {
             scopes.push(new VariablesInScope(getCursor()));
         }
@@ -50,7 +53,13 @@ class ScopeAwareVisitor extends JavaVisitor<ExecutionContext> {
 
     @Override
     public J postVisit(J j, ExecutionContext ctx) {
+        if (j instanceof J.ClassDeclaration) {
+            scopes.pop();
+        }
         if (j instanceof J.Block) {
+            scopes.pop();
+        }
+        if (j instanceof J.MethodDeclaration) {
             scopes.pop();
         }
         return super.postVisit(j, ctx);

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -281,6 +281,45 @@ class JodaTimeRecipeTest implements RewriteTest {
     }
 
     @Test
+    void migrationWithRecord() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+
+              record A(String x) {
+                  public void foo() {
+                      new Bar().bar(new DateTime());
+                  }
+
+                  private static class Bar {
+                      public void bar(DateTime dt) {
+                          dt.getMillis();
+                      }
+                  }
+              }
+              """,
+            """
+              import java.time.ZonedDateTime;
+
+              record A(String x) {
+                  public void foo() {
+                      new Bar().bar(ZonedDateTime.now());
+                  }
+
+                  private static class Bar {
+                      public void bar(ZonedDateTime dt) {
+                          dt.toInstant().toEpochMilli();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void migrateMethodWithSafeReturnExpression() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed?
- fixes #635

With Java Records, class variables are defined as constructor parameters, that was previously unhandled.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
