### PR TITLE
Improve JakartaXmlWs recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -774,17 +774,25 @@ recipeList:
       groupId: jakarta.xml.ws
       artifactId: jakarta.xml.ws-api
       newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: com.sun.xml.ws
-      artifactId: jaxws-rt
-      version: 3.x
-      scope: runtime
-      onlyIfUsing: javax.xml.ws..*
-      acceptTransitive: true
+  - org.openrewrite.maven.ChangeDependencyScope:
+      groupId: jakarta.xml.ws
+      artifactId: jakarta.xml.ws-api
+      newScope: provided
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: com.sun.xml.ws
       artifactId: jaxws-rt
       newVersion: 3.x
+  - org.openrewrite.maven.ChangeDependencyScope:
+      groupId: com.sun.xml.ws
+      artifactId: jaxws-rt
+      newScope: provided
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: com.sun.xml.ws
+      artifactId: jaxws-rt
+      version: 3.x
+      scope: provided
+      onlyIfUsing: javax.xml.ws..*
+      acceptTransitive: true
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.xml.ws
       newPackageName: jakarta.xml.ws


### PR DESCRIPTION
- Fixes #730 

## What's changed?
- Use `provided` scope in the Jakarta XML WS recipe
- Handle more upgrade scenarios correctly

## What's your motivation?
#730 

## Anything in particular you'd like reviewers to focus on?
Unsure if the `jaxws-rt` dependency is still needed when upgrading to EE9. Maybe it could be removed? but for now making it `provided` scope similar to what gets added via https://github.com/openrewrite/rewrite-migrate-java/blob/88a1c90c0ac3b83a749712621a7551f12c2c340f/src/main/resources/META-INF/rewrite/java-version-11.yml#L235

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
