### PR TITLE
Fix Java to Jakarta XJC binding migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -723,8 +723,8 @@ tags:
   - jakarta
 preconditions:
   # IBM-specific exclusion
-  - org.openrewrite.FindSourceFiles:
-      filePattern: "!(ibm-*)"
+  - org.openrewrite.xml.search.DoesNotUseNamespaceUri:
+      namespaceUri: http://websphere.ibm.com/xml/ns/javaee
 recipeList:
   # Update namespace first
   - org.openrewrite.xml.ChangeTagAttribute:

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -721,6 +721,9 @@ tags:
   - jaxb
   - javax
   - jakarta
+preconditions:
+  - org.openrewrite.FindSourceFiles:
+      filePattern: "!(ibm-*)"
 recipeList:
   # Update namespace first
   - org.openrewrite.xml.ChangeTagAttribute:

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -722,6 +722,7 @@ tags:
   - javax
   - jakarta
 preconditions:
+  # IBM-specific exclusion
   - org.openrewrite.FindSourceFiles:
       filePattern: "!(ibm-*)"
 recipeList:

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -722,18 +722,20 @@ tags:
   - javax
   - jakarta
 recipeList:
-  - org.openrewrite.xml.ChangeTagAttribute:
-      #language=xpath
-      elementName: "//*[namespace-uri() = 'http://java.sun.com/xml/ns/jaxb' and local-name() = 'bindings']"
-      attributeName: version
-      oldValue: 1.0
-      newValue: 3.0
+  # Update namespace first
   - org.openrewrite.xml.ChangeTagAttribute:
       #language=xpath
       elementName: "//*[namespace-uri() = 'http://java.sun.com/xml/ns/jaxb' and local-name() = 'bindings']"
       attributeName: xmlns:jxb
       oldValue: http://java.sun.com/xml/ns/jaxb
       newValue: https://jakarta.ee/xml/ns/jaxb
+  # Update version
+  - org.openrewrite.xml.ChangeTagAttribute:
+      #language=xpath
+      elementName: "//*[namespace-uri() = 'https://jakarta.ee/xml/ns/jaxb' and local-name() = 'bindings']"
+      attributeName: version
+      oldValue: 1.0
+      newValue: 3.0
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxXmlSoapToJakartaXmlSoap

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
@@ -17,6 +17,8 @@ package org.openrewrite.java.migrate.jakarta;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -34,54 +36,79 @@ class UpdateXJCBindingsToJakartaEE implements RewriteTest {
           xml(
             //language=xml
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <jxb:bindings version="3.0"
-                          xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
-                          xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            </jxb:bindings>
-            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <jxb:bindings version="3.0"
+                            xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+              </jxb:bindings>
+              """
           )
         );
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/741")
     void noMigrateIBMFiles() {
         rewriteRun(
           //language=xml
           xml(
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <jxb:bindings version="1.0"
-                          xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-                          xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            </jxb:bindings>
-            """,
-            spec -> spec.path("ibm-web-ext.xml")
+              <?xml version="1.0" encoding="UTF-8"?>
+              <jxb:bindings version="1.0"
+                            xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+                            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                            xmlns:ibm="http://websphere.ibm.com/xml/ns/javaee">
+              </jxb:bindings>
+              """
           )
         );
     }
 
     @Nested
     class Migrate {
+
+        @Test
+        @DocumentExample
+        void both() {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="1.0"
+                                xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """,
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="3.0"
+                                xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """
+              )
+            );
+        }
         @Test
         void version() {
             rewriteRun(
               //language=xml
               xml(
                 """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <jxb:bindings version="1.0"
-                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
-                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                </jxb:bindings>
-                """,
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="1.0"
+                                xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """,
                 """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <jxb:bindings version="3.0"
-                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
-                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                </jxb:bindings>
-                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="3.0"
+                                xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """
               )
             );
         }
@@ -92,42 +119,19 @@ class UpdateXJCBindingsToJakartaEE implements RewriteTest {
               //language=xml
               xml(
                 """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <jxb:bindings version="3.0"
-                              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                </jxb:bindings>
-                """,
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="3.0"
+                                xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """,
                 """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <jxb:bindings version="3.0"
-                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
-                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                </jxb:bindings>
-                """
-              )
-            );
-        }
-
-        @Test
-        void both() {
-            rewriteRun(
-              //language=xml
-              xml(
-                """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <jxb:bindings version="1.0"
-                              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                </jxb:bindings>
-                """,
-                """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <jxb:bindings version="3.0"
-                              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
-                              xmlns:xs="http://www.w3.org/2001/XMLSchema">
-                </jxb:bindings>
-                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="3.0"
+                                xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """
               )
             );
         }

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
@@ -44,6 +44,23 @@ class UpdateXJCBindingsToJakartaEE implements RewriteTest {
         );
     }
 
+    @Test
+    void noMigrateIBMFiles() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <jxb:bindings version="1.0"
+                          xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+                          xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            </jxb:bindings>
+            """,
+            spec -> spec.path("ibm-web-ext.xml")
+          )
+        );
+    }
+
     @Nested
     class Migrate {
         @Test

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
@@ -64,7 +64,6 @@ class UpdateXJCBindingsToJakartaEE implements RewriteTest {
 
     @Nested
     class Migrate {
-        @Disabled // temporarily disabling this to make the project build as we need a release.
         @Test
         void version() {
             rewriteRun(

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.migrate.jakarta;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
- Fix XJC binding namespace/version in EE9 migration.
- Fixes failing test and also makes sure both namespace and version upgrade properly all the time.
- Exclude IBM files from these changes.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fix failing build

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
