### PR TITLE
fix: Skip code references in comment

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
@@ -26,11 +26,9 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.analysis.dataflow.Dataflow;
 import org.openrewrite.analysis.dataflow.analysis.SinkFlowSummary;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
+import org.openrewrite.java.JavadocVisitor;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.java.tree.J.VariableDeclarations.NamedVariable;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.MethodCall;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,6 +48,19 @@ class JodaTimeScanner extends ScopeAwareVisitor {
     public JodaTimeScanner(JodaTimeRecipe.Accumulator acc) {
         super(new LinkedList<>());
         this.acc = acc;
+    }
+
+    @Override
+    protected JavadocVisitor<ExecutionContext> getJavadocVisitor() {
+        return new JavadocVisitor<ExecutionContext>(this) {
+            /**
+             * Do not visit the method referenced from the Javadoc, may cause recipe to fail.
+             */
+            @Override
+            public Javadoc visitReference(Javadoc.Reference reference, ExecutionContext ctx) {
+                return reference;
+            }
+        };
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/ScopeAwareVisitor.java
@@ -34,6 +34,9 @@ class ScopeAwareVisitor extends JavaVisitor<ExecutionContext> {
 
     @Override
     public J preVisit(J j, ExecutionContext ctx) {
+        if (j instanceof J.ClassDeclaration) {
+            scopes.push(new VariablesInScope(getCursor()));
+        }
         if (j instanceof J.Block) {
             scopes.push(new VariablesInScope(getCursor()));
         }
@@ -50,7 +53,13 @@ class ScopeAwareVisitor extends JavaVisitor<ExecutionContext> {
 
     @Override
     public J postVisit(J j, ExecutionContext ctx) {
+        if (j instanceof J.ClassDeclaration) {
+            scopes.pop();
+        }
         if (j instanceof J.Block) {
+            scopes.pop();
+        }
+        if (j instanceof J.MethodDeclaration) {
             scopes.pop();
         }
         return super.postVisit(j, ctx);

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -467,4 +467,39 @@ class JodaTimeRecipeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void migrateWithMethodReferenceInComment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+
+              class A {
+                  public void foo() {
+                      /**
+                       * some method reference in comment
+                       * {@link java.util.List#add(DateTime)}
+                       */
+                      System.out.println(new DateTime());
+                  }
+              }
+              """,
+            """
+              import java.time.ZonedDateTime;
+
+              class A {
+                  public void foo() {
+                      /**
+                       * some method reference in comment
+                       * {@link java.util.List#add(DateTime)}
+                       */
+                      System.out.println(ZonedDateTime.now());
+                  }
+              }
+              """
+            )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -281,6 +281,45 @@ class JodaTimeRecipeTest implements RewriteTest {
     }
 
     @Test
+    void migrationWithRecord() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.joda.time.DateTime;
+
+              record A(String x) {
+                  public void foo() {
+                      new Bar().bar(new DateTime());
+                  }
+
+                  private static class Bar {
+                      public void bar(DateTime dt) {
+                          dt.getMillis();
+                      }
+                  }
+              }
+              """,
+            """
+              import java.time.ZonedDateTime;
+
+              record A(String x) {
+                  public void foo() {
+                      new Bar().bar(ZonedDateTime.now());
+                  }
+
+                  private static class Bar {
+                      public void bar(ZonedDateTime dt) {
+                          dt.toInstant().toEpochMilli();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void migrateMethodWithSafeReturnExpression() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed?
- fixes: #636 

Recipe doesn't have any handling for migrating code references in comments, so skip those.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
