### PR TITLE
Migrate XJC bindings to Jakarta EE

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -699,6 +699,29 @@ recipeList:
       groupId: org.codehaus.mojo
       artifactId: jaxb-maven-plugin
       newVersion: 4.x
+  - org.openrewrite.java.migrate.jakarta.JavaxXmlToJakartaXmlXJCBinding
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JavaxXmlToJakartaXmlXJCBinding
+displayName: Migrate XJC Bindings to Jakata XML
+description: Java EE has been rebranded to Jakarta EE, migrates the namespace and version in XJC bindings.
+tags:
+  - jaxb
+  - javax
+  - jakarta
+recipeList:
+  - org.openrewrite.xml.ChangeTagAttribute:
+      #language=xpath
+      elementName: "//*[namespace-uri() = 'http://java.sun.com/xml/ns/jaxb' and local-name() = 'bindings']"
+      attributeName: version
+      oldValue: 1.0
+      newValue: 3.0
+  - org.openrewrite.xml.ChangeTagAttribute:
+      #language=xpath
+      elementName: "//*[namespace-uri() = 'http://java.sun.com/xml/ns/jaxb' and local-name() = 'bindings']"
+      attributeName: xmlns:jxb
+      oldValue: http://java.sun.com/xml/ns/jaxb
+      newValue: https://jakarta.ee/xml/ns/jaxb
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxXmlSoapToJakartaXmlSoap

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.jakarta;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+public class UpdateXJCBindingsToJakartaEE implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.migrate.jakarta.JavaxXmlToJakartaXmlXJCBinding");
+    }
+
+    @Test
+    void noMigrate() {
+        rewriteRun(
+          xml(
+            //language=xml
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <jxb:bindings version="3.0"
+                          xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                          xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            </jxb:bindings>
+            """
+          )
+        );
+    }
+
+    @Nested
+    class Migrate {
+        @Test
+        void version() {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <jxb:bindings version="1.0"
+                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                </jxb:bindings>
+                """,
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <jxb:bindings version="3.0"
+                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                </jxb:bindings>
+                """
+              )
+            );
+        }
+
+        @Test
+        void namespace() {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <jxb:bindings version="3.0"
+                              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                </jxb:bindings>
+                """,
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <jxb:bindings version="3.0"
+                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                </jxb:bindings>
+                """
+              )
+            );
+        }
+
+        @Test
+        void both() {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <jxb:bindings version="1.0"
+                              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                </jxb:bindings>
+                """,
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <jxb:bindings version="3.0"
+                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                </jxb:bindings>
+                """
+              )
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->
Migrate XJC bindings files to have required version and namespace for Jakara EE

## What's changed?
<!-- A brief description of the changes in this pull request -->
additional recipe to migrate custom bindings.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Better migration coverage of XML Projects.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
