### PR TITLE
Update other websocket apis for javax to jakarta

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -112,6 +112,14 @@ recipeList:
       artifactId: jakarta.websocket-api
       newVersion: 2.1.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.websocket
+      artifactId: jakarta.websocket-client-api
+      newVersion: 2.1.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.websocket
+      artifactId: jakarta.websocket-all
+      newVersion: 2.1.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.jms
       artifactId: jakarta.jms-api
       newVersion: 3.1.x
@@ -460,10 +468,10 @@ recipeList:
       oldFullyQualifiedTypeName: org.apache.commons.mail.EmailException
       newFullyQualifiedTypeName: org.apache.commons.mail2.core.EmailException
   - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.commons.mail.EmailConstants 
+      oldFullyQualifiedTypeName: org.apache.commons.mail.EmailConstants
       newFullyQualifiedTypeName: org.apache.commons.mail2.core.EmailConstants
   - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.commons.mail.EmailUtils 
+      oldFullyQualifiedTypeName: org.apache.commons.mail.EmailUtils
       newFullyQualifiedTypeName: org.apache.commons.mail2.core.EmailUtils
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.commons.mail

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -640,6 +640,26 @@ recipeList:
       groupId: jakarta.websocket
       artifactId: jakarta.websocket-api
       newVersion: 2.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.websocket
+      oldArtifactId: javax.websocket-client-api
+      newGroupId: jakarta.websocket
+      newArtifactId: jakarta.websocket-client-api
+      newVersion: 2.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.websocket
+      artifactId: jakarta.websocket-client-api
+      newVersion: 2.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.websocket
+      oldArtifactId: javax.websocket-all
+      newGroupId: jakarta.websocket
+      newArtifactId: jakarta.websocket-all
+      newVersion: 2.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.websocket
+      artifactId: jakarta.websocket-all
+      newVersion: 2.0.x
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.websocket
       newPackageName: jakarta.websocket


### PR DESCRIPTION
## What's changed?
Update the other websocket APIs in EE9 and EE10 migration.
Originally only updated `websocket-api`, now including `websocket-client-api` and `websocket-all`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
