### PR TITLE
Migrate `com:intellij:annotations` to `org.jetbrains:annotations`

### DIFF
--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -303,6 +303,48 @@ examples:
     language: java
 ---
 type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.java.migrate.ComIntelliJAnnotationsToOrgJetbrainsAnnotations
+examples:
+- description: ''
+  sources:
+  - before: project
+    language: mavenProject
+  - before: |
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>my-app</artifactId>
+        <version>1</version>
+
+        <dependencies>
+          <dependency>
+            <groupId>com.intellij</groupId>
+            <artifactId>annotations</artifactId>
+            <version>5.1</version>
+          </dependency>
+        </dependencies>
+      </project>
+    path: pom.xml
+    language: xml
+- description: ''
+  sources:
+  - before: |
+      plugins {
+          id("java-library")
+      }
+      repositories {
+          mavenCentral()
+      }
+      dependencies {
+          implementation("com.intellij:annotations:5.1")
+          implementation "com.intellij:annotations:6.0.3"
+          implementation group: "com.intellij", name: "annotations", version: "12.0"
+      }
+    path: build.gradle
+    language: groovy
+---
+type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.java.migrate.DeleteDeprecatedFinalize
 examples:
 - description: ''
@@ -3282,25 +3324,6 @@ examples:
 - description: ''
   sources:
   - before: |
-      import com.google.common.base.MoreObjects;
-
-      class A {
-          Object foo(Object obj) {
-              return MoreObjects.firstNonNull(obj, "default");
-          }
-      }
-    after: |
-      import java.util.Objects;
-
-      class A {
-          Object foo(Object obj) {
-              return Objects.requireNonNullElse(obj, "default");
-          }
-      }
-    language: java
-- description: ''
-  sources:
-  - before: |
       import com.google.common.base.Optional;
 
       class A {
@@ -3341,6 +3364,25 @@ examples:
               } catch (NoSuchElementException e) {
                   return "";
               }
+          }
+      }
+    language: java
+- description: ''
+  sources:
+  - before: |
+      import com.google.common.base.MoreObjects;
+
+      class A {
+          Object foo(Object obj) {
+              return MoreObjects.firstNonNull(obj, "default");
+          }
+      }
+    after: |
+      import java.util.Objects;
+
+      class A {
+          Object foo(Object obj) {
+              return Objects.requireNonNullElse(obj, "default");
           }
       }
     language: java

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -303,48 +303,6 @@ examples:
     language: java
 ---
 type: specs.openrewrite.org/v1beta/example
-recipeName: org.openrewrite.java.migrate.ComIntelliJAnnotationsToOrgJetbrainsAnnotations
-examples:
-- description: ''
-  sources:
-  - before: project
-    language: mavenProject
-  - before: |
-      <project>
-        <modelVersion>4.0.0</modelVersion>
-
-        <groupId>com.mycompany.app</groupId>
-        <artifactId>my-app</artifactId>
-        <version>1</version>
-
-        <dependencies>
-          <dependency>
-            <groupId>com.intellij</groupId>
-            <artifactId>annotations</artifactId>
-            <version>5.1</version>
-          </dependency>
-        </dependencies>
-      </project>
-    path: pom.xml
-    language: xml
-- description: ''
-  sources:
-  - before: |
-      plugins {
-          id("java-library")
-      }
-      repositories {
-          mavenCentral()
-      }
-      dependencies {
-          implementation("com.intellij:annotations:5.1")
-          implementation "com.intellij:annotations:6.0.3"
-          implementation group: "com.intellij", name: "annotations", version: "12.0"
-      }
-    path: build.gradle
-    language: groovy
----
-type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.java.migrate.DeleteDeprecatedFinalize
 examples:
 - description: ''

--- a/src/main/resources/META-INF/rewrite/intellij-annotations-to-jetbrains-annotations.yml
+++ b/src/main/resources/META-INF/rewrite/intellij-annotations-to-jetbrains-annotations.yml
@@ -1,4 +1,4 @@
-﻿#
+#
 # Copyright 2025 the original author or authors.
 # <p>
 # Licensed under the Moderne Source Available License (the "License");

--- a/src/main/resources/META-INF/rewrite/intellij-annotations-to-jetbrains-annotations.yml
+++ b/src/main/resources/META-INF/rewrite/intellij-annotations-to-jetbrains-annotations.yml
@@ -1,0 +1,32 @@
+﻿#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.ComIntelliJAnnotationsToOrgJetbrainsAnnotations
+displayName: Migrate com.intellij:annotations to org.jetbrains:annotations
+description: >-
+  This recipe will upgrade old dependency of com.intellij:annotations to the newer org.jetbrains:annotations.
+tags:
+  - intellij
+  - jetbrains
+  - annotations
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.intellij
+      oldArtifactId: annotations
+      newGroupId: org.jetbrains
+      newVersion: latest.release

--- a/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.Scope;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.function.UnaryOperator.identity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+
+public class ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.beforeRecipe(withToolingApi());
+        spec.recipeFromResource(
+          "/META-INF/rewrite/intellij-annotations-to-jetbrains-annotations.yml",
+          "org.openrewrite.java.migrate.ComIntelliJAnnotationsToOrgJetbrainsAnnotations"
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void mavenDependencyUpdate() {
+        rewriteRun(
+          mavenProject("project",
+            pomXml(
+              //language=xml
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.intellij</groupId>
+                      <artifactId>annotations</artifactId>
+                      <version>5.1</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+              spec -> spec
+                .after(identity())
+                .afterRecipe(doc -> assertThat(doc.getMarkers().findFirst(MavenResolutionResult.class)
+                  .get().getDependencies().get(Scope.Compile))
+                  .filteredOn(rd -> rd.getDepth() == 0)
+                  .satisfiesExactly(
+                    rd -> {
+                        assertThat(rd.getGroupId()).isEqualTo("org.jetbrains");
+                        assertThat(rd.getArtifactId()).isEqualTo("annotations");
+                    }))
+            )
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void gradleDependencyUpdates() {
+        rewriteRun(
+          buildGradle(
+            //language=groovy
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("com.intellij:annotations:5.1")
+                  implementation "com.intellij:annotations:6.0.3"
+                  implementation group: "com.intellij", name: "annotations", version: "12.0"
+              }
+              """,
+            spec -> spec.after(buildGradle -> {
+                Matcher version = Pattern.compile("\\d+\\.\\d+(\\.\\d+)?").matcher(buildGradle);
+                assertThat(version.find()).isTrue();
+                String dependencyVersion = version.group(0);
+                return """
+                  plugins {
+                      id("java-library")
+                  }
+                  repositories {
+                      mavenCentral()
+                  }
+                  dependencies {
+                      implementation("org.jetbrains:annotations:%1$s")
+                      implementation "org.jetbrains:annotations:%1$s"
+                      implementation group: "org.jetbrains", name: "annotations", version: "%1$s"
+                  }
+                  """.formatted(dependencyVersion);
+            })
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 import static java.util.function.UnaryOperator.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;

--- a/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.maven.tree.Scope;
 import org.openrewrite.test.RecipeSpec;
@@ -42,7 +41,6 @@ class ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest implements RewriteTest
           );
     }
 
-    @DocumentExample
     @Test
     void mavenDependencyUpdate() {
         rewriteRun(
@@ -81,7 +79,6 @@ class ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest implements RewriteTest
         );
     }
 
-    @DocumentExample
     @Test
     void gradleDependencyUpdates() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
@@ -35,11 +35,11 @@ import static org.openrewrite.maven.Assertions.pomXml;
 class ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
-        spec.recipeFromResource(
+        spec.beforeRecipe(withToolingApi())
+          .recipeFromResource(
           "/META-INF/rewrite/intellij-annotations-to-jetbrains-annotations.yml",
           "org.openrewrite.java.migrate.ComIntelliJAnnotationsToOrgJetbrainsAnnotations"
-        );
+          );
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
@@ -31,7 +31,6 @@ import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest implements RewriteTest {
     @Override

--- a/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest.java
@@ -33,7 +33,7 @@ import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
-public class ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest implements RewriteTest {
+class ComIntelliJAnnotationsToOrgJetbrainsAnnotationsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.beforeRecipe(withToolingApi());


### PR DESCRIPTION
- Finishes #289 

## What's changed?
- Adding declarative recipe for migrating `com.intellij:annotations` dependencies to `org.jetbrains:annotations` (the moving of the artifact is already indicated on [Maven Central](https://mvnrepository.com/artifact/com.intellij/annotations)). As noted in the issue, the packages used within the dependencies were already using `org.jetbrains.annotations` back to the oldest available version of `com.intelli:annotations` (v5.1) so packages do not need to be migrated.

### Checklist
- [X] I've added unit tests to cover cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
