### PR TITLE
Add JSpecify best practices recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -13,10 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jspecify.JSpecifyBestPractices
+displayName: JSpecify best practices
+description: >-
+  Apply JSpecify best practices, such as migrating off of alternatives, and adding missing `@Nullable` annotations.
+tags:
+  - java
+recipeList:
+- org.openrewrite.java.jspecify.MigrateToJSpecify
+- org.openrewrite.staticanalysis.AnnotateNullableMethods
+- org.openrewrite.staticanalysis.AnnotateNullableParameters
+- org.openrewrite.staticanalysis.NullableOnMethodReturnType
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.jspecify.MigrateToJspecify
+name: org.openrewrite.java.jspecify.MigrateToJSpecify
 displayName: Migrate to JSpecify
 description: >-
   This recipe will migrate to JSpecify annotations from various other nullability annotation standards.
@@ -27,7 +40,7 @@ recipeList:
   - org.openrewrite.java.jspecify.MigrateFromJakartaAnnotationApi
   - org.openrewrite.java.jspecify.MigrateFromJetbrainsAnnotations
   # Running the following recipe on current versions of Spring can cause Spring to misunderstand a nullable field.
-  #   For instance, a custom Prometheus scrape endpoint with @Nullable Set<String> includedNames will fail if 
+  #   For instance, a custom Prometheus scrape endpoint with @Nullable Set<String> includedNames will fail if
   #   includedNames is null and if @Nullable is @org.jspecify.annotations.Nullable.
   # - org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations
 

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
@@ -26,12 +26,12 @@ import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 @SuppressWarnings("NotNullFieldNotInitialized")
-class MigrateToJspecifyTest implements RewriteTest {
+class JSpecifyBestPracticesTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .recipeFromResource("/META-INF/rewrite/jspecify.yml", "org.openrewrite.java.jspecify.MigrateToJspecify")
+          .recipeFromResource("/META-INF/rewrite/jspecify.yml", "org.openrewrite.java.jspecify.JSpecifyBestPractices")
           .parser(JavaParser.fromJavaVersion().classpath("jsr305", "jakarta.annotation-api", "annotations", "spring-core"));
     }
 


### PR DESCRIPTION
## What's your motivation?
Combine together a few JSpecify related recipes from rewrite-static-analysis here.

## Have you considered any alternatives or workarounds?
Considered adding this in rewrite-static-analysis itself, but that lacks a dependency on rewrite-java-dependencies, and the migration recipes were already here.

## Any additional context
- Follows https://github.com/openrewrite/rewrite-static-analysis/pull/578