### PR TITLE
Prefer JDK methods for Maps and Sets of an expected size

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     runtimeOnly("org.openrewrite:rewrite-java-17")
     runtimeOnly("org.openrewrite:rewrite-java-21")
 
+    runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release:recipes")
+
     testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")
     testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSize.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSize.java
@@ -22,6 +22,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaCoordinates;
@@ -46,11 +47,14 @@ public class NoMapsAndSetsWithExpectedSize extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                Preconditions.or(
-                        new UsesMethod<>(NEW_HASHMAP),
-                        new UsesMethod<>(NEW_LINKED_HASHMAP),
-                        new UsesMethod<>(NEW_HASHSET),
-                        new UsesMethod<>(NEW_LINKED_HASHSET)
+                Preconditions.and(
+                        new UsesJavaVersion<>(19),
+                        Preconditions.or(
+                                new UsesMethod<>(NEW_HASHMAP),
+                                new UsesMethod<>(NEW_LINKED_HASHMAP),
+                                new UsesMethod<>(NEW_HASHSET),
+                                new UsesMethod<>(NEW_LINKED_HASHSET)
+                        )
                 ),
                 new JavaVisitor<ExecutionContext>() {
                     @Override

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSize.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSize.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaCoordinates;
+
+public class NoMapsAndSetsWithExpectedSize extends Recipe {
+
+    private static final MethodMatcher NEW_HASHMAP = new MethodMatcher("com.google.common.collect.Maps newHashMapWithExpectedSize(int)", false);
+    private static final MethodMatcher NEW_LINKED_HASHMAP = new MethodMatcher("com.google.common.collect.Maps newLinkedHashMapWithExpectedSize(int)", false);
+    private static final MethodMatcher NEW_HASHSET = new MethodMatcher("com.google.common.collect.Sets newHashSetWithExpectedSize(int)", false);
+    private static final MethodMatcher NEW_LINKED_HASHSET = new MethodMatcher("com.google.common.collect.Sets newLinkedHashSetWithExpectedSize(int)", false);
+
+    @Override
+    public String getDisplayName() {
+        return "Prefer JDK methods for Maps and Sets of an expected size";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Prefer Java 19+ methods to create Maps and Sets of an expected size instead of using Guava methods.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                Preconditions.or(
+                        new UsesMethod<>(NEW_HASHMAP),
+                        new UsesMethod<>(NEW_LINKED_HASHMAP),
+                        new UsesMethod<>(NEW_HASHSET),
+                        new UsesMethod<>(NEW_LINKED_HASHSET)
+                ),
+                new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation j = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                        if (NEW_HASHMAP.matches(j)) {
+                            maybeRemoveImport("com.google.common.collect.Maps");
+                            maybeAddImport("java.util.HashMap");
+                            JavaCoordinates coordinates = j.getCoordinates().replace();
+                            return JavaTemplate.builder("new HashMap<>(#{any()})")
+                                    .imports("java.util.HashMap")
+                                    .build()
+                                    .apply(getCursor(), coordinates, j.getArguments().toArray());
+                        } else if (NEW_LINKED_HASHMAP.matches(j)) {
+                            maybeRemoveImport("com.google.common.collect.Maps");
+                            maybeAddImport("java.util.LinkedHashMap");
+                            JavaCoordinates coordinates = j.getCoordinates().replace();
+                            return JavaTemplate.builder("new LinkedHashMap<>(#{any()})")
+                                    .imports("java.util.LinkedHashMap")
+                                    .build()
+                                    .apply(getCursor(), coordinates, j.getArguments().toArray());
+                        } else if (NEW_HASHSET.matches(j)) {
+                            maybeRemoveImport("com.google.common.collect.Sets");
+                            maybeAddImport("java.util.HashSet");
+                            JavaCoordinates coordinates = j.getCoordinates().replace();
+                            return JavaTemplate.builder("new HashSet<>(#{any()})")
+                                    .imports("java.util.HashSet")
+                                    .build()
+                                    .apply(getCursor(), coordinates, j.getArguments().toArray());
+                        } else if (NEW_LINKED_HASHSET.matches(j)) {
+                            maybeRemoveImport("com.google.common.collect.Sets");
+                            maybeAddImport("java.util.LinkedHashSet");
+                            JavaCoordinates coordinates = j.getCoordinates().replace();
+                            return JavaTemplate.builder("new LinkedHashSet<>(#{any()})")
+                                    .imports("java.util.LinkedHashSet")
+                                    .build()
+                                    .apply(getCursor(), coordinates, j.getArguments().toArray());
+                        }
+                        return j;
+                    }
+                }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -64,6 +64,8 @@ recipeList:
   - org.openrewrite.java.migrate.guava.PreferMathMultiplyExact
   - org.openrewrite.java.migrate.guava.NoGuavaAtomicsNewReference
 
+  - tech.picnic.errorprone.refasterrules.InputStreamRulesRecipes
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.guava.NoGuavaJava11

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -79,7 +79,7 @@ tags:
   - java11
 preconditions:
   - org.openrewrite.java.search.HasJavaVersion:
-      version: 11
+      version: "[11,)"
 recipeList:
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableListOf
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableMapOf
@@ -103,7 +103,7 @@ tags:
   - java21
 preconditions:
   - org.openrewrite.java.search.HasJavaVersion:
-      version: 21
+      version: "[21,)"
 recipeList:
   - org.openrewrite.java.migrate.guava.NoMapsAndSetsWithExpectedSize
   - org.openrewrite.java.migrate.guava.PreferMathClamp

--- a/src/main/resources/META-INF/rewrite/no-guava.yml
+++ b/src/main/resources/META-INF/rewrite/no-guava.yml
@@ -25,6 +25,8 @@ description: >-
 tags:
   - guava
 recipeList:
+  - org.openrewrite.java.migrate.guava.NoGuavaJava11
+  - org.openrewrite.java.migrate.guava.NoGuavaJava21
   - org.openrewrite.java.migrate.guava.NoGuavaCreateTempDir
   - org.openrewrite.java.migrate.guava.NoGuavaDirectExecutor
   - org.openrewrite.java.migrate.guava.NoGuavaListsNewArrayList
@@ -73,8 +75,10 @@ description: >-
 tags:
   - guava
   - java11
+preconditions:
+  - org.openrewrite.java.search.HasJavaVersion:
+      version: 11
 recipeList:
-  - org.openrewrite.java.migrate.guava.NoGuava
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableListOf
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableMapOf
   - org.openrewrite.java.migrate.guava.NoGuavaImmutableSetOf
@@ -95,9 +99,13 @@ description: >-
 tags:
   - guava
   - java21
+preconditions:
+  - org.openrewrite.java.search.HasJavaVersion:
+      version: 21
 recipeList:
-  - org.openrewrite.java.migrate.guava.NoGuavaJava11
+  - org.openrewrite.java.migrate.guava.NoMapsAndSetsWithExpectedSize
   - org.openrewrite.java.migrate.guava.PreferMathClamp
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.guava.PreferJavaNioCharsetStandardCharsets

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaJava21Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaJava21Test.java
@@ -17,23 +17,17 @@ package org.openrewrite.java.migrate.guava;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.java.Assertions.*;
 
 class NoGuavaJava21Test implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(
-            Environment.builder()
-              .scanRuntimeClasspath("org.openrewrite.java.migrate.guava")
-              .build()
-              .activateRecipes("org.openrewrite.java.migrate.guava.NoGuavaJava21")
-          )
+        spec
+          .recipeFromResource("/META-INF/rewrite/no-guava.yml", "org.openrewrite.java.migrate.guava.NoGuava")
           .parser(JavaParser.fromJavaVersion().classpath("guava"));
     }
 
@@ -122,32 +116,30 @@ class NoGuavaJava21Test implements RewriteTest {
     @Test
     void noGuavaImmutableOfException() {
         rewriteRun(
-          version(
-            //language=java
-            java(
-              """
-                import com.google.common.collect.ImmutableSet;
-                import com.google.common.collect.ImmutableMap;
+          //language=java
+          java(
+            """
+              import com.google.common.collect.ImmutableSet;
+              import com.google.common.collect.ImmutableMap;
 
-                class A {
-                    public Object getMap() {
-                        return ImmutableMap.of("key", ImmutableSet.of("value1", "value2"));
-                    }
-                }
-                """,
-              """
-                import com.google.common.collect.ImmutableSet;
+              class A {
+                  public Object getMap() {
+                      return ImmutableMap.of("key", ImmutableSet.of("value1", "value2"));
+                  }
+              }
+              """,
+            """
+              import com.google.common.collect.ImmutableSet;
 
-                import java.util.Map;
+              import java.util.Map;
 
-                class A {
-                    public Object getMap() {
-                        return Map.of("key", ImmutableSet.of("value1", "value2"));
-                    }
-                }
-                """
-            ),
-            21
+              class A {
+                  public Object getMap() {
+                      return Map.of("key", ImmutableSet.of("value1", "value2"));
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(21))
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaRefasterTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaRefasterTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class PreferJavaUtilObjectsTest implements RewriteTest {
+class NoGuavaRefasterTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new NoGuavaRefasterRecipes())
@@ -178,33 +178,6 @@ class PreferJavaUtilObjectsTest implements RewriteTest {
               class A {
                   Object foo(Object obj) {
                       return Preconditions.checkNotNull(obj, "%s", "foo");
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void moreObjectsFirstNonNullToObjectsRequireNonNullElse() {
-        rewriteRun(spec -> spec.recipeFromResource("/META-INF/rewrite/no-guava.yml", "org.openrewrite.java.migrate.guava.NoGuavaJava11"),
-          //language=java
-          java(
-            """
-              import com.google.common.base.MoreObjects;
-
-              class A {
-                  Object foo(Object obj) {
-                      return MoreObjects.firstNonNull(obj, "default");
-                  }
-              }
-              """,
-            """
-              import java.util.Objects;
-
-              class A {
-                  Object foo(Object obj) {
-                      return Objects.requireNonNullElse(obj, "default");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate.guava;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -30,6 +31,35 @@ class NoGuavaTest implements RewriteTest {
         spec
           .recipeFromResource("/META-INF/rewrite/no-guava.yml", "org.openrewrite.java.migrate.guava.NoGuava")
           .parser(JavaParser.fromJavaVersion().classpath("guava"));
+    }
+
+    @DocumentExample
+    @Test
+    void moreObjectsFirstNonNullToObjectsRequireNonNullElse() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.base.MoreObjects;
+
+              class A {
+                  Object foo(Object obj) {
+                      return MoreObjects.firstNonNull(obj, "default");
+                  }
+              }
+              """,
+            """
+              import java.util.Objects;
+
+              class A {
+                  Object foo(Object obj) {
+                      return Objects.requireNonNullElse(obj, "default");
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(11))
+          )
+        );
     }
 
     @Test
@@ -94,34 +124,6 @@ class NoGuavaTest implements RewriteTest {
                   }
               }
               """
-          )
-        );
-    }
-
-    @Test
-    void moreObjectsFirstNonNullToObjectsRequireNonNullElse() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import com.google.common.base.MoreObjects;
-
-              class A {
-                  Object foo(Object obj) {
-                      return MoreObjects.firstNonNull(obj, "default");
-                  }
-              }
-              """,
-            """
-              import java.util.Objects;
-
-              class A {
-                  Object foo(Object obj) {
-                      return Objects.requireNonNullElse(obj, "default");
-                  }
-              }
-              """,
-            spec -> spec.markers(javaVersion(11))
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaTest.java
@@ -17,22 +17,18 @@ package org.openrewrite.java.migrate.guava;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
 
 class NoGuavaTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(
-            Environment.builder()
-              .scanRuntimeClasspath("org.openrewrite.java.migrate.guava")
-              .build()
-              .activateRecipes("org.openrewrite.java.migrate.guava.NoGuava")
-          )
+        spec
+          .recipeFromResource("/META-INF/rewrite/no-guava.yml", "org.openrewrite.java.migrate.guava.NoGuava")
           .parser(JavaParser.fromJavaVersion().classpath("guava"));
     }
 
@@ -98,6 +94,34 @@ class NoGuavaTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void moreObjectsFirstNonNullToObjectsRequireNonNullElse() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.base.MoreObjects;
+
+              class A {
+                  Object foo(Object obj) {
+                      return MoreObjects.firstNonNull(obj, "default");
+                  }
+              }
+              """,
+            """
+              import java.util.Objects;
+
+              class A {
+                  Object foo(Object obj) {
+                      return Objects.requireNonNullElse(obj, "default");
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(11))
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSizeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSizeTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
 
 class NoMapsAndSetsWithExpectedSizeTest implements RewriteTest {
     @Override
@@ -60,7 +61,8 @@ class NoMapsAndSetsWithExpectedSizeTest implements RewriteTest {
                       Set<String> d = new LinkedHashSet<>(1);
                   }
               }
-              """
+              """,
+            spec -> spec.markers(javaVersion(21))
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSizeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoMapsAndSetsWithExpectedSizeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class NoMapsAndSetsWithExpectedSizeTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new NoMapsAndSetsWithExpectedSize());
+    }
+
+    @DocumentExample
+    @Test
+    void noMapSetWithExpectedSize() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.google.common.collect.Maps;
+              import com.google.common.collect.Sets;
+              import java.util.Map;
+              import java.util.Set;
+
+              class A {
+                  void method() {
+                      Map<String, String> a = Maps.newHashMapWithExpectedSize(1);
+                      Map<String, String> b = Maps.newLinkedHashMapWithExpectedSize(1);
+                      Set<String> c = Sets.newHashSetWithExpectedSize(1);
+                      Set<String> d = Sets.newLinkedHashSetWithExpectedSize(1);
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+
+              class A {
+                  void method() {
+                      Map<String, String> a = new HashMap<>(1);
+                      Map<String, String> b = new LinkedHashMap<>(1);
+                      Set<String> c = new HashSet<>(1);
+                      Set<String> d = new LinkedHashSet<>(1);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
- Phase out Guava methods that create Maps and Sets of an expected size.
- Add preconditions to the NoGuavaJava11 and NoGuavaJava21 recipes
- Include NoGuavaJava11 and NoGuavaJava21 with NoGuava for easier running
- Remove inclusion of NoGuavaJava11 from NoGuavaJava21
- Remove inclusion of NoGuava from NoGuavaJava11
- Include `tech.picnic.errorprone.refasterrules.InputStreamRulesRecipes`

## What's your motivation?
Further the phase out of Guava methods, as seen on
- https://github.com/gaul/modernizer-maven-plugin/issues/258

## Anyone you would like to review specifically?
As suggested by @knutwannheden 

## Have you considered any alternatives or workarounds?
Declarative didn't work as we swap a method invocation for a constructor call.
Refaster didn't work as we do not yet support generics needed here.

## Any additional context
There's additional rules added we could still phase out:
https://github.com/gaul/modernizer-maven-plugin/compare/modernizer-maven-plugin-2.9.0...modernizer-maven-plugin-3.0.0