### PR TITLE
Create Faces 3.0 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -333,29 +333,6 @@ recipeList:
       recursive: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JavaxFacesToJakartaFaces
-displayName: Migrate deprecated `javax.faces` packages to `jakarta.faces`
-description: Java EE has been rebranded to Jakarta EE, necessitating a package relocation.
-recipeList:
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: javax.faces
-      oldArtifactId: javax.faces-api
-      newGroupId: jakarta.faces
-      newArtifactId: jakarta.faces-api
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: jakarta.faces
-      artifactId: jakarta.faces-api
-      newVersion: 3.0.x
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.faces
-      newPackageName: jakarta.faces
-      recursive: true
-  - org.openrewrite.java.ChangePackageInStringLiteral:
-      oldPackageName: javax.faces
-      newPackageName: jakarta.faces
----
-type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxInjectMigrationToJakartaInject
 displayName: Migrate deprecated `javax.inject` packages to `jakarta.inject`
 description: Java EE has been rebranded to Jakarta EE, necessitating a package relocation.

--- a/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
@@ -1,0 +1,540 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JavaxFacesToJakartaFaces
+displayName: JSF 2.x to Jakarta Faces 3.x
+description: Jakarta EE 9 uses Faces 3.0 a major upgrade to Jakarta packages and XML namespaces.
+tags:
+  - jakarta
+  - faces
+  - jsf
+# NOTE: The spec versions in this section come from https://jakarta.ee/xml/ns/jakartaee/#9
+recipeList:
+  - org.openrewrite.java.migrate.jakarta.UpdateJakartaFacesApi3
+  - org.openrewrite.java.migrate.jakarta.JakartaFacesXhtml
+  - org.openrewrite.java.migrate.jakarta.JakartaFacesEcmaScript
+  - org.openrewrite.java.migrate.jakarta.JavaxFacesConfigXmlToJakartaFacesConfigXml
+  - org.openrewrite.java.migrate.jakarta.JavaxFacesTagLibraryXmlToJakartaFacesTagLibraryXml
+  - org.openrewrite.java.migrate.jakarta.JavaxWebFragmentXmlToJakartaWebFragmentXml
+  - org.openrewrite.java.migrate.jakarta.JavaxWebXmlToJakartaWebXml
+  - org.openrewrite.java.migrate.jakarta.FacesJNDINamesChanged
+  - org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesExpressionLanguageClasses
+  - org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesResourceResolver
+  - org.openrewrite.java.migrate.jakarta.RemovedStateManagerMethods
+  - org.openrewrite.java.migrate.jakarta.RemovedUIComponentConstant
+  - org.openrewrite.java.migrate.jakarta.FacesManagedBeansDeprecated
+  - org.openrewrite.java.migrate.jakarta.UpgradeFacesOpenSourceLibraries
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.UpdateJakartaFacesApi3
+displayName: Migrate deprecated `javax.faces` packages to `jakarta.faces`
+description: Java EE has been rebranded to Jakarta EE, necessitating a package relocation and upgrade.
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.faces
+      oldArtifactId: javax.faces-api
+      newGroupId: jakarta.faces
+      newArtifactId: jakarta.faces-api
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.faces
+      artifactId: jakarta.faces-api
+      newVersion: 3.0.x
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: javax.faces
+      newPackageName: jakarta.faces
+      recursive: true
+  - org.openrewrite.java.ChangePackageInStringLiteral:
+      oldPackageName: javax.faces
+      newPackageName: jakarta.faces
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JakartaFacesXhtml
+displayName: Faces XHTML migration for Jakarta EE 9
+description: Find and replace legacy JSF namespaces and javax references with Jakarta Faces values in XHTML files.
+tags:
+  - jakarta
+  - faces
+  - jsf
+recipeList:
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsf/html"
+      replace: "jakarta.faces.html"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsf/html"
+      replace: "jakarta.faces.html"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsf/facelets"
+      replace: "jakarta.faces.facelets"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsf/facelets"
+      replace: "jakarta.faces.facelets"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsf/core"
+      replace: "jakarta.faces.core"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsf/core"
+      replace: "jakarta.faces.core"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsp/jstl/core"
+      replace: "jakarta.tags.core"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsp/jstl/core"
+      replace: "jakarta.tags.core"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsf/composite"
+      replace: "jakarta.faces.composite"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsf/composite"
+      replace: "jakarta.faces.composite"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsf/passthrough"
+      replace: "jakarta.faces.passthrough"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsf/passthrough"
+      replace: "jakarta.faces.passthrough"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsp/jstl/functions"
+      replace: "jakarta.tags.functions"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsp/jstl/functions"
+      replace: "jakarta.tags.functions"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://java.sun.com/jsf"
+      replace: "jakarta.faces"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://xmlns.jcp.org/jsf"
+      replace: "jakarta.faces"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://primefaces.org/ui/extensions"
+      replace: "primefaces.extensions"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "http://primefaces.org/ui"
+      replace: "primefaces"
+      filePattern: '**/*.xhtml'
+  - org.openrewrite.text.FindAndReplace:
+      find: javax.
+      replace: jakarta.
+      filePattern: '**/*.xhtml'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JavaxFacesConfigXmlToJakartaFacesConfigXml
+displayName: Migrate xmlns entries in `faces-config.xml` files
+description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+tags:
+  - jakarta
+  - faces
+  - jsf
+recipeList:
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: version
+      elementName: faces-config
+      newValue: 3.0
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xmlns
+      elementName: faces-config
+      newValue: https://jakarta.ee/xml/ns/jakartaee
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xsi:schemaLocation
+      elementName: faces-config
+      newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd
+  - org.openrewrite.text.FindAndReplace:
+      find: "javax."
+      replace: "jakarta."
+      filePattern: '**/faces-config.xml'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JavaxFacesTagLibraryXmlToJakartaFacesTagLibraryXml
+displayName: Migrate xmlns entries in `taglib.xml` files
+description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+tags:
+  - jakarta
+  - faces
+  - jsf
+recipeList:
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: version
+      elementName: facelet-taglib
+      newValue: 3.0
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xmlns
+      elementName: facelet-taglib
+      newValue: https://jakarta.ee/xml/ns/jakartaee
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xsi:schemaLocation
+      elementName: facelet-taglib
+      newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_3_0.xsd
+  - org.openrewrite.text.FindAndReplace:
+      find: javax.
+      replace: jakarta.
+      filePattern: '**/*taglib*.xml'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JavaxWebFragmentXmlToJakartaWebFragmentXml
+displayName: Migrate xmlns entries in `web-fragment.xml` files
+description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+tags:
+  - jakarta
+  - faces
+  - jsf
+recipeList:
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: version
+      elementName: web-fragment
+      newValue: 5.0
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xmlns
+      elementName: web-fragment
+      newValue: https://jakarta.ee/xml/ns/jakartaee
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xsi:schemaLocation
+      elementName: web-fragment
+      newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_5_0.xsd
+  - org.openrewrite.text.FindAndReplace:
+      find: "javax."
+      replace: "jakarta."
+      filePattern: '**/web-fragment.xml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "jakarta.sql."
+      replace: "javax.sql."
+      filePattern: '**/web-fragment.xml'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JavaxWebXmlToJakartaWebXml
+displayName: Migrate xmlns entries in `web.xml` files
+description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+tags:
+  - jakarta
+  - faces
+  - jsf
+recipeList:
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: version
+      elementName: web-app
+      newValue: 5.0
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xmlns
+      elementName: web-app
+      newValue: https://jakarta.ee/xml/ns/jakartaee
+  - org.openrewrite.xml.ChangeTagAttribute:
+      attributeName: xsi:schemaLocation
+      elementName: web-app
+      newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd
+  - org.openrewrite.text.FindAndReplace:
+      find: "javax."
+      replace: "jakarta."
+      filePattern: '**/web.xml'
+  - org.openrewrite.text.FindAndReplace:
+      find: "jakarta.sql."
+      replace: "javax.sql."
+      filePattern: '**/web.xml'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.JakartaFacesEcmaScript
+displayName: Migrate JSF values inside EcmaScript files
+description: Convert JSF to Faces values inside JavaScript,TypeScript, and Properties files.
+tags:
+  - jakarta
+  - faces
+  - jsf
+recipeList:
+  - org.openrewrite.text.FindAndReplace:
+      find: javax.
+      replace: jakarta.
+      filePattern: '**/*.js;**/*.ts;**/*.properties'
+  - org.openrewrite.text.FindAndReplace:
+      find: window.jsf
+      replace: window.faces
+      filePattern: '**/*.js;**/*.ts'
+  - org.openrewrite.text.FindAndReplace:
+      find: jsf.ajax
+      replace: faces.ajax
+      filePattern: '**/*.js;**/*.ts'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.FacesJNDINamesChanged
+displayName: >-
+  JNDI name `jsf/ClientSideSecretKey` has been renamed to `faces/ClientSideSecretKey`,
+  and the `jsf/FlashSecretKey` JNDI name has been renamed to `faces/FlashSecretKey`
+description: >-
+  The `jsf/ClientSideSecretKey` JNDI name has been renamed to `faces/ClientSideSecretKey`,
+  and the `jsf/FlashSecretKey` JNDI name has been renamed to `faces/FlashSecretKey`.
+  The JNDI keys that have been renamed are updated to allow use of the keys.
+recipeList:
+  - org.openrewrite.xml.ChangeTagValue:
+      elementName: //env-entry-name
+      oldValue: jsf/ClientSideSecretKey
+      newValue: faces/ClientSideSecretKey
+  - org.openrewrite.xml.ChangeTagValue:
+      elementName: //env-entry-name
+      oldValue: jsf/FlashSecretKey
+      newValue: faces/FlashSecretKey
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesResourceResolver
+displayName: Replace `ResourceResolver` with `ResourceHandler`
+description: >-
+  The `ResourceResolver` class was removed in Jakarta Faces 3.0.
+  The functionality provided by that class can be replaced by using the `jakarta.faces.application.ResourceHandler` class.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.view.facelets.ResourceResolver
+      newFullyQualifiedTypeName: jakarta.faces.application.ResourceHandler
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.view.facelets.ResourceResolver
+      newFullyQualifiedTypeName: jakarta.faces.application.ResourceHandler
+      ignoreDefinition: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.RemovedUIComponentConstant
+displayName: Replace `CURRENT_COMPONENT` and `CURRENT_COMPOSITE_COMPONENT` with `getCurrentComponent()` and `getCurrentCompositeComponent()`
+description: >-
+  Replace `jakarta.faces.component.UIComponent.CURRENT_COMPONENT` and `CURRENT_COMPOSITE_COMPONENT` constants with `jakarta.faces.component.UIComponent.getCurrentComponent()` and `getCurrentCompositeComponent()`.
+  that were added in JSF 2.0.
+recipeList:
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: jakarta.faces.component.UIComponent.CURRENT_COMPONENT
+      fullyQualifiedConstantName: jakarta.faces.component.UIComponent.getCurrentComponent()
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: jakarta.faces.component.UIComponent.CURRENT_COMPOSITE_COMPONENT
+      fullyQualifiedConstantName: jakarta.faces.component.UIComponent.getCurrentCompositeComponent()
+---
+# TODO: check if this migration is EE9 or EE10
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.RemovedStateManagerMethods
+displayName: Use `StateManagementStrategy`
+description: >-
+  Methods that were removed from the `jakarta.faces.application.StateManager` and `javax.faces.application.StateManager` classes in Jakarta Faces 4.0 are replaced
+  by `jakarta.faces.view.StateManagementStrategy` or `javax.faces.view.StateManagementStrategy` based on Jakarta10 migration in Faces 4.0.
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "*.faces.application.StateManager getComponentStateToSave(*.faces.context.FacesContext)"
+      newMethodName: saveView
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "*.faces.application.StateManager getTreeStructureToSave(*.faces.context.FacesContext)"
+      newMethodName: saveView
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "*.faces.application.StateManager restoreComponentState(*.faces.context.FacesContext,*.faces.component.UIViewRoot,String)"
+      newMethodName: restoreView
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "*.faces.application.StateManager restoreTreeStructure(*.faces.context.FacesContext,String,String)"
+      newMethodName: restoreView
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "*.faces.application.StateManager saveSerializedView(*.faces.context.FacesContext)"
+      newMethodName: saveView
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.application.StateManager
+      newFullyQualifiedTypeName: jakarta.faces.view.StateManagementStrategy
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.application.StateManager
+      newFullyQualifiedTypeName: jakarta.faces.view.StateManagementStrategy
+      ignoreDefinition: true
+---
+# TODO: optimize recipe, prob previous recipe messed it up
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesExpressionLanguageClasses
+displayName: Use `jakarta.el` instead of `jakarta.faces.el` and `javax.faces.el`
+description: >-
+  Several classes were removed and replaced in Jakarta Faces 3.0.
+  The only Object definition not removed in the `jakarta.faces.el` package is the CompositeComponentExpressionHolder interface.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.MethodBinding
+      newFullyQualifiedTypeName: jakarta.el.MethodExpression
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.PropertyResolver
+      newFullyQualifiedTypeName: jakarta.el.ELResolver
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.ValueBinding
+      newFullyQualifiedTypeName: jakarta.el.ValueExpression
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.VariableResolver
+      newFullyQualifiedTypeName: jakarta.el.ELResolver
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.EvaluationException
+      newFullyQualifiedTypeName: jakarta.el.ELException
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.MethodNotFoundException
+      newFullyQualifiedTypeName: jakarta.el.MethodNotFoundException
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.PropertyNotFoundException
+      newFullyQualifiedTypeName: jakarta.el.PropertyNotFoundException
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.el.ReferenceSyntaxException
+      newFullyQualifiedTypeName: jakarta.el.ELException
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.MethodBinding
+      newFullyQualifiedTypeName: jakarta.el.MethodExpression
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.PropertyResolver
+      newFullyQualifiedTypeName: jakarta.el.ELResolver
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.ValueBinding
+      newFullyQualifiedTypeName: jakarta.el.ValueExpression
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.VariableResolver
+      newFullyQualifiedTypeName: jakarta.el.ELResolver
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.EvaluationException
+      newFullyQualifiedTypeName: jakarta.el.ELException
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.MethodNotFoundException
+      newFullyQualifiedTypeName: jakarta.el.MethodNotFoundException
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.PropertyNotFoundException
+      newFullyQualifiedTypeName: jakarta.el.PropertyNotFoundException
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.el.ReferenceSyntaxException
+      newFullyQualifiedTypeName: jakarta.el.ELException
+      ignoreDefinition: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.FacesManagedBeansDeprecated
+displayName: Substitute deprecated Faces Managed Beans
+description: >-
+  This recipe substitutes Faces Managed Beans, which were deprecated in JavaServer Faces 3.0.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.bean.ApplicationScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.ApplicationScoped
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.bean.ApplicationScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.ApplicationScoped
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.bean.ManagedProperty
+      newFullyQualifiedTypeName: jakarta.faces.annotation.ManagedProperty
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.bean.ManagedProperty
+      newFullyQualifiedTypeName: jakarta.faces.annotation.ManagedProperty
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.bean.NoneScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.Dependent
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.bean.NoneScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.Dependent
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.bean.RequestScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.RequestScoped
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.bean.RequestScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.RequestScoped
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.bean.SessionScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.SessionScoped
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.bean.SessionScoped
+      newFullyQualifiedTypeName: jakarta.enterprise.context.SessionScoped
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.faces.bean.ViewScoped
+      newFullyQualifiedTypeName: jakarta.faces.view.ViewScoped
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: jakarta.faces.bean.ViewScoped
+      newFullyQualifiedTypeName: jakarta.faces.view.ViewScoped
+      ignoreDefinition: true
+---
+# TODO: should this upgrade to earliest or latest compatible version for EE9?
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.jakarta.UpgradeFacesOpenSourceLibraries
+displayName: Upgrade Faces open source libraries
+description: Upgrade PrimeFaces, OmniFaces, and MyFaces libraries to Jakarta EE9 versions.
+tags:
+  - jakarta
+  - faces
+  - jsf
+  - myfaces
+  - omnifaces
+  - primefaces
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyClassifier:
+      groupId: org.primefaces
+      artifactId: primefaces
+      newClassifier: jakarta
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.primefaces
+      artifactId: primefaces
+      newVersion: 14.0.x
+  - org.openrewrite.maven.ChangeDependencyClassifier:
+      groupId: org.primefaces.extensions
+      artifactId: primefaces-extensions
+      newClassifier: jakarta
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.primefaces.extensions
+      artifactId: primefaces-extensions
+      newVersion: 14.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.omnifaces
+      artifactId: omnifaces
+      newVersion: 4.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.apache.myfaces.core
+      artifactId: myfaces-api
+      newVersion: 4.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.apache.myfaces.core
+      artifactId: myfaces-impl
+      newVersion: 4.0.x

--- a/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
@@ -17,25 +17,20 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.Faces2xMigrationToJakarta4x
-displayName: JSF 2.x to Jakarta Faces 4.x
-description: Jakarta EE 10 uses Faces 4.0 a major upgrade to Jakarta packages and XML namespaces.
+displayName: Upgrade to Jakarta Faces 4.x
+description: Jakarta EE 10 uses Faces 4.0.
 tags:
   - jakarta
   - faces
   - jsf
+# NOTE: The spec versions in this section come from https://jakarta.ee/xml/ns/jakartaee/#10
 recipeList:
   - org.openrewrite.java.migrate.jakarta.UpdateJakartaFacesApi4
-  - org.openrewrite.java.migrate.jakarta.JakartaFacesXhtml
-  - org.openrewrite.java.migrate.jakarta.JakartaFacesEcmaScript
-  - org.openrewrite.java.migrate.jakarta.JavaxFacesConfigXmlToJakartaFacesConfigXml
-  - org.openrewrite.java.migrate.jakarta.JavaxFacesTagLibraryXmlToJakartaFacesTagLibraryXml
-  - org.openrewrite.java.migrate.jakarta.JavaxWebFragmentXmlToJakartaWebFragmentXml
-  - org.openrewrite.java.migrate.jakarta.JavaxWebXmlToJakartaWebXml
-  - org.openrewrite.java.migrate.jakarta.FacesJNDINamesChanged
-  - org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesExpressionLanguageClasses
-  - org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesResourceResolver
+  - org.openrewrite.java.migrate.jakarta.JakartaFacesConfigXml4
+  - org.openrewrite.java.migrate.jakarta.JakartaFacesTagLibraryXml4
+  - org.openrewrite.java.migrate.jakarta.JakartaWebFragmentXml6
+  - org.openrewrite.java.migrate.jakarta.JakartaWebXml6
   - org.openrewrite.java.migrate.jakarta.RemovedStateManagerMethods
-  - org.openrewrite.java.migrate.jakarta.RemovedUIComponentConstant
   - org.openrewrite.java.migrate.jakarta.FacesManagedBeansRemoved
   - org.openrewrite.java.migrate.jakarta.UpgradeFacesOpenSourceLibraries
 ---
@@ -50,95 +45,9 @@ recipeList:
       newVersion: 4.0.x
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JakartaFacesXhtml
-displayName: Faces XHTML migration for Jakarta EE 10
-description: Find and replace legacy JSF namespaces and javax references with Jakarta Faces values in XHTML files.
-tags:
-  - jakarta
-  - faces
-  - jsf
-recipeList:
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsf/html"
-      replace: "jakarta.faces.html"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsf/html"
-      replace: "jakarta.faces.html"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsf/facelets"
-      replace: "jakarta.faces.facelets"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsf/facelets"
-      replace: "jakarta.faces.facelets"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsf/core"
-      replace: "jakarta.faces.core"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsf/core"
-      replace: "jakarta.faces.core"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsp/jstl/core"
-      replace: "jakarta.tags.core"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsp/jstl/core"
-      replace: "jakarta.tags.core"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsf/composite"
-      replace: "jakarta.faces.composite"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsf/composite"
-      replace: "jakarta.faces.composite"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsf/passthrough"
-      replace: "jakarta.faces.passthrough"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsf/passthrough"
-      replace: "jakarta.faces.passthrough"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsp/jstl/functions"
-      replace: "jakarta.tags.functions"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsp/jstl/functions"
-      replace: "jakarta.tags.functions"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://java.sun.com/jsf"
-      replace: "jakarta.faces"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://xmlns.jcp.org/jsf"
-      replace: "jakarta.faces"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://primefaces.org/ui/extensions"
-      replace: "primefaces.extensions"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://primefaces.org/ui"
-      replace: "primefaces"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: javax.
-      replace: jakarta.
-      filePattern: '**/*.xhtml'
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JavaxFacesConfigXmlToJakartaFacesConfigXml
+name: org.openrewrite.java.migrate.jakarta.JakartaFacesConfigXml4
 displayName: Migrate xmlns entries in `faces-config.xml` files
-description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+description: Jakarta EE 10 uses Faces version 4.
 tags:
   - jakarta
   - faces
@@ -148,23 +57,15 @@ recipeList:
       attributeName: version
       elementName: faces-config
       newValue: 4.0
-  - org.openrewrite.xml.ChangeTagAttribute:
-      attributeName: xmlns
-      elementName: faces-config
-      newValue: https://jakarta.ee/xml/ns/jakartaee
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xsi:schemaLocation
       elementName: faces-config
       newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd
-  - org.openrewrite.text.FindAndReplace:
-      find: "javax."
-      replace: "jakarta."
-      filePattern: '**/faces-config.xml'
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JavaxFacesTagLibraryXmlToJakartaFacesTagLibraryXml
+name: org.openrewrite.java.migrate.jakarta.JakartaFacesTagLibraryXml4
 displayName: Migrate xmlns entries in `taglib.xml` files
-description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+description: Faces 4 uses facelet-taglib 4.0.
 tags:
   - jakarta
   - faces
@@ -175,22 +76,14 @@ recipeList:
       elementName: facelet-taglib
       newValue: 4.0
   - org.openrewrite.xml.ChangeTagAttribute:
-      attributeName: xmlns
-      elementName: facelet-taglib
-      newValue: https://jakarta.ee/xml/ns/jakartaee
-  - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xsi:schemaLocation
       elementName: facelet-taglib
       newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd
-  - org.openrewrite.text.FindAndReplace:
-      find: javax.
-      replace: jakarta.
-      filePattern: '**/*taglib*.xml'
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JavaxWebFragmentXmlToJakartaWebFragmentXml
+name: org.openrewrite.java.migrate.jakarta.JakartaWebFragmentXml6
 displayName: Migrate xmlns entries in `web-fragment.xml` files
-description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+description: Faces 4 uses web-fragment 6.0.
 tags:
   - jakarta
   - faces
@@ -199,28 +92,16 @@ recipeList:
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: version
       elementName: web-fragment
-      newValue: 5.0
-  - org.openrewrite.xml.ChangeTagAttribute:
-      attributeName: xmlns
-      elementName: web-fragment
-      newValue: https://jakarta.ee/xml/ns/jakartaee
+      newValue: 6.0
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xsi:schemaLocation
       elementName: web-fragment
-      newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_5_0.xsd
-  - org.openrewrite.text.FindAndReplace:
-      find: "javax."
-      replace: "jakarta."
-      filePattern: '**/web-fragment.xml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "jakarta.sql."
-      replace: "javax.sql."
-      filePattern: '**/web-fragment.xml'
+      newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_0.xsd
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JavaxWebXmlToJakartaWebXml
+name: org.openrewrite.java.migrate.jakarta.JakartaWebXml6
 displayName: Migrate xmlns entries in `web.xml` files
-description: Java EE has been rebranded to Jakarta EE, necessitating an XML namespace relocation.
+description: Faces 4 uses web-app 6.0.
 tags:
   - jakarta
   - faces
@@ -231,93 +112,11 @@ recipeList:
       elementName: web-app
       newValue: 6.0
   - org.openrewrite.xml.ChangeTagAttribute:
-      attributeName: xmlns
-      elementName: web-app
-      newValue: https://jakarta.ee/xml/ns/jakartaee
-  - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xsi:schemaLocation
       elementName: web-app
       newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd
-  - org.openrewrite.text.FindAndReplace:
-      find: "javax."
-      replace: "jakarta."
-      filePattern: '**/web.xml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "jakarta.sql."
-      replace: "javax.sql."
-      filePattern: '**/web.xml'
 ---
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.JakartaFacesEcmaScript
-displayName: Migrate JSF values inside EcmaScript files
-description: Convert JSF to Faces values inside JavaScript,TypeScript, and Properties files.
-tags:
-  - jakarta
-  - faces
-  - jsf
-recipeList:
-  - org.openrewrite.text.FindAndReplace:
-      find: javax.
-      replace: jakarta.
-      filePattern: '**/*.js;**/*.ts;**/*.properties'
-  - org.openrewrite.text.FindAndReplace:
-      find: window.jsf
-      replace: window.faces
-      filePattern: '**/*.js;**/*.ts'
-  - org.openrewrite.text.FindAndReplace:
-      find: jsf.ajax
-      replace: faces.ajax
-      filePattern: '**/*.js;**/*.ts'
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.FacesJNDINamesChanged
-displayName: >-
-  JNDI name `jsf/ClientSideSecretKey` has been renamed to `faces/ClientSideSecretKey`,
-  and the `jsf/FlashSecretKey` JNDI name has been renamed to `faces/FlashSecretKey`
-description: >-
-  The `jsf/ClientSideSecretKey` JNDI name has been renamed to `faces/ClientSideSecretKey`,
-  and the `jsf/FlashSecretKey` JNDI name has been renamed to `faces/FlashSecretKey`.
-  The JNDI keys that have been renamed are updated to allow use of the keys.
-recipeList:
-  - org.openrewrite.xml.ChangeTagValue:
-      elementName: //env-entry-name
-      oldValue: jsf/ClientSideSecretKey
-      newValue: faces/ClientSideSecretKey
-  - org.openrewrite.xml.ChangeTagValue:
-      elementName: //env-entry-name
-      oldValue: jsf/FlashSecretKey
-      newValue: faces/FlashSecretKey
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesResourceResolver
-displayName: Replace `ResourceResolver` with `ResourceHandler`
-description: >-
-  The `ResourceResolver` class was removed in Jakarta Faces 4.0.
-  The functionality provided by that class can be replaced by using the `jakarta.faces.application.ResourceHandler` class.
-recipeList:
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.view.facelets.ResourceResolver
-      newFullyQualifiedTypeName: jakarta.faces.application.ResourceHandler
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.view.facelets.ResourceResolver
-      newFullyQualifiedTypeName: jakarta.faces.application.ResourceHandler
-      ignoreDefinition: true
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.RemovedUIComponentConstant
-displayName: Replace `CURRENT_COMPONENT` and `CURRENT_COMPOSITE_COMPONENT` with `getCurrentComponent()` and `getCurrentCompositeComponent()`
-description: >-
-  Replace `jakarta.faces.component.UIComponent.CURRENT_COMPONENT` and `CURRENT_COMPOSITE_COMPONENT` constants with `jakarta.faces.component.UIComponent.getCurrentComponent()` and `getCurrentCompositeComponent()`.
-  that were added in JSF 2.0.
-recipeList:
-  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
-      existingFullyQualifiedConstantName: jakarta.faces.component.UIComponent.CURRENT_COMPONENT
-      fullyQualifiedConstantName: jakarta.faces.component.UIComponent.getCurrentComponent()
-  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
-      existingFullyQualifiedConstantName: jakarta.faces.component.UIComponent.CURRENT_COMPOSITE_COMPONENT
-      fullyQualifiedConstantName: jakarta.faces.component.UIComponent.getCurrentCompositeComponent()
----
+# TODO: check if this migration is EE9 or EE10
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.RemovedStateManagerMethods
 displayName: Use `StateManagementStrategy`
@@ -355,82 +154,10 @@ recipeList:
       ignoreDefinition: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.jakarta.RemovedJakartaFacesExpressionLanguageClasses
-displayName: Use `jakarta.el` instead of `jakarta.faces.el` and `javax.faces.el`
-description: >-
-  Several classes were removed and replaced in Jakarta Faces 4.0.
-  The only Object definition not removed in the `jakarta.faces.el` package is the CompositeComponentExpressionHolder interface.
-recipeList:
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.MethodBinding
-      newFullyQualifiedTypeName: jakarta.el.MethodExpression
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.PropertyResolver
-      newFullyQualifiedTypeName: jakarta.el.ELResolver
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.ValueBinding
-      newFullyQualifiedTypeName: jakarta.el.ValueExpression
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.VariableResolver
-      newFullyQualifiedTypeName: jakarta.el.ELResolver
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.EvaluationException
-      newFullyQualifiedTypeName: jakarta.el.ELException
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.MethodNotFoundException
-      newFullyQualifiedTypeName: jakarta.el.MethodNotFoundException
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.PropertyNotFoundException
-      newFullyQualifiedTypeName: jakarta.el.PropertyNotFoundException
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: jakarta.faces.el.ReferenceSyntaxException
-      newFullyQualifiedTypeName: jakarta.el.ELException
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.MethodBinding
-      newFullyQualifiedTypeName: jakarta.el.MethodExpression
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.PropertyResolver
-      newFullyQualifiedTypeName: jakarta.el.ELResolver
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.ValueBinding
-      newFullyQualifiedTypeName: jakarta.el.ValueExpression
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.VariableResolver
-      newFullyQualifiedTypeName: jakarta.el.ELResolver
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.EvaluationException
-      newFullyQualifiedTypeName: jakarta.el.ELException
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.MethodNotFoundException
-      newFullyQualifiedTypeName: jakarta.el.MethodNotFoundException
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.PropertyNotFoundException
-      newFullyQualifiedTypeName: jakarta.el.PropertyNotFoundException
-      ignoreDefinition: true
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: javax.faces.el.ReferenceSyntaxException
-      newFullyQualifiedTypeName: jakarta.el.ELException
-      ignoreDefinition: true
----
-type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.FacesManagedBeansRemoved
-displayName: Substitute deprecated Faces Managed Beans
+displayName: Substitute removed Faces Managed Beans
 description: >-
-  This recipe substitutes Faces Managed Beans, which were deprecated in JavaServer Faces 2.3 and have been removed from Jakarta Faces 4.0.
+  This recipe substitutes Faces Managed Beans, which were deprecated in JavaServer Faces 3.0 and have been removed from Jakarta Faces 4.0.
 recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.faces.bean.ApplicationScoped


### PR DESCRIPTION
!! WORK IN PROGRESS
Most of the migrations currently in the Faces 4 migration should actually happen during the EE9 Faces 3 migration.

## What's changed?
Created new Faces 3.0 migration, moved the javax to jakarta changes from Faces 4 (EE10) into here.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
