### PR TITLE
Fix #681: WebAPI from 8.0 -> 9.1 -> 10.0

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -1016,6 +1016,12 @@ recipeList:
       newGroupId: jakarta.platform
       newArtifactId: jakarta.jakartaee-api
       newVersion: 9.1.0
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax
+      oldArtifactId: javaee-web-api
+      newGroupId: jakarta.platform
+      newArtifactId: jakarta.jakartaee-web-api
+      newVersion: 9.1.0
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.platform
       artifactId: "*"


### PR DESCRIPTION
This migrates `javax` to `jakarta` WEB-API to 9. then in the 10.0 it already has this conversion which will handle taking it to 10.0.0

```yml
type: specs.openrewrite.org/v1beta/recipe
name: org.openrewrite.java.migrate.jakarta.UpdateJakartaPlatform10
displayName: Update Jakarta EE Platform Dependencies to 10.0.0
description: Update Jakarta EE Platform Dependencies to 10.0.0.
recipeList:
  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
      groupId: jakarta.platform
      artifactId: "*"
      newVersion: 10.0.0
```