### PR TITLE
Java21 recipe deprecatedSecurityManager

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
+++ b/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.List;
+
+public class DeprecatedSecurityManager extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Call `System.setProperty(\"java.security.manager\")` before calling `java.lang.System setSecurityManager(java.lang.SecurityManager)`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The default value of the `java.security.manager` system property has been changed to disallow since Java 18." +
+                " Unless the system property is set to allow on the command line, any invocation of System.setSecurityManager(SecurityManager) " +
+                " with a non-null argument will throw an `UnsupportedOperationException`. " +
+                " You can set system property as `Djava.security.manager=allow.` to prevent the exception"
+                + "The recipe calls `System.setProperty(\"java.security.manager\")` before calling `java.lang.System setSecurityManager(SecurityManager)`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
+                MethodMatcher SETSECURITY_REF = new MethodMatcher("java.lang.System setSecurityManager(java.lang.SecurityManager) ", true);
+                List<Statement> statements = block.getStatements();
+                boolean propertySet = false;
+                for (int i = 0; i < statements.size() ; i++) {
+                    Statement stmt = statements.get(i);
+                    if (stmt instanceof J.MethodInvocation) {
+                        if (SETSECURITY_REF.matches((J.MethodInvocation) stmt)) {
+                            for (Statement statement : statements) {
+                                if (statement instanceof J.MethodInvocation &&
+                                        ((J.MethodInvocation) statement).getSimpleName().equals("setProperty") &&
+                                        ((J.MethodInvocation) statement).getArguments().get(0) instanceof J.Literal &&
+                                        ((J.Literal) ((J.MethodInvocation) statement).getArguments().get(0)).getValue().equals("java.security.manager")) {
+                                    propertySet = true;
+                                    break;
+                                }
+                            }
+                            String templateString = "System.setProperty(\"java.security.manager\", \"allow\");";
+                            if (!propertySet) {
+                                stmt = JavaTemplate.builder(templateString)
+                                        .contextSensitive()
+                                        .build().apply(new Cursor(getCursor(), stmt),
+                                                stmt.getCoordinates().replace());
+                                statements = ListUtils.insert(statements, stmt, i);
+                                return block.withStatements(statements);
+                            }
+                        }
+                    }
+                }
+                return super.visitBlock(block, ctx);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
+++ b/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
@@ -30,7 +30,7 @@ public class DeprecatedSecurityManager extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Call `System.setProperty(\"java.security.manager\")` before calling `java.lang.System setSecurityManager(java.lang.SecurityManager)`";
+        return "Call `System.setProperty(\"java.security.manager\",\"allow\")` before calling `System.setSecurityManager(java.lang.SecurityManager)`";
     }
 
     @Override
@@ -38,8 +38,8 @@ public class DeprecatedSecurityManager extends Recipe {
         return "The default value of the `java.security.manager` system property has been changed to disallow since Java 18." +
                 " Unless the system property is set to allow on the command line, any invocation of System.setSecurityManager(SecurityManager) " +
                 " with a non-null argument will throw an `UnsupportedOperationException`. " +
-                " You can set system property as `Djava.security.manager=allow.` to prevent the exception" +
-                "The recipe calls `System.setProperty(\"java.security.manager\",\"allow\")` before calling `java.lang.System setSecurityManager(SecurityManager)`.";
+                " You can set system property as `Djava.security.manager=allow.` to prevent the exception." +
+                "The recipe calls `System.setProperty(\"java.security.manager\",\"allow\")` before calling `System.setSecurityManager(SecurityManager)`.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
+++ b/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
@@ -38,8 +38,8 @@ public class DeprecatedSecurityManager extends Recipe {
         return "The default value of the `java.security.manager` system property has been changed to disallow since Java 18." +
                 " Unless the system property is set to allow on the command line, any invocation of System.setSecurityManager(SecurityManager) " +
                 " with a non-null argument will throw an `UnsupportedOperationException`. " +
-                " You can set system property as `Djava.security.manager=allow.` to prevent the exception"
-                + "The recipe calls `System.setProperty(\"java.security.manager\")` before calling `java.lang.System setSecurityManager(SecurityManager)`.";
+                " You can set system property as `Djava.security.manager=allow.` to prevent the exception" +
+                "The recipe calls `System.setProperty(\"java.security.manager\")` before calling `java.lang.System setSecurityManager(SecurityManager)`.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
+++ b/src/main/java/org/openrewrite/java/migrate/DeprecatedSecurityManager.java
@@ -39,7 +39,7 @@ public class DeprecatedSecurityManager extends Recipe {
                 " Unless the system property is set to allow on the command line, any invocation of System.setSecurityManager(SecurityManager) " +
                 " with a non-null argument will throw an `UnsupportedOperationException`. " +
                 " You can set system property as `Djava.security.manager=allow.` to prevent the exception" +
-                "The recipe calls `System.setProperty(\"java.security.manager\")` before calling `java.lang.System setSecurityManager(SecurityManager)`.";
+                "The recipe calls `System.setProperty(\"java.security.manager\",\"allow\")` before calling `java.lang.System setSecurityManager(SecurityManager)`.";
     }
 
     @Override

--- a/src/main/resources/META-INF/rewrite/java-version-21.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-21.yml
@@ -37,7 +37,7 @@ recipeList:
   - org.openrewrite.java.migrate.UpgradePluginsForJava21
   - org.openrewrite.java.migrate.DeleteDeprecatedFinalize
   - org.openrewrite.java.migrate.RemovedSubjectMethods
-
+  - org.openrewrite.java.migrate.DeprecatedSecurityManager
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.UpgradeBuildToJava21

--- a/src/test/java/org/openrewrite/java/migrate/DeprecatedSecurityManagerTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/DeprecatedSecurityManagerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+class DeprecatedSecurityManagerTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new DeprecatedSecurityManager())
+          .allSources(src -> src.markers(javaVersion(11)));
+    }
+    @Test
+    @DocumentExample
+    void deprecatedSecurityManager() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.lang.Thread;
+              import java.lang.*;
+
+              public class Test {
+
+                 public void foo(){
+                     String x = "dlaj";
+                 }
+                 public static void main(String[] args) {
+                     System.setSecurityManager(new SecurityManager());
+                     int i = 5;
+                 }
+              }
+              """,
+            """
+              import java.lang.Thread;
+              import java.lang.*;
+
+              public class Test {
+
+                 public void foo(){
+                     String x = "dlaj";
+                 }
+                 public static void main(String[] args) {
+                     System.setProperty("java.security.manager", "allow");
+                     System.setSecurityManager(new SecurityManager());
+                     int i = 5;
+                 }
+              }
+              """
+          )
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/migrate/DeprecatedSecurityManagerTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/DeprecatedSecurityManagerTest.java
@@ -27,7 +27,7 @@ class DeprecatedSecurityManagerTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new DeprecatedSecurityManager())
-          .allSources(src -> src.markers(javaVersion(11)));
+            .allSources(src -> src.markers(javaVersion(21)));
     }
     @Test
     @DocumentExample


### PR DESCRIPTION
## What's changed?
Java 21 recipe: org.openrewrite.java.migrate.DeprecatedSecurityManager

## What's your motivation?
The default value of the java.security.manager system property has been changed to disallow since Java 18. Unless the system property is set to allow on the command line, any invocation of System.setSecurityManager(SecurityManager) with a non-null argument will throw an UnsupportedOperationException. You can set system property as Djava.security.manager=allow. 
This recipe calls 
``` System.setProperty("java.security.manager", "allow");```
whenever
 System.setSecurityManager(SecurityManager) is called

Reference : https://bugs.openjdk.org/browse/JDK-8271301 & https://bugs.openjdk.org/browse/JDK-8270380
## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
