### PR TITLE
[JacksonJavaxToJakarta] Rewrite JaxbAnnotationModule to JakartaXmlBindAnnotationModule

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr353")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
+    testRuntimeOnly("com.fasterxml.jackson.module:jackson-module-jaxb-annotations")
     testRuntimeOnly("org.apache.johnzon:johnzon-core:1.2.18")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
     testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -918,6 +918,9 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.datatype.jsr353.JSR353Module
       newFullyQualifiedTypeName: com.fasterxml.jackson.datatype.jsonp.JSONPModule
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
+      newFullyQualifiedTypeName: com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
@@ -294,4 +294,40 @@ class JacksonJavaxtoJakartaTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void thatJaxbAnnotationModuleIsRewritten() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath(
+              "jackson-core",
+              "jackson-databind",
+              "jackson-module-jaxb-annotations",
+              "jackson-module-jakarta-xmlbind-annotations")),
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
+              public class JacksonTest {
+                  void foo() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      mapper.registerModule(new JaxbAnnotationModule());
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
+
+              public class JacksonTest {
+                  void foo() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      mapper.registerModule(new JakartaXmlBindAnnotationModule());
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.jakarta;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -295,14 +296,14 @@ class JacksonJavaxtoJakartaTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/652")
     @Test
     void thatJaxbAnnotationModuleIsRewritten() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath(
-              "jackson-core",
-              "jackson-databind",
-              "jackson-module-jaxb-annotations",
-              "jackson-module-jakarta-xmlbind-annotations")),
+            "jackson-core",
+            "jackson-databind",
+            "jackson-module-jaxb-annotations")),
           //language=java
           java(
             """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR declares an additional `ChangeType` step in the `jakarta-ee-9.yml` to rewrite the `JaxbAnnotationsModule` to the `JakartaXmlBindAnnotationModule`.

- Fixes #652.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
