### PR TITLE
Insert <shared-cache-mode> before <properties>  to ensure correct schema order

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/JpaCacheProperties.java
+++ b/src/main/java/org/openrewrite/java/migrate/JpaCacheProperties.java
@@ -154,10 +154,26 @@ class PersistenceXmlVisitor extends XmlVisitor<ExecutionContext> {
             // if we could determine an appropriate value, create the element.
             if (scmValue != null) {
                 if (!v1) {
-                    Xml.Tag newNode = Xml.Tag.build("<shared-cache-mode>" + scmValue + "</shared-cache-mode>");
+                    //Xml.Tag newNode = Xml.Tag.build("<shared-cache-mode>" + scmValue + "</shared-cache-mode>");
                     // Ideally we would insert <shared-cache-mode> before the <validation-mode> and <properties> nodes
                     Cursor parent = getCursor().getParentOrThrow();
-                    t = autoFormat(addOrUpdateChild(t, newNode, parent), ctx, parent);
+                    List<Xml.Tag> newChildren = new ArrayList<>();
+                    Xml.Tag sharedCacheTag = Xml.Tag.build("<shared-cache-mode>" + scmValue + "</shared-cache-mode>").withPrefix("\n        ");
+                    boolean added = false;
+
+                    for (Xml.Tag child : t.getChildren()) {
+                        if (!added && "properties".equals(child.getName())) {
+                            newChildren.add(sharedCacheTag);
+                            added = true;
+                        }
+                        newChildren.add(child);
+                    }
+                    if (!added) {
+                        newChildren.add(sharedCacheTag);
+                    }
+
+                    t = t.withContent(newChildren);
+                    t = autoFormat(t, ctx, parent);
                 } else {
                     // version="1.0"
                     // add a property for eclipselink

--- a/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
@@ -837,13 +837,12 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set1">
-                      <!-- flag -->
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>NONE</shared-cache-mode>
                       <properties>
                           <!-- Connection properties -->
                           <!-- remove and insert shared-cache-mode NONE -->
                       </properties>
-                      <shared-cache-mode>NONE</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -873,13 +872,12 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set2">
-                      <!-- flag -->
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>ALL</shared-cache-mode>
                       <properties>
                           <!-- Connection properties -->
                           <!-- remove and insert shared-cache-mode ALL -->
                       </properties>
-                      <shared-cache-mode>ALL</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -909,15 +907,13 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set3">
-                      <!-- flag -->
-                      <!-- add shared-cache-mode ENABLE_SELECTIVE -->
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
                       <properties>
                           <!-- Connection properties -->
                           <property name="openjpa.DataCache" value="truE(Types=foo.bar.Person;foo.bar.Employee)"/>
                           <!-- leave - manual fix-->
                       </properties>
-                      <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -947,15 +943,13 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set4">
-                      <!-- flag -->
-                      <!-- add shared-cache-mode DISABLE_SELECTIVE -->
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
                       <properties>
                           <!-- Connection properties -->
                           <property name="openjpa.DataCache" value="TRUE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/>
                           <!-- leave - manual fix -->
                       </properties>
-                      <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -985,13 +979,12 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_notset1">
-                      <!-- flag, insert shared-cache-mode NONE -->
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>NONE</shared-cache-mode>
                       <properties>
                           <!-- Connection properties -->
                           <property name="somethingelese" value="junk"></property>
                       </properties>
-                      <shared-cache-mode>NONE</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -1139,13 +1132,11 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache3_flagged">
-                      <!-- flag -->
-                      <!-- create shared-cache-mode NONE -->
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>NONE</shared-cache-mode>
                       <properties>
                           <property name="javax.persistence.jdbc.driver" value="com.ibm.db2.jcc.DB2Driver" />
                       </properties>
-                      <shared-cache-mode>NONE</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -1307,8 +1298,8 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache9_flagged">  <!-- flag -->
-                      <shared-cache-mode>NONE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>NONE</shared-cache-mode>
                       <properties>
                           <property name="openjpa.DataCache" value="True"/> <!-- delete -->
                       </properties>
@@ -1319,8 +1310,8 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache9_flagged">  <!-- flag -->
-                      <shared-cache-mode>NONE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>NONE</shared-cache-mode>
                       <properties>
                           <!-- delete -->
                       </properties>
@@ -1352,12 +1343,11 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache10_flagged">
-                      <!-- flag and insert shared-cache-mode NONE -->
                       <validation-mode>NONE</validation-mode>
+                      <shared-cache-mode>NONE</shared-cache-mode>
                       <properties>
                           <!-- delete -->
                       </properties>
-                      <shared-cache-mode>NONE</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -1385,11 +1375,10 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache11_flagged">
-                      <!-- flag and insert shared-cache-mode ALL-->
+                      <shared-cache-mode>ALL</shared-cache-mode>
                       <properties>
                           <!-- delete -->
                       </properties>
-                      <shared-cache-mode>ALL</shared-cache-mode>
                   </persistence-unit>
               </persistence>
               """,
@@ -1397,4 +1386,40 @@ class JpaCachePropertiesTest implements RewriteTest {
           )
         );
     }
+    @Test
+    void openjpa_shared_cache11_flagged() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+                <persistence-unit name="openjpa_cache11_flagged">
+                    <!-- flag and insert shared-cache-mode ALL-->
+                    <properties>
+                        <property name="openjpa.DataCache" value="tRue"/><!-- delete -->
+                    </properties>
+                </persistence-unit>
+            </persistence>
+            """,
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+                <persistence-unit name="openjpa_cache11_flagged">
+                    <shared-cache-mode>ALL</shared-cache-mode>
+                    <properties>
+                        <!-- delete -->
+                    </properties>
+                </persistence-unit>
+            </persistence>
+            """,
+            sourceSpecs -> sourceSpecs.path(PERSISTENCE_FILENAME)
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Added logic to insert &lt;shared-cache-mode&gt; before &lt;properties&gt; and added the test case for it.

## Anything in particular you'd like reviewers to focus on?
After making the changes to recipe the tests were not passing as they were not taking accepting comments, all the tests start to pass once I removed the comments in the test cases therefore I would like a review on it.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
