### PR TITLE
Ensure jakarta.annotation dependency is provided scope. Add/change tests

### DIFF
--- a/src/main/resources/META-INF/rewrite/add-common-annotations-dependencies.yml
+++ b/src/main/resources/META-INF/rewrite/add-common-annotations-dependencies.yml
@@ -33,9 +33,15 @@ recipeList:
       newGroupId: jakarta.annotation
       newArtifactId: jakarta.annotation-api
       newVersion: 1.3.x
+  # Jakarta EE recommends `provided` scope
+  - org.openrewrite.maven.ChangeDependencyScope:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api
+      newScope: provided
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.annotation
       artifactId: jakarta.annotation-api
       version: 1.3.x
       onlyIfUsing: javax.annotation..*
+      scope: provided
       acceptTransitive: true

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
@@ -53,7 +53,7 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
             //language=xml
             pomXml(
               """
-                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -61,7 +61,7 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
                 </project>
                 """,
               """
-                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -101,7 +101,7 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
             //language=xml
             pomXml(
               """
-                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -116,7 +116,7 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
                 </project>
                 """,
               """
-                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.sample</groupId>
                   <artifactId>sample</artifactId>

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
@@ -43,7 +43,7 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
               java(
                 """
                   import javax.annotation.Generated;
-                  
+
                   @Generated("Hello")
                   class A {
                   }
@@ -53,7 +53,6 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
             //language=xml
             pomXml(
               """
-                <?xml version="1.0" encoding="UTF-8"?>
                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.sample</groupId>
@@ -62,7 +61,6 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
                 </project>
                 """,
               """
-                <?xml version="1.0" encoding="UTF-8"?>
                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>org.sample</groupId>
@@ -73,6 +71,62 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
                       <groupId>jakarta.annotation</groupId>
                       <artifactId>jakarta.annotation-api</artifactId>
                       <version>1.3.5</version>
+                      <scope>provided</scope>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void changeAndUpgradeDependencyIfAnnotationJsr250Present() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn("package javax.annotation; public @interface Generated {}")),
+          mavenProject("my-project",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import javax.annotation.Generated;
+
+                  @Generated("Hello")
+                  class A {
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>javax.annotation</groupId>
+                      <artifactId>javax.annotation-api</artifactId>
+                      <version>1.3.2</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>jakarta.annotation</groupId>
+                      <artifactId>jakarta.annotation-api</artifactId>
+                      <version>1.3.5</version>
+                      <scope>provided</scope>
                     </dependency>
                   </dependencies>
                 </project>


### PR DESCRIPTION
- Fixes #728 

## What's changed?
Changes recipe that adds `jakarta.annotation-api` to use `provided` scope 

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Discussed in #728 - considered fixing `AddDependency` or `ChangeDependency`, but may not be the correct solution.

## Any additional context
I believe migrating from Java EE to Jakarta EE, it may be recommended to switch maven dependency scopes to `provided` as the runtime environment likely provides the Jakarta EE APIs. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
