### PR TITLE
Make `org.openrewrite.java.migrate.lombok.log.LogVisitor` public to avoid class loader access issues when loading recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/log/LogVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/log/LogVisitor.java
@@ -25,7 +25,7 @@ import org.openrewrite.java.tree.TypeUtils;
 import static java.util.Comparator.comparing;
 
 @EqualsAndHashCode(callSuper = false)
-class LogVisitor extends JavaIsoVisitor<ExecutionContext> {
+public class LogVisitor extends JavaIsoVisitor<ExecutionContext> {
 
     private final String logType;
     private final String factoryType;


### PR DESCRIPTION
## What's changed?
Made `org.openrewrite.java.migrate.lombok.log.LogVisitor` public

## What's your motivation?
Workaround the following when loading `rewrite-devcenter` recipes:
```
class org.openrewrite.java.migrate.lombok.log.UseLog$1 cannot access its superclass org.openrewrite.java.migrate.lombok.log.LogVisitor (org.openrewrite.java.migrate.lombok.log.UseLog$1 is in unnamed module of loader io.moderne.recipe.RecipeClassLoader @71f96dfb; org.openrewrite.java.migrate.lombok.log.LogVisitor is in unnamed module of loader 'app')
```

## Anything in particular you'd like reviewers to focus on?
Alternative solutions

## Anyone you would like to review specifically?
@pstreef 

## Have you considered any alternatives or workarounds?
No

## Any additional context

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
