### PR TITLE
Remove and cleanup `System.getSecurityManager()`

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -88,3 +88,25 @@ recipeList:
       methodPattern: java.lang.SecurityManager#check*(..)
   - org.openrewrite.staticanalysis.UnnecessaryCatch
   - org.openrewrite.staticanalysis.UnnecessaryThrows
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.SystemGetSecurityManagerToNull
+displayName: Replace `System.getSecurityManager()` with `null`
+description: >-
+    The Security Manager API is unsupported in Java 24. This recipe will replace `System.getSecurityManager()` with `null`
+    to make its behavior more obvious and try to simplify execution paths afterwards.
+tags:
+  - java25
+  - security
+  - deprecation
+preconditions:
+  - org.openrewrite.java.migrate.search.FindJavaVersion:
+      version: 24
+  - org.openrewrite.java.search.FindMethods:
+      methodPattern: java.lang.System#getSecurityManager()
+recipeList:
+  - org.openrewrite.java.ReplaceMethodInvocationWithConstant
+      methodPattern: java.lang.System#getSecurityManager()
+      constant: "null"
+  - org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -106,7 +106,7 @@ preconditions:
   - org.openrewrite.java.search.FindMethods:
       methodPattern: java.lang.System#getSecurityManager()
 recipeList:
-  - org.openrewrite.java.ReplaceMethodInvocationWithConstant
+  - org.openrewrite.java.ReplaceMethodInvocationWithConstant:
       methodPattern: java.lang.System#getSecurityManager()
       constant: "null"
   - org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution


### PR DESCRIPTION

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Since Java 24 a call to `System.getSecurityManager()` always returns `null`. 
The recipe makes this explicit by replacing these calls with null.
Afterward, cleans up the code if unreachable branches are now obvious.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
