### PR TITLE
Upgrade existing jakarta.annotation-api to 2.0.x for EE9

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -112,6 +112,10 @@ recipeList:
       newGroupId: jakarta.annotation
       newArtifactId: jakarta.annotation-api
       newVersion: 2.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api
+      newVersion: 2.0.x
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.annotation
       newPackageName: jakarta.annotation

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
@@ -574,7 +574,7 @@ class JavaxToJakartaTest implements RewriteTest {
     }
 
     @Test
-    void doNothingIfNotFoundTransitiveDependency() {
+    void upgradeAnnotationApiFromV1ToV2() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(javaxServlet)),
           mavenProject(
@@ -592,8 +592,7 @@ class JavaxToJakartaTest implements RewriteTest {
             //language=xml
             pomXml(
               """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -603,6 +602,21 @@ class JavaxToJakartaTest implements RewriteTest {
                       <groupId>jakarta.annotation</groupId>
                       <artifactId>jakarta.annotation-api</artifactId>
                       <version>1.3.5</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>jakarta.annotation</groupId>
+                      <artifactId>jakarta.annotation-api</artifactId>
+                      <version>2.0.0</version>
                     </dependency>
                   </dependencies>
                 </project>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
In the Jakarta EE 9 recipe list, add an extra recipe step to ensure `jakarta.annotation-api` is upgraded to the correct version for EE9 in case an older version was used.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

#### QUESTION: Is it even a valid case to run `AddCommonAnnotationsDependencies` first, before running `JavaxMigrationToJakarta` (Jakarta EE 9 migration)? Should the EE 9 migration supercede the former recipe?

If [`AddCommonAnnotationsDependencies`](https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/resources/META-INF/rewrite/add-common-annotations-dependencies.yml) is run beforehand, it updates the original `javax.annotation-api` to use `jakarta.annotation-api:1.3.x`. The EE9 recipe then fails to upgrade to `2.0.x` because the original `javax.annotation-api` no longer exists.

When this recipe runs afterwards, it should update the version if the jakarta version of the artifact already existed.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
