### PR TITLE
Add migration from `javax.servlet.servlet-api` to `javax.servlet.javax.servlet-api`

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-ee-8.yml
+++ b/src/main/resources/META-INF/rewrite/java-ee-8.yml
@@ -23,6 +23,12 @@ tags:
   - javaee8
   - deprecated
 recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.servlet
+      oldArtifactId: servlet-api
+      newGroupId: javax.servlet
+      newArtifactId: javax.servlet-api
+      newVersion: 3.x
   - org.openrewrite.java.migrate.javaee7
   - org.openrewrite.java.migrate.javaee8.ServletIsRequestedSessionIdFromURL
   - org.openrewrite.java.migrate.javaee8.ApacheDefaultProvider
@@ -42,8 +48,8 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.javaee8.ApacheDefaultProvider
 displayName: Flags any `org.apache.bval.jsr*` (bval 1.1) and `org.apache.bval.jsr303*` (bval 1.0) package references
 description: >-
-  This recipe flags any `org.apache.bval.jsr*` (bval 1.1) and `org.apache.bval.jsr303*` (bval 1.0) package references in validation.xml deployment descriptors. 
-  Bean Validation 2.0 and later use the Hibernate Validator implementation instead of the 
+  This recipe flags any `org.apache.bval.jsr*` (bval 1.1) and `org.apache.bval.jsr303*` (bval 1.0) package references in validation.xml deployment descriptors.
+  Bean Validation 2.0 and later use the Hibernate Validator implementation instead of the
   Apache BVal implementation which was used for Bean Validation 1.0 and 1.1.
 recipeList:
   - org.openrewrite.xml.ChangeTagValue:
@@ -60,4 +66,3 @@ recipeList:
       newValue: org.hibernate.validator.engine.ConstraintValidatorFactoryImpl
   - org.openrewrite.xml.RemoveXmlTag:
       xPath: /validation-config/parameter-name-provider
-      


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
When java became jakarta the artifact `javax.servlet.servlet-api` was renamed to `javax.servlet.javax.servlet-api` and at the same time a `jakarta.servlet.jakarta.servlet-api` was introduced

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @sambsnyd 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
