### PR TITLE
Update RemovedJakartaFacesExpressionLanguageClassesTest.java Issue/Bug-5538. Renamed eLResolver to elResolver & other objects

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/jakarta/RemovedJakartaFacesExpressionLanguageClassesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/RemovedJakartaFacesExpressionLanguageClassesTest.java
@@ -102,24 +102,24 @@ class RemovedJakartaFacesExpressionLanguageClassesTest implements RewriteTest {
             }
             """,
                 """
-            package com.test;
-
-            import jakarta.el.ELException;
-            import jakarta.el.ELResolver;
-            import jakarta.el.MethodNotFoundException;
-            import jakarta.el.PropertyNotFoundException;
-
-            public class Test {
-
-                public void testJakarta_1() {
-                    ELResolver elResolver = null;
-                    ELException elException = null;
-                    MethodNotFoundException methodNotFoundException1 = null;
-                    PropertyNotFoundException propertyNotFoundException1 = null;
-                    ELException elException1 = null;
-                }
-            }
-            """
+                  package com.test;
+                  
+                  import jakarta.el.ELException;
+                  import jakarta.el.ELResolver;
+                  import jakarta.el.MethodNotFoundException;
+                  import jakarta.el.PropertyNotFoundException;
+                  
+                  public class Test {
+                  
+                      public void testJakarta_1() {
+                          ELResolver elResolver = null;
+                          ELException elException = null;
+                          MethodNotFoundException methodNotFoundException1 = null;
+                          PropertyNotFoundException propertyNotFoundException1 = null;
+                          ELException elException1 = null;
+                      }
+                  }
+                  """
           ));
     }
 

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/RemovedJakartaFacesExpressionLanguageClassesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/RemovedJakartaFacesExpressionLanguageClassesTest.java
@@ -68,7 +68,7 @@ class RemovedJakartaFacesExpressionLanguageClassesTest implements RewriteTest {
 
                    public void testJakarta() {
                         MethodExpression methodExpression = null;
-                        ELResolver eLResolver = null;
+                        ELResolver elResolver = null;
                         ValueExpression valueExpression = null;
                    }
               }
@@ -112,11 +112,11 @@ class RemovedJakartaFacesExpressionLanguageClassesTest implements RewriteTest {
             public class Test {
 
                 public void testJakarta_1() {
-                    ELResolver eLResolver = null;
-                    ELException eLException = null;
+                    ELResolver elResolver = null;
+                    ELException elException = null;
                     MethodNotFoundException methodNotFoundException1 = null;
                     PropertyNotFoundException propertyNotFoundException1 = null;
-                    ELException eLException1 = null;
+                    ELException elException1 = null;
                 }
             }
             """
@@ -155,7 +155,7 @@ class RemovedJakartaFacesExpressionLanguageClassesTest implements RewriteTest {
 
                    public void testJavax() {
                         MethodExpression methodExpression = null;
-                        ELResolver eLResolver = null;
+                        ELResolver elResolver = null;
                         ValueExpression valueExpression = null;
                    }
               }
@@ -199,11 +199,11 @@ class RemovedJakartaFacesExpressionLanguageClassesTest implements RewriteTest {
             public class Test {
 
                 public void testJavax_1() {
-                    ELResolver eLResolver = null;
-                    ELException eLException = null;
+                    ELResolver elResolver = null;
+                    ELException elException = null;
                     MethodNotFoundException methodNotFoundException1 = null;
                     PropertyNotFoundException propertyNotFoundException1 = null;
-                    ELException eLException1 = null;
+                    ELException elException1 = null;
                 }
             }
             """


### PR DESCRIPTION
Issue/Bug-5538. Renamed eLResolver to elResolver.

## What's changed?
As part of issue 5538, modified eLResolver to elResolver to follow common java object name pattern.

## What's your motivation?
I was looking for my good first first commit in public repo. Not sure if I am following everything correctly. 

## Anything in particular you'd like reviewers to focus on?
I have also modified eLException -> elException and elException1 = elException1

## Anyone you would like to review specifically?
@greg-at-moderne as you opened this issue. @timtebeek @Jenson3210 FYI

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
