### PR TITLE
[JacksonJavaxToJakarta] Rewrite JacksonJaxbJsonProvider to JacksonXmlBindJsonProvider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testRuntimeOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr353")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-core")
     testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind")
+    testRuntimeOnly("com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider")
     testRuntimeOnly("com.fasterxml.jackson.module:jackson-module-jaxb-annotations")
     testRuntimeOnly("org.apache.johnzon:johnzon-core:1.2.18")
     testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -918,6 +918,9 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.datatype.jsr353.JSR353Module
       newFullyQualifiedTypeName: com.fasterxml.jackson.datatype.jsonp.JSONPModule
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider
+      newFullyQualifiedTypeName: com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
@@ -294,4 +294,28 @@ class JacksonJavaxtoJakartaTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void thatJaxbJsonProviderIsRewritten() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath(
+              "jackson-core",
+              "jackson-databind",
+              "jackson-jaxrs-json-provider",
+              "jackson-jakarta-rs-json-provider")),
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+
+              public class A extends JacksonJaxbJsonProvider {}
+              """,
+            """
+              import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+
+              public class A extends JacksonXmlBindJsonProvider {}
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
@@ -337,7 +337,6 @@ class JacksonJavaxtoJakartaTest implements RewriteTest {
     void thatJaxbJsonProviderIsRewritten() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath(
-              "jackson-core",
               "jackson-databind",
               "jackson-jaxrs-json-provider")),
           //language=java


### PR DESCRIPTION
## What's changed?
This PR declares an additional `ChangeType` step in the `jakarta-ee-9.yml` to rewrite `JacksonJaxbJsonProvider` to `JacksonXmlBindJsonProvider`.

- Fixes #653.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
