### PR TITLE
Replace the jacoco supporting Gradle 8 deprecated properties

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecations.java
+++ b/src/main/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecations.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.jacoco;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class Gradle8JacocoReportDeprecations extends Recipe {
+
+    @Override
+    public @NotNull String getDisplayName() {
+        return "Replace gradle 8 introduced deprecations in jacoco report task";
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return "Set the `enabled` to `required` and the `destination` to `outputLocation` for Reports deprecations that were removed in gradle 8. " +
+                "See [the gradle docs on this topic](https://docs.gradle.org/current/userguide/upgrading_version_7.html#report_and_testreport_api_cleanup).";
+    }
+
+    @Override
+    public @NotNull TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new IsBuildGradle<>(), new GroovyIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.@NotNull Assignment visitAssignment(J.@NotNull Assignment assignment, @NotNull ExecutionContext ctx) {
+                String prefix = getCursor().getNearestMessage("path");
+                String prefixOrEmpty = prefix == null ? "" : prefix + ".";
+                if (assignment.getVariable() instanceof J.FieldAccess) {
+                    J.FieldAccess fieldAccess = (J.FieldAccess) assignment.getVariable();
+                    String fieldName = getFieldName(fieldAccess);
+                    return replaceDeprecations(assignment, prefixOrEmpty + fieldName);
+                } else if (assignment.getVariable() instanceof J.Identifier) {
+                    J.Identifier identifier = (J.Identifier) assignment.getVariable();
+                    return replaceDeprecations(assignment, prefixOrEmpty + identifier.getSimpleName());
+                }
+                return assignment;
+            }
+
+            @Override
+            public J.@NotNull MethodInvocation visitMethodInvocation(J.@NotNull MethodInvocation method, @NotNull ExecutionContext executionContext) {
+                String parent = getCursor().getNearestMessage("path");
+                if (parent == null) {
+                    getCursor().putMessage("path", method.getSimpleName());
+                } else {
+                    getCursor().putMessage("path", parent + "." + method.getSimpleName());
+                }
+                return super.visitMethodInvocation(method, executionContext);
+            }
+
+            private @NotNull J.Assignment replaceDeprecations(J.@NotNull Assignment assignment, String path) {
+                String[] parts = path.split("\\.");
+                if (parts.length == 4 && "jacocoTestReport".equalsIgnoreCase(parts[0]) && "reports".equalsIgnoreCase(parts[1])) {
+                    String reportType = parts[2];
+                    if ("xml".equalsIgnoreCase(reportType) || "csv".equalsIgnoreCase(reportType) || "html".equalsIgnoreCase(reportType)) {
+                        if (assignment.getVariable() instanceof J.FieldAccess) {
+                            J.FieldAccess fieldAccess = (J.FieldAccess) assignment.getVariable();
+                            if ("enabled".equalsIgnoreCase(parts[3])) {
+                                return assignment.withVariable(fieldAccess.withName(fieldAccess.getName().withSimpleName("required")));
+                            } else if ("destination".equalsIgnoreCase(parts[3])) {
+                                return assignment.withVariable(fieldAccess.withName(fieldAccess.getName().withSimpleName("outputLocation")));
+                            }
+                        } else if (assignment.getVariable() instanceof J.Identifier) {
+                            J.Identifier identifier = (J.Identifier) assignment.getVariable();
+                            if ("enabled".equalsIgnoreCase(parts[3])) {
+                                return assignment.withVariable(identifier.withSimpleName("required"));
+                            } else if ("destination".equalsIgnoreCase(parts[3])) {
+                                return assignment.withVariable(identifier.withSimpleName("outputLocation"));
+                            }
+                        }
+                    }
+                }
+                return assignment;
+            }
+
+            private @NotNull String getFieldName(J.@NotNull FieldAccess fieldAccess) {
+                String fieldName = fieldAccess.getSimpleName();
+                Expression target = fieldAccess;
+                while (target instanceof J.FieldAccess) {
+                    target = ((J.FieldAccess) target).getTarget();
+                    if (target instanceof J.Identifier) {
+                        fieldName = ((J.Identifier) target).getSimpleName() + "." + fieldName;
+                    } else if (target instanceof J.FieldAccess){
+                        fieldName = ((J.FieldAccess) target).getSimpleName() + "." + fieldName;
+                    }
+                }
+                return fieldName;
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecations.java
+++ b/src/main/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecations.java
@@ -32,7 +32,7 @@ public class Gradle8JacocoReportDeprecations extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Replace gradle 8 introduced deprecations in jacoco report task";
+        return "Replace Gradle 8 introduced deprecations in JaCoCo report task";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecations.java
+++ b/src/main/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecations.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.migrate.jacoco;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -32,21 +31,21 @@ import org.openrewrite.java.tree.J;
 public class Gradle8JacocoReportDeprecations extends Recipe {
 
     @Override
-    public @NotNull String getDisplayName() {
+    public String getDisplayName() {
         return "Replace gradle 8 introduced deprecations in jacoco report task";
     }
 
     @Override
-    public @NotNull String getDescription() {
+    public String getDescription() {
         return "Set the `enabled` to `required` and the `destination` to `outputLocation` for Reports deprecations that were removed in gradle 8. " +
                 "See [the gradle docs on this topic](https://docs.gradle.org/current/userguide/upgrading_version_7.html#report_and_testreport_api_cleanup).";
     }
 
     @Override
-    public @NotNull TreeVisitor<?, ExecutionContext> getVisitor() {
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new IsBuildGradle<>(), new GroovyIsoVisitor<ExecutionContext>() {
             @Override
-            public J.@NotNull Assignment visitAssignment(J.@NotNull Assignment assignment, @NotNull ExecutionContext ctx) {
+            public J. Assignment visitAssignment(J. Assignment assignment, ExecutionContext ctx) {
                 String prefix = getCursor().getNearestMessage("path");
                 String prefixOrEmpty = prefix == null ? "" : prefix + ".";
                 if (assignment.getVariable() instanceof J.FieldAccess) {
@@ -61,17 +60,17 @@ public class Gradle8JacocoReportDeprecations extends Recipe {
             }
 
             @Override
-            public J.@NotNull MethodInvocation visitMethodInvocation(J.@NotNull MethodInvocation method, @NotNull ExecutionContext executionContext) {
+            public J. MethodInvocation visitMethodInvocation(J. MethodInvocation method, ExecutionContext ctx) {
                 String parent = getCursor().getNearestMessage("path");
                 if (parent == null) {
                     getCursor().putMessage("path", method.getSimpleName());
                 } else {
                     getCursor().putMessage("path", parent + "." + method.getSimpleName());
                 }
-                return super.visitMethodInvocation(method, executionContext);
+                return super.visitMethodInvocation(method, ctx);
             }
 
-            private @NotNull J.Assignment replaceDeprecations(J.@NotNull Assignment assignment, String path) {
+            private J.Assignment replaceDeprecations(J. Assignment assignment, String path) {
                 String[] parts = path.split("\\.");
                 if (parts.length == 4 && "jacocoTestReport".equalsIgnoreCase(parts[0]) && "reports".equalsIgnoreCase(parts[1])) {
                     String reportType = parts[2];
@@ -96,7 +95,7 @@ public class Gradle8JacocoReportDeprecations extends Recipe {
                 return assignment;
             }
 
-            private @NotNull String getFieldName(J.@NotNull FieldAccess fieldAccess) {
+            private String getFieldName(J. FieldAccess fieldAccess) {
                 String fieldName = fieldAccess.getSimpleName();
                 Expression target = fieldAccess;
                 while (target instanceof J.FieldAccess) {

--- a/src/main/resources/META-INF/rewrite/jacoco.yml
+++ b/src/main/resources/META-INF/rewrite/jacoco.yml
@@ -34,3 +34,4 @@ recipeList:
       groupId: org.jacoco
       artifactId: jacoco-maven-plugin
       newVersion: 0.8.x
+  - org.openrewrite.java.migrate.jacoco.Gradle8JacocoReportDeprecations

--- a/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate.jacoco;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
@@ -17,16 +17,21 @@ package org.openrewrite.java.migrate.jacoco;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 
 class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
 
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new Gradle8JacocoReportDeprecations());
+    }
+
     @Test
     void enabledDeprecatedInCollapsedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -58,7 +63,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @DocumentExample
     void enabledDeprecatedInNormalSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -97,7 +101,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void enabledDeprecatedInElapsedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -148,7 +151,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void enabledDeprecatedInMixedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -191,7 +193,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void enabledDeprecatedInSemiCollapsedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -226,7 +227,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void enabledInAnotherExtensionNotTouched() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -246,7 +246,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void destinationDeprecatedInCollapsedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -278,7 +277,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void destinationDeprecatedInNormalSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -317,7 +315,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void destinationDeprecatedInElapsedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -368,7 +365,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void destinationDeprecatedInMixedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -411,7 +407,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void destinationDeprecatedInSemiCollapsedSyntax() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {
@@ -446,7 +441,6 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     @Test
     void destinationInAnotherExtensionNotTouched() {
         rewriteRun(
-          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
           buildGradle(
             """
               plugins {

--- a/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
@@ -1,6 +1,7 @@
 package org.openrewrite.java.migrate.jacoco;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
@@ -39,6 +40,7 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     void enabledDeprecatedInNormalSyntax() {
         rewriteRun(
           spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
@@ -257,6 +259,7 @@ class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
     @Test
     void destinationDeprecatedInNormalSyntax() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jacoco/Gradle8JacocoReportDeprecationsTest.java
@@ -1,0 +1,447 @@
+package org.openrewrite.java.migrate.jacoco;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+
+class Gradle8JacocoReportDeprecationsTest implements RewriteTest {
+
+    @Test
+    void enabledDeprecatedInCollapsedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport.reports.xml.enabled = false
+              jacocoTestReport.reports.csv.enabled = true
+              jacocoTestReport.reports.html.enabled = false
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport.reports.xml.required = false
+              jacocoTestReport.reports.csv.required = true
+              jacocoTestReport.reports.html.required = false
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void enabledDeprecatedInNormalSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.enabled = false
+                      csv.enabled = true
+                      html.enabled = false
+                  }
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.required = false
+                      csv.required = true
+                      html.required = false
+                  }
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void enabledDeprecatedInElapsedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml {
+                          enabled = false
+                      }
+                      csv {
+                          enabled = false
+                      }
+                      html {
+                          enabled = false
+                      }
+                  }
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml {
+                          required = false
+                      }
+                      csv {
+                          required = false
+                      }
+                      html {
+                          required = false
+                      }
+                  }
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void enabledDeprecatedInMixedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.enabled = false
+                      csv.enabled = false
+                      html {
+                          enabled = false
+                      }
+                  }
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.required = false
+                      csv.required = false
+                      html {
+                          required = false
+                      }
+                  }
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void enabledDeprecatedInSemiCollapsedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports.xml.enabled = false
+                  reports.csv.enabled = false
+                  reports.html.enabled = false
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports.xml.required = false
+                  reports.csv.required = false
+                  reports.html.required = false
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void enabledInAnotherExtensionNotTouched() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+
+              tasks.register("example", JavaCompile) {
+                   xml.enabled = false
+                   jacocoTestReport.reports.html.enabled = false
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void destinationDeprecatedInCollapsedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport.reports.xml.destination = layout.buildDirectory.dir('jacocoXml')
+              jacocoTestReport.reports.csv.destination = layout.buildDirectory.dir('jacocoCsv')
+              jacocoTestReport.reports.html.destination = layout.buildDirectory.dir('jacocoHtml')
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport.reports.xml.outputLocation = layout.buildDirectory.dir('jacocoXml')
+              jacocoTestReport.reports.csv.outputLocation = layout.buildDirectory.dir('jacocoCsv')
+              jacocoTestReport.reports.html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void destinationDeprecatedInNormalSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.destination = layout.buildDirectory.dir('jacocoXml')
+                      csv.destination = layout.buildDirectory.dir('jacocoCsv')
+                      html.destination = layout.buildDirectory.dir('jacocoHtml')
+                  }
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.outputLocation = layout.buildDirectory.dir('jacocoXml')
+                      csv.outputLocation = layout.buildDirectory.dir('jacocoCsv')
+                      html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+                  }
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void destinationDeprecatedInElapsedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml {
+                          destination = layout.buildDirectory.dir('jacocoXml')
+                      }
+                      csv {
+                          destination = layout.buildDirectory.dir('jacocoCsv')
+                      }
+                      html {
+                          destination = layout.buildDirectory.dir('jacocoHtml')
+                      }
+                  }
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml {
+                          outputLocation = layout.buildDirectory.dir('jacocoXml')
+                      }
+                      csv {
+                          outputLocation = layout.buildDirectory.dir('jacocoCsv')
+                      }
+                      html {
+                          outputLocation = layout.buildDirectory.dir('jacocoHtml')
+                      }
+                  }
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void destinationDeprecatedInMixedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.destination = layout.buildDirectory.dir('jacocoXml')
+                      csv.destination = layout.buildDirectory.dir('jacocoCsv')
+                      html {
+                          destination = layout.buildDirectory.dir('jacocoHtml')
+                      }
+                  }
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports {
+                      xml.outputLocation = layout.buildDirectory.dir('jacocoXml')
+                      csv.outputLocation = layout.buildDirectory.dir('jacocoCsv')
+                      html {
+                          outputLocation = layout.buildDirectory.dir('jacocoHtml')
+                      }
+                  }
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void destinationDeprecatedInSemiCollapsedSyntax() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports.xml.destination = layout.buildDirectory.dir('jacocoXml')
+                  reports.csv.destination = layout.buildDirectory.dir('jacocoCsv')
+                  reports.html.destination = layout.buildDirectory.dir('jacocoHtml')
+              }
+
+              """,
+            """
+              plugins {
+                  id "java"
+                  id "jacoco"
+              }
+
+              jacocoTestReport {
+                  reports.xml.outputLocation = layout.buildDirectory.dir('jacocoXml')
+                  reports.csv.outputLocation = layout.buildDirectory.dir('jacocoCsv')
+                  reports.html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
+    void destinationInAnotherExtensionNotTouched() {
+        rewriteRun(
+          spec -> spec.recipe(new Gradle8JacocoReportDeprecations()),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+
+              tasks.register("example", JavaCompile) {
+                   xml.destination = false
+                   jacocoTestReport.reports.html.destination = layout.buildDirectory.dir('jacocoHtml')
+              }
+
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
In order to migrate jacoco to newer version / gradle version, we have to replace the properties as mentioned in [Gradle docs](https://docs.gradle.org/current/userguide/upgrading_version_7.html#report_and_testreport_api_cleanup). 

This should leak also in the spring recipes as there we also bump jacoco. 