### PR TITLE
Omit migration to @Setter annotated field of other annotations are present

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokUtils.java
@@ -53,7 +53,7 @@ class LombokUtils {
             return false;
         }
         // Check there is no annotation except @Overwrite
-        if (noneAtAllOrOnlyOverrideAnnotated(cursor, service)) {
+        if (hasAnyAnnotatioOtherThanOverride(cursor, service)) {
             return false;
         }
         // Check field is declared on method type
@@ -120,7 +120,7 @@ class LombokUtils {
         }
 
         // Check there is no annotation except @Overwrite
-        if (noneAtAllOrOnlyOverrideAnnotated(cursor, service)) {
+        if (hasAnyAnnotatioOtherThanOverride(cursor, service)) {
             return false;
         }
 
@@ -167,9 +167,8 @@ class LombokUtils {
         return PACKAGE;
     }
 
-    private static boolean noneAtAllOrOnlyOverrideAnnotated(Cursor cursor, AnnotationService service) {
+    private static boolean hasAnyAnnotatioOtherThanOverride(Cursor cursor, AnnotationService service) {
         List<J.Annotation> annotations = service.getAllAnnotations(cursor);
-        return !annotations.isEmpty() &&
-                !(annotations.size() == 1 && OVERRIDE_MATCHER.matches(annotations.get(0)));
+        return !(annotations.isEmpty() || (annotations.size() == 1 && OVERRIDE_MATCHER.matches(annotations.get(0))));
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokUtils.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokUtils.java
@@ -32,16 +32,13 @@ import static org.openrewrite.java.tree.J.Modifier.Type.*;
 
 class LombokUtils {
 
-    private static final AnnotationMatcher overwriteMatcher = new AnnotationMatcher("java.lang.Override");
-    private static final AnnotationService annotationService = new AnnotationService();
+    private static final AnnotationMatcher OVERRIDE_MATCHER = new AnnotationMatcher("java.lang.Override");
 
-
-    static boolean isGetter(Cursor cursor) {
+    static boolean isGetter(Cursor cursor, AnnotationService service) {
         if (!(cursor.getValue() instanceof J.MethodDeclaration)) {
             return false;
         }
         J.MethodDeclaration method = cursor.getValue();
-
         if (method.getMethodType() == null) {
             return false;
         }
@@ -56,7 +53,7 @@ class LombokUtils {
             return false;
         }
         // Check there is no annotation except @Overwrite
-        if (noneAtAllOrOnlyOverwriteAnnotated(cursor)) {
+        if (noneAtAllOrOnlyOverrideAnnotated(cursor, service)) {
             return false;
         }
         // Check field is declared on method type
@@ -101,7 +98,7 @@ class LombokUtils {
         return "get" + StringUtils.capitalize(fieldName);
     }
 
-    static boolean isSetter(Cursor cursor) {
+    static boolean isSetter(Cursor cursor, AnnotationService service) {
         if (!(cursor.getValue() instanceof J.MethodDeclaration)) {
             return false;
         }
@@ -123,7 +120,7 @@ class LombokUtils {
         }
 
         // Check there is no annotation except @Overwrite
-        if (noneAtAllOrOnlyOverwriteAnnotated(cursor)) {
+        if (noneAtAllOrOnlyOverrideAnnotated(cursor, service)) {
             return false;
         }
 
@@ -170,9 +167,9 @@ class LombokUtils {
         return PACKAGE;
     }
 
-    private static boolean noneAtAllOrOnlyOverwriteAnnotated(Cursor cursor) {
-        List<J.Annotation> annotations = annotationService.getAllAnnotations(cursor);
+    private static boolean noneAtAllOrOnlyOverrideAnnotated(Cursor cursor, AnnotationService service) {
+        List<J.Annotation> annotations = service.getAllAnnotations(cursor);
         return !annotations.isEmpty() &&
-                !(annotations.size() == 1 && overwriteMatcher.matches(annotations.get(0)));
+                !(annotations.size() == 1 && OVERRIDE_MATCHER.matches(annotations.get(0)));
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokGetter.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokGetter.java
@@ -54,7 +54,7 @@ public class UseLombokGetter extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.@Nullable MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                if (LombokUtils.isGetter(method)) {
+                if (LombokUtils.isGetter(getCursor())) {
                     Expression returnExpression = ((J.Return) method.getBody().getStatements().get(0)).getExpression();
                     if (returnExpression instanceof J.Identifier &&
                             ((J.Identifier) returnExpression).getFieldType() != null) {

--- a/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokGetter.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokGetter.java
@@ -23,6 +23,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
@@ -54,7 +55,7 @@ public class UseLombokGetter extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.@Nullable MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                if (LombokUtils.isGetter(getCursor())) {
+                if (LombokUtils.isGetter(getCursor(), service(AnnotationService.class))) {
                     Expression returnExpression = ((J.Return) method.getBody().getStatements().get(0)).getExpression();
                     if (returnExpression instanceof J.Identifier &&
                             ((J.Identifier) returnExpression).getFieldType() != null) {

--- a/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokSetter.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokSetter.java
@@ -53,7 +53,7 @@ public class UseLombokSetter extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.@Nullable MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                if (LombokUtils.isSetter(method)) {
+                if (LombokUtils.isSetter(getCursor())) {
                     Expression assignmentVariable = ((J.Assignment) method.getBody().getStatements().get(0)).getVariable();
                     if (assignmentVariable instanceof J.FieldAccess &&
                             ((J.FieldAccess) assignmentVariable).getName().getFieldType() != null) {

--- a/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokSetter.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/UseLombokSetter.java
@@ -23,6 +23,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
@@ -53,7 +54,7 @@ public class UseLombokSetter extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.@Nullable MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                if (LombokUtils.isSetter(getCursor())) {
+                if (LombokUtils.isSetter(getCursor(), service(AnnotationService.class))) {
                     Expression assignmentVariable = ((J.Assignment) method.getBody().getStatements().get(0)).getVariable();
                     if (assignmentVariable instanceof J.FieldAccess &&
                             ((J.FieldAccess) assignmentVariable).getName().getFieldType() != null) {

--- a/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokGetterTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokGetterTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.lombok;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -530,6 +531,7 @@ class UseLombokGetterTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5015")
     void noChangeIfAnnotated() {
         rewriteRun(// language=java
           java("@interface MyOtherAnnotation {}"),
@@ -550,6 +552,7 @@ class UseLombokGetterTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5015")
     void replaceGetterIfOverwrite() {
         rewriteRun(// language=java
           java(

--- a/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokGetterTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokGetterTest.java
@@ -528,4 +528,52 @@ class UseLombokGetterTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void noChangeIfAnnotated() {
+        rewriteRun(// language=java
+          java("@interface MyOtherAnnotation {}"),
+          java(
+            """
+              class A {
+
+                  int foo = 9;
+
+                  @MyOtherAnnotation
+                  public int getFoo() {
+                      return foo;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceGetterIfOverwrite() {
+        rewriteRun(// language=java
+          java(
+            """
+              class A {
+
+                  int foo = 9;
+
+                  @Override
+                  public int getFoo() {
+                      return foo;
+                  }
+              }
+              """,
+            """
+              import lombok.Getter;
+
+              class A {
+
+                  @Getter
+                  int foo = 9;
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokSetterTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokSetterTest.java
@@ -537,4 +537,52 @@ class UseLombokSetterTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void noChangeIfAnnotated() {
+        rewriteRun(// language=java
+          java("@interface MyOtherAnnotation {}"),
+          java(
+            """
+              class A {
+
+                  int foo = 9;
+
+                  @MyOtherAnnotation
+                  public void setFoo(int fub) {
+                      this.foo = fub;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceSetterIfOverwrite() {
+        rewriteRun(// language=java
+          java(
+            """
+              class A {
+
+                  int foo = 9;
+
+                  @Override
+                  public void setFoo(int foo) {
+                      this.foo = foo;
+                  }
+              }
+              """,
+            """
+              import lombok.Setter;
+
+              class A {
+
+                  @Setter
+                  int foo = 9;
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokSetterTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokSetterTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.lombok;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -539,6 +540,7 @@ class UseLombokSetterTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5015")
     void noChangeIfAnnotated() {
         rewriteRun(// language=java
           java("@interface MyOtherAnnotation {}"),
@@ -559,6 +561,7 @@ class UseLombokSetterTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5015")
     void replaceSetterIfOverwrite() {
         rewriteRun(// language=java
           java(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
- Reported in https://github.com/openrewrite/rewrite/issues/5015 the Lombok recipes don't migrate other annotations.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
prevent breaking changes
## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
