### PR TITLE
Pick better SDKMan versions

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java
+++ b/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java
@@ -20,8 +20,10 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.binary.Binary;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.quark.Quark;
 import org.openrewrite.remote.Remote;
+import org.openrewrite.semver.LatestRelease;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextParser;
 
@@ -92,11 +94,18 @@ public class UpdateSdkMan extends Recipe {
                 Matcher matcher = pattern.matcher(plainText.getText());
                 if (matcher.find()) {
                     String ver = newVersion == null ? matcher.group(1) : newVersion;
-                    String dist = newDistribution == null ? matcher.group(2) : newDistribution;
-                    for (String candidate : readSdkmanJavaCandidates()) {
-                        if (candidate.startsWith(ver) && candidate.endsWith(dist)) {
-                            return plainText.withText(matcher.replaceFirst("java=" + candidate));
-                        }
+                    String dist = newDistribution == null ? matcher.group(2) : "-" + newDistribution;
+                    String oldFull = matcher.group(1) + matcher.group(2);
+                    String newBasis = ver + dist;
+                    LatestRelease releaseComparator = new LatestRelease(dist);
+                    Pattern majorPattern = Pattern.compile("^" + ver + "[.-].*");
+                    List<String> filteredCandidates = ListUtils.filter(
+                            readSdkmanJavaCandidates(),
+                            candidate -> majorPattern.matcher(candidate).matches() && (releaseComparator.isValid(oldFull, candidate) || releaseComparator.isValid(newBasis, candidate))
+                    );
+                    String idealCandidate = filteredCandidates.stream().sorted(releaseComparator).reduce((first, second) -> second).orElse(null);
+                    if (idealCandidate != null) {
+                        return plainText.withText(matcher.replaceFirst("java=" + idealCandidate));
                     }
                 }
                 return sourceFile;

--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -33,11 +33,11 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan("17", null)),
           text(
             """
-            java=11.0.25-tem
-            """,
+              java=11.0.25-tem
+              """,
             """
-            java=17.0.14-tem
-            """,
+              java=17.0.14-tem
+              """,
             spec -> spec.path(".sdkmanrc")
           )
         );
@@ -49,11 +49,11 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan("17.0.14", null)),
           text(
             """
-            java=11.1.2-tem
-            """,
+              java=11.1.2-tem
+              """,
             """
-            java=17.0.14-tem
-            """,
+              java=17.0.14-tem
+              """,
             spec -> spec.path(".sdkmanrc")
           )
         );
@@ -65,11 +65,11 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan(null, "amzn")),
           text(
             """
-            java=11.0.26-tem
-            """,
+              java=11.0.26-tem
+              """,
             """
-            java=11.0.26-amzn
-            """,
+              java=11.0.26-amzn
+              """,
             spec -> spec.path(".sdkmanrc")
           )
         );
@@ -81,11 +81,11 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan("17", "graalce")),
           text(
             """
-            java=11.0.25-amzn
-            """,
+              java=11.0.25-amzn
+              """,
             """
-            java=17.0.9-graalce
-            """,
+              java=17.0.9-graalce
+              """,
             spec -> spec.path(".sdkmanrc")
           )
         );
@@ -97,8 +97,8 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan("42", null)),
           text(
             """
-            java=11.1.2-tem
-            """,
+              java=11.1.2-tem
+              """,
             spec -> spec.path(".sdkmanrc")
           )
         );
@@ -110,8 +110,8 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan(null, "notreal")),
           text(
             """
-            java=11.1.2-tem
-            """,
+              java=11.1.2-tem
+              """,
             spec -> spec.path(".sdkmanrc")
           )
         );
@@ -128,8 +128,8 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan("17", "tem")),
           text(
             """
-            java=11.1.2-tem
-            """,
+              java=11.1.2-tem
+              """,
             spec -> spec.path(".not-sdkmanrc")
           )
         );
@@ -141,11 +141,27 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan("17", null)),
           text(
             """
-            java=11.0.25.fx-zulu
-            """,
+              java=11.0.25.fx-zulu
+              """,
             """
-            java=17.0.14.fx-zulu
-            """,
+              java=17.0.14.fx-zulu
+              """,
+            spec -> spec.path(".sdkmanrc")
+          )
+        );
+    }
+
+    @Test
+    void zuluNonCrac() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateSdkMan("17", null)),
+          text(
+            """
+              java=11.0.26-zulu
+              """,
+            """
+              java=17.0.15-zulu
+              """,
             spec -> spec.path(".sdkmanrc")
           )
         );

--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -36,7 +36,7 @@ class UpdateSdkManTest implements RewriteTest {
               java=11.0.25-tem
               """,
             """
-              java=17.0.14-tem
+              java=17.0.15-tem
               """,
             spec -> spec.path(".sdkmanrc")
           )
@@ -144,7 +144,7 @@ class UpdateSdkManTest implements RewriteTest {
               java=11.0.25.fx-zulu
               """,
             """
-              java=17.0.14.fx-zulu
+              java=17.0.15.fx-zulu
               """,
             spec -> spec.path(".sdkmanrc")
           )


### PR DESCRIPTION
## What's your motivation?
Right now we pick an incorrect distribution for Zulu upgrades to Java 17.
There's are the versions that are available:
```
17.0.13.crac-zulu
17.0.14-zulu
17.0.14.crac-zulu
17.0.14.fx-zulu
17.0.15-zulu
17.0.15.crac-zulu
17.0.15.fx-zulu
```

We ought to pick `17.0.15-zulu` as the highest version number, with a matching (non fx/crac) distribution.

In practice, we pick 17.0.13.crac-zulu as the first match here:
https://github.com/openrewrite/rewrite-migrate-java/blob/962b76c47d6115ba48e553189fb78181094fb07c/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java#L96-L98
