### PR TITLE
Add Getter method to `useMimeCoder` field in `UseJavaUtilBase64` recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
+++ b/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
 import org.openrewrite.*;
 import org.openrewrite.java.ChangeType;
 import org.openrewrite.java.JavaTemplate;
@@ -34,6 +35,7 @@ import java.util.Base64;
 public class UseJavaUtilBase64 extends Recipe {
     private final String sunPackage;
 
+    @Getter
     @Option(displayName = "Use Mime Coder", description = "Use `Base64.getMimeEncoder()/getMimeDecoder()` instead of `Base64.getEncoder()/getDecoder()`.", required = false, example = "false")
     boolean useMimeCoder;
 


### PR DESCRIPTION
…cipe

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add Getter method to `useMimeCoder` field in `UseJavaUtilBase64` recipe

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

It seems that when running a recipe with configuration parameters, there must be a Getter method to the parameter field in recipe.

For example:

```
---
type: specs.openrewrite.org/v1beta/recipe
name: UseJavaUtilBase64
displayName: UseJavaUtilBase64
description: UseJavaUtilBase64.
recipeList:
  - org.openrewrite.java.migrate.UseJavaUtilBase64:
      useMimeCoder: true

```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
