### PR TITLE
Security Manager API Removal

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 the original author or authors.
+# Copyright 2025 the original author or authors.
 # <p>
 # Licensed under the Moderne Source Available License (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -41,8 +41,8 @@ recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.security.AccessController#checkPermission(..)
   - org.openrewrite.java.RemoveMethodInvocations:
-      methodPattern: import java.security.Policy#setPolicy(..)
+      methodPattern: java.security.Policy#setPolicy(..)
   - org.openrewrite.java.RemoveMethodInvocations:
-      methodPattern: import java.lang.SecurityManager#check*(..)
+      methodPattern: java.lang.SecurityManager#check*(..)
   - org.openrewrite.staticanalysis.UnnecessaryCatch
   - org.openrewrite.staticanalysis.UnnecessaryThrows

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -1,0 +1,48 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.UpgradeToJava25
+displayName: Migrate to Java 25
+description: >-
+  This recipe will apply changes commonly needed when migrating to Java 25. This recipe will also replace deprecated API
+  with equivalents when there is a clear migration strategy. Build files will also be updated to use Java 25 as the
+  target/source and plugins will be also be upgraded to versions that are compatible with Java 25.
+tags:
+  - java25
+recipeList:
+  - org.openrewrite.java.migrate.RemoveSecurityManagerAPI
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemoveSecurityManagerAPI
+displayName: Remove Security Manager API
+description: The Security Manager API is unsupported in Java 24. This recipe will remove the API and any usages of it.
+tags:
+  - java25
+preconditions:
+  - org.openrewrite.java.migrate.search.FindJavaVersion:
+      version: 24
+recipeList:
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: java.security.AccessController#checkPermission(*)
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: import java.security.Policy#setPolicy(*)
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: import java.lang.SecurityManager#check*(*)
+  - org.openrewrite.staticanalysis.UnnecessaryCatch
+  - org.openrewrite.staticanalysis.UnnecessaryThrows

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -34,14 +34,71 @@ displayName: Remove Security Manager API
 description: The Security Manager API is unsupported in Java 24. This recipe will remove the API and any usages of it.
 tags:
   - java25
+  - security
+  - deprecation
 preconditions:
   - org.openrewrite.java.migrate.search.FindJavaVersion:
       version: 24
 recipeList:
+  - org.openrewrite.java.migrate.RemoveSecurityPolicy
+  - org.openrewrite.java.migrate.RemoveSecurityAccessController
+  - org.openrewrite.java.migrate.RemoveSecurityManager
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.AccessController
+displayName: Remove Security AccessController
+description: The Security Manager API is unsupported in Java 24. This recipe will remove the usage of `java.security.AccessController`.
+tags:
+  - java25
+  - security
+  - deprecation
+preconditions:
+  - org.openrewrite.java.migrate.search.FindJavaVersion:
+      version: 24
+  - org.openrewrite.java.search.FindTypes:
+      fullyQualifiedTypeName: java.security.AccessController
+recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.security.AccessController#checkPermission(..)
+  - org.openrewrite.staticanalysis.UnnecessaryCatch
+  - org.openrewrite.staticanalysis.UnnecessaryThrows
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemoveSecurityPolicy
+displayName: Remove Security Policy
+description: The Security Manager API is unsupported in Java 24. This recipe will remove the use of `java.security.Policy`.
+tags:
+  - java25
+  - security
+  - deprecation
+preconditions:
+  - org.openrewrite.java.migrate.search.FindJavaVersion:
+      version: 24
+  - org.openrewrite.java.search.FindTypes:
+      fullyQualifiedTypeName: java.security.Policy
+recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.security.Policy#setPolicy(..)
+  - org.openrewrite.staticanalysis.UnnecessaryCatch
+  - org.openrewrite.staticanalysis.UnnecessaryThrows
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemoveSecurityManager
+displayName: Remove Security SecurityManager
+description: The Security Manager API is unsupported in Java 24. This recipe will remove the usage of `java.security.SecurityManager`.
+tags:
+  - java25
+  - security
+  - deprecation
+preconditions:
+  - org.openrewrite.java.migrate.search.FindJavaVersion:
+      version: 24
+  - org.openrewrite.java.search.FindTypes:
+      fullyQualifiedTypeName: java.security.SecurityManager
+recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.lang.SecurityManager#check*(..)
   - org.openrewrite.staticanalysis.UnnecessaryCatch

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -39,10 +39,10 @@ preconditions:
       version: 24
 recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
-      methodPattern: java.security.AccessController#checkPermission(*)
+      methodPattern: java.security.AccessController#checkPermission(..)
   - org.openrewrite.java.RemoveMethodInvocations:
-      methodPattern: import java.security.Policy#setPolicy(*)
+      methodPattern: import java.security.Policy#setPolicy(..)
   - org.openrewrite.java.RemoveMethodInvocations:
-      methodPattern: import java.lang.SecurityManager#check*(*)
+      methodPattern: import java.lang.SecurityManager#check*(..)
   - org.openrewrite.staticanalysis.UnnecessaryCatch
   - org.openrewrite.staticanalysis.UnnecessaryThrows

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -41,8 +41,8 @@ tags:
 preconditions:
   - org.openrewrite.java.migrate.search.FindJavaVersion:
       version: 24
-  - org.openrewrite.java.search.FindTypes:
-      fullyQualifiedTypeName: java.security.AccessController
+  - org.openrewrite.java.search.FindMethods:
+      methodPattern: java.security.AccessController#checkPermission(..)
 recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.security.AccessController#checkPermission(..)
@@ -61,8 +61,8 @@ tags:
 preconditions:
   - org.openrewrite.java.migrate.search.FindJavaVersion:
       version: 24
-  - org.openrewrite.java.search.FindTypes:
-      fullyQualifiedTypeName: java.security.Policy
+  - org.openrewrite.java.search.FindMethods:
+      methodPattern: java.security.Policy#setPolicy(..)
 recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.security.Policy#setPolicy(..)
@@ -81,8 +81,8 @@ tags:
 preconditions:
   - org.openrewrite.java.migrate.search.FindJavaVersion:
       version: 24
-  - org.openrewrite.java.search.FindTypes:
-      fullyQualifiedTypeName: java.security.SecurityManager
+  - org.openrewrite.java.search.FindMethods:
+      methodPattern: java.lang.SecurityManager#check*(..)
 recipeList:
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.lang.SecurityManager#check*(..)

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -25,21 +25,6 @@ description: >-
 tags:
   - java25
 recipeList:
-  - org.openrewrite.java.migrate.RemoveSecurityManagerAPI
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.RemoveSecurityManagerAPI
-displayName: Remove Security Manager API
-description: The Security Manager API is unsupported in Java 24. This recipe will remove the API and any usages of it.
-tags:
-  - java25
-  - security
-  - deprecation
-preconditions:
-  - org.openrewrite.java.migrate.search.FindJavaVersion:
-      version: 24
-recipeList:
   - org.openrewrite.java.migrate.RemoveSecurityPolicy
   - org.openrewrite.java.migrate.RemoveSecurityAccessController
   - org.openrewrite.java.migrate.RemoveSecurityManager


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
With Java 24 the Security Manager API pushes users from using itself. We can help by removing the methods.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
