### PR TITLE
Make fields annotated with `@Produces` static

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -19,8 +19,6 @@ import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -1,4 +1,18 @@
-package org.openrewrite.java.migrate;
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;
@@ -28,7 +42,7 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
         return Preconditions.check(new UsesType<>("jakarta.enterprise.inject.Produces", false),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
-                    public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
+                    public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
 
                         J.ClassDeclaration visitingClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
                         boolean isSessionBean = visitingClass.getLeadingAnnotations().stream()
@@ -48,7 +62,7 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
                                 return multiVariable.withModifiers(updatedModifiers);
                             }
                         }
-                        return super.visitVariableDeclarations(multiVariable, executionContext);
+                        return super.visitVariableDeclarations(multiVariable, ctx);
                     }
                 });
     }

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -58,7 +58,7 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
                             return false;
                         }
                         return hasAnnotation(j, "@jakarta.ejb.Singleton") ||
-                                hasAnnotation(j, "@jakarta.ejb.Statefull") ||
+                                hasAnnotation(j, "@jakarta.ejb.Stateful") ||
                                 hasAnnotation(j, "@jakarta.ejb.Stateless");
                     }
 

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -50,21 +50,21 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
                     public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                         if (!multiVariable.hasModifier(J.Modifier.Type.Static) &&
                             hasAnnotation(multiVariable, "@jakarta.enterprise.inject.Produces") &&
-                            isSessionBean()) {
+                            isInSessionBean()) {
                             return multiVariable.withModifiers(ListUtils.concat(multiVariable.getModifiers(),
                                     new J.Modifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, null, J.Modifier.Type.Static, Collections.emptyList())));
                         }
                         return super.visitVariableDeclarations(multiVariable, ctx);
                     }
 
-                    private boolean isSessionBean() {
-                        J.ClassDeclaration j = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                        if (j == null) {
+                    private boolean isInSessionBean() {
+                        J.ClassDeclaration parentClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                        if (parentClass == null) {
                             return false;
                         }
-                        return hasAnnotation(j, "@jakarta.ejb.Singleton") ||
-                               hasAnnotation(j, "@jakarta.ejb.Stateful") ||
-                               hasAnnotation(j, "@jakarta.ejb.Stateless");
+                        return hasAnnotation(parentClass, "@jakarta.ejb.Singleton") ||
+                               hasAnnotation(parentClass, "@jakarta.ejb.Stateful") ||
+                               hasAnnotation(parentClass, "@jakarta.ejb.Stateless");
                     }
 
                     private boolean hasAnnotation(J j, String annotationPattern) {

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.openrewrite.java.migrate;
 
 import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -19,6 +19,7 @@ import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -41,9 +41,9 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(Preconditions.and(new UsesType<>("jakarta.enterprise.inject.Produces", false),
                         Preconditions.or(
-                                new UsesType<>("@jakarta.ejb.Singleton", false),
-                                new UsesType<>("@jakarta.ejb.Stateful", false),
-                                new UsesType<>("@jakarta.ejb.Stateless", false)
+                                new UsesType<>("jakarta.ejb.Singleton", false),
+                                new UsesType<>("jakarta.ejb.Stateful", false),
+                                new UsesType<>("jakarta.ejb.Stateless", false)
                         )),
                 new JavaVisitor<ExecutionContext>() {
                     @Override

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -39,13 +39,18 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>("jakarta.enterprise.inject.Produces", false),
+        return Preconditions.check(Preconditions.and(new UsesType<>("jakarta.enterprise.inject.Produces", false),
+                        Preconditions.or(
+                                new UsesType<>("@jakarta.ejb.Singleton", false),
+                                new UsesType<>("@jakarta.ejb.Stateful", false),
+                                new UsesType<>("@jakarta.ejb.Stateless", false)
+                        )),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
                     public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                         if (!multiVariable.hasModifier(J.Modifier.Type.Static) &&
-                                hasAnnotation(multiVariable, "@jakarta.enterprise.inject.Produces") &&
-                                isSessionBean()) {
+                            hasAnnotation(multiVariable, "@jakarta.enterprise.inject.Produces") &&
+                            isSessionBean()) {
                             return multiVariable.withModifiers(ListUtils.concat(multiVariable.getModifiers(),
                                     new J.Modifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, null, J.Modifier.Type.Static, Collections.emptyList())));
                         }
@@ -58,8 +63,8 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
                             return false;
                         }
                         return hasAnnotation(j, "@jakarta.ejb.Singleton") ||
-                                hasAnnotation(j, "@jakarta.ejb.Stateful") ||
-                                hasAnnotation(j, "@jakarta.ejb.Stateless");
+                               hasAnnotation(j, "@jakarta.ejb.Stateful") ||
+                               hasAnnotation(j, "@jakarta.ejb.Stateless");
                     }
 
                     private boolean hasAnnotation(J j, String annotationPattern) {

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -24,35 +24,38 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
-import java.util.Collections;
+import static java.util.Collections.emptyList;
 
 public class AddStaticVariableOnProducerSessionBean extends Recipe {
     @Override
     public String getDisplayName() {
-        return "Adds static variable to @Produces field that are on session bean";
+        return "Adds `static` modifier to `@Produces` field that are on session bean";
     }
 
     @Override
     public String getDescription() {
-        return "Ensures that the fields annotated with @Produces which is inside the session bean (@Stateless, @Stateful, or @Singleton) are declared static.";
+        return "Ensures that the fields annotated with `@Produces` which is inside the session bean (`@Stateless`, `@Stateful`, or `@Singleton`) are declared `static`.";
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.and(new UsesType<>("jakarta.enterprise.inject.Produces", false),
+        return Preconditions.check(
+                Preconditions.and(
+                        new UsesType<>("jakarta.enterprise.inject.Produces", false),
                         Preconditions.or(
                                 new UsesType<>("jakarta.ejb.Singleton", false),
                                 new UsesType<>("jakarta.ejb.Stateful", false),
                                 new UsesType<>("jakarta.ejb.Stateless", false)
-                        )),
+                        )
+                ),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
                     public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                         if (!multiVariable.hasModifier(J.Modifier.Type.Static) &&
-                            hasAnnotation(multiVariable, "@jakarta.enterprise.inject.Produces") &&
-                            isInSessionBean()) {
+                                hasAnnotation(multiVariable, "@jakarta.enterprise.inject.Produces") &&
+                                isInSessionBean()) {
                             return multiVariable.withModifiers(ListUtils.concat(multiVariable.getModifiers(),
-                                    new J.Modifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, null, J.Modifier.Type.Static, Collections.emptyList())));
+                                    new J.Modifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, null, J.Modifier.Type.Static, emptyList())));
                         }
                         return super.visitVariableDeclarations(multiVariable, ctx);
                     }
@@ -63,8 +66,8 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
                             return false;
                         }
                         return hasAnnotation(parentClass, "@jakarta.ejb.Singleton") ||
-                               hasAnnotation(parentClass, "@jakarta.ejb.Stateful") ||
-                               hasAnnotation(parentClass, "@jakarta.ejb.Stateless");
+                                hasAnnotation(parentClass, "@jakarta.ejb.Stateful") ||
+                                hasAnnotation(parentClass, "@jakarta.ejb.Stateless");
                     }
 
                     private boolean hasAnnotation(J j, String annotationPattern) {

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -1,4 +1,18 @@
-package org.openrewrite.java.migrate;
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import lombok.val;
 import org.openrewrite.ExecutionContext;
@@ -24,6 +38,7 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
 
+            @Override
             public J visitClassDeclaration(J.ClassDeclaration cs, ExecutionContext ctx) {
                 boolean isSessionBean = cs.getLeadingAnnotations().stream()
                         .map(J.Annotation::getSimpleName)

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -1,28 +1,16 @@
-/*
- * Copyright 2025 the original author or authors.
- * <p>
- * Licensed under the Moderne Source Available License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * https://docs.moderne.io/licensing/moderne-source-available-license
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.openrewrite.java.migrate;
 
-import lombok.val;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class AddStaticVariableOnProducerSessionBean extends Recipe {
     @Override
@@ -37,45 +25,31 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesType<>("jakarta.enterprise.inject.Produces", false),
+                new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
 
-            @Override
-            public J visitClassDeclaration(J.ClassDeclaration cs, ExecutionContext ctx) {
-                boolean isSessionBean = cs.getLeadingAnnotations().stream()
-                        .map(J.Annotation::getSimpleName)
-                        .anyMatch(name -> name.equals("Stateless") || name.equals("Stateful") || name.equals("Singleton"));
+                        J.ClassDeclaration visitingClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                        boolean isSessionBean = visitingClass.getLeadingAnnotations().stream()
+                                .map(J.Annotation::getSimpleName)
+                                .anyMatch(name -> name.equals("Stateless") || name.equals("Stateful") || name.equals("Singleton"));
+                        if (isSessionBean) {
+                            boolean isProduces = multiVariable.getLeadingAnnotations().stream()
+                                    .anyMatch(anno -> anno.getSimpleName().equals("Produces"));
 
-                if (isSessionBean) {
-                    J.Block classBody = cs.getBody();
-                    val statements = classBody.getStatements();
-                    for (J statement : statements) {
-                        if (statement instanceof J.VariableDeclarations) {
-                            J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) statement;
-                            for (J.Annotation annotations : variableDeclarations.getLeadingAnnotations()) {
-                                if (annotations.getSimpleName().equals("Produces")) {
-                                    JavaType type = variableDeclarations.getType();
-                                    if (type instanceof JavaType.FullyQualified) {
-                                        String fqTypeName = ((JavaType.FullyQualified) type).getFullyQualifiedName();
+                            boolean containsStatic = multiVariable.getModifiers().stream()
+                                    .anyMatch(m -> m.getType() == J.Modifier.Type.Static);
 
-                                        JavaTemplate template = JavaTemplate.builder(
-                                                        "@Produces\nprivate static #{any(" + fqTypeName + ")} #{any(java.lang.String)};")
-                                                .imports("javax.enterprise.inject.Produces")
-                                                .build();
+                            if (!containsStatic && isProduces) {
+                                List<J.Modifier> updatedModifiers = new ArrayList<>(multiVariable.getModifiers());
 
-                                        return template.apply(getCursor(),
-                                                variableDeclarations.getCoordinates().replace(),
-                                                variableDeclarations.getTypeExpression(),
-                                                variableDeclarations.getVariables().get(0).getName());
-                                    }
-                                }
+                                updatedModifiers.add(new J.Modifier(Tree.randomId(), Space.format(" "), Markers.EMPTY, null, J.Modifier.Type.Static, Collections.emptyList()));
+                                return multiVariable.withModifiers(updatedModifiers);
                             }
-
                         }
+                        return super.visitVariableDeclarations(multiVariable, executionContext);
                     }
-
-                }
-                return super.visitClassDeclaration(cs, ctx);
-            }
-        };
+                });
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -1,0 +1,65 @@
+package org.openrewrite.java.migrate;
+
+import lombok.val;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+public class AddStaticVariableOnProducerSessionBean extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Adds static variable to @Produces field that are on session bean";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Ensures that the fields annotated with @Produces which is inside the session bean (@Stateless, @Stateful, or @Singleton) are declared static.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+
+            public J visitClassDeclaration(J.ClassDeclaration cs, ExecutionContext ctx) {
+                boolean isSessionBean = cs.getLeadingAnnotations().stream()
+                        .map(J.Annotation::getSimpleName)
+                        .anyMatch(name -> name.equals("Stateless") || name.equals("Stateful") || name.equals("Singleton"));
+
+                if (isSessionBean) {
+                    J.Block classBody = cs.getBody();
+                    val statements = classBody.getStatements();
+                    for (J statement : statements) {
+                        if (statement instanceof J.VariableDeclarations) {
+                            J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) statement;
+                            for (J.Annotation annotations : variableDeclarations.getLeadingAnnotations()) {
+                                if (annotations.getSimpleName().equals("Produces")) {
+                                    JavaType type = variableDeclarations.getType();
+                                    if (type instanceof JavaType.FullyQualified) {
+                                        String fqTypeName = ((JavaType.FullyQualified) type).getFullyQualifiedName();
+
+                                        JavaTemplate template = JavaTemplate.builder(
+                                                        "@Produces\nprivate static #{any(" + fqTypeName + ")} #{any(java.lang.String)};")
+                                                .imports("javax.enterprise.inject.Produces")
+                                                .build();
+
+                                        return template.apply(getCursor(),
+                                                variableDeclarations.getCoordinates().replace(),
+                                                variableDeclarations.getTypeExpression(),
+                                                variableDeclarations.getVariables().get(0).getName());
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+
+                }
+                return super.visitClassDeclaration(cs, ctx);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.openrewrite.java.migrate;
 
 import lombok.val;
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -42,24 +42,23 @@ public class AddStaticVariableOnProducerSessionBean extends Recipe {
         return Preconditions.check(new UsesType<>("jakarta.enterprise.inject.Produces", false),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
+                    public J visitClassDeclaration(J.ClassDeclaration cd, ExecutionContext ctx) {
+                        if (hasAnnotation(cd, "@jakarta.ejb.Singleton") ||
+                            hasAnnotation(cd, "@jakarta.ejb.Stateful") ||
+                            hasAnnotation(cd, "@jakarta.ejb.Stateless")) {
+                            return super.visitClassDeclaration(cd, ctx);
+                        }
+                        return cd;
+                    }
+
+                    @Override
                     public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                         if (!multiVariable.hasModifier(J.Modifier.Type.Static) &&
-                                hasAnnotation(multiVariable, "@jakarta.enterprise.inject.Produces") &&
-                                isSessionBean()) {
+                            hasAnnotation(multiVariable, "@jakarta.enterprise.inject.Produces")) {
                             return multiVariable.withModifiers(ListUtils.concat(multiVariable.getModifiers(),
                                     new J.Modifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, null, J.Modifier.Type.Static, Collections.emptyList())));
                         }
                         return super.visitVariableDeclarations(multiVariable, ctx);
-                    }
-
-                    private boolean isSessionBean() {
-                        J.ClassDeclaration j = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                        if (j == null) {
-                            return false;
-                        }
-                        return hasAnnotation(j, "@jakarta.ejb.Singleton") ||
-                                hasAnnotation(j, "@jakarta.ejb.Stateful") ||
-                                hasAnnotation(j, "@jakarta.ejb.Stateless");
                     }
 
                     private boolean hasAnnotation(J j, String annotationPattern) {

--- a/src/main/resources/META-INF/rewrite/java-ee-7.yml
+++ b/src/main/resources/META-INF/rewrite/java-ee-7.yml
@@ -27,12 +27,13 @@ recipeList:
   - org.openrewrite.java.migrate.javaee7.OpenJPAPersistenceProvider
   - org.openrewrite.java.migrate.JpaCacheProperties
   - org.openrewrite.java.migrate.BeansXmlNamespace
+  - org.openrewrite.java.migrate.AddStaticVariableOnProducerSessionBean
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.javaee7.OpenJPAPersistenceProvider
 displayName: Removed OpenJPA providers in the persistence.xml file
 description: >-
-  When migrating  to EclipseLink, using OpenJPA providers in EclipseLink results in runtime errors. To resolve these errors, 
+  When migrating  to EclipseLink, using OpenJPA providers in EclipseLink results in runtime errors. To resolve these errors,
   the recipe removes the flagged OpenJPA provider from the persistence.xml.
 recipeList:
   - org.openrewrite.xml.ChangeTagValue:

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -1,0 +1,75 @@
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AddStaticVariableOnProducerSessionBean());
+    }
+
+    @Test
+    @DocumentExample
+    void addProducesFieldStaticOnSessionBean() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.test;
+              @interface Stateless {}
+              @interface Produces {}
+
+              class SomeDependency {}
+              @Stateless
+              public class MySessionBean {
+                  @Produces
+                  private SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """,
+            """
+              package com.test;
+              @interface Stateless {}
+              @interface Produces {}
+
+              class SomeDependency {}
+              @Stateless
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeOnStaticVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import javax.ejb.Singleton;
+              import javax.enterprise.inject.Produces;
+
+              @Singleton
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -48,14 +48,15 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AddStaticVariableOnProducerSessionBean());
+        spec.recipe(new AddStaticVariableOnProducerSessionBean())
+          .parser(JavaParser.fromJavaVersion()
+            .dependsOn(jakarta_produces, jakarta_stateless, someDependency));
     }
 
     @Test
     @DocumentExample
     void addProducesFieldStaticOnSessionBean() {
         rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateless, someDependency)),
           //language=java
           java(
             """
@@ -73,19 +74,19 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
               }
               """,
             """
-                    package com.test;
-                    import jakarta.ejb.Stateless;
-                    import jakarta.enterprise.inject.Produces;
+              package com.test;
+              import jakarta.ejb.Stateless;
+              import jakarta.enterprise.inject.Produces;
 
-                    @Stateless
-                    public class MySessionBean {
-                        @Produces
-                        private static SomeDependency someDependency;
-                        void exampleMethod() {
-                           return;
-                        }
-                    }
-                    """
+              @Stateless
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
           )
         );
     }
@@ -96,10 +97,12 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
           //language=java
           java(
             """
-              import javax.ejb.Singleton;
-              import javax.enterprise.inject.Produces;
+              package com.test;
 
-              @Singleton
+              import jakarta.ejb.Stateless;
+              import jakarta.enterprise.inject.Produces;
+
+              @Stateless
               public class MySessionBean {
                   @Produces
                   private static SomeDependency someDependency;

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -27,38 +27,38 @@ import static org.openrewrite.java.Assertions.java;
 class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     @Language("java")
     private static final String jakarta_produces =
-            """
-                    package jakarta.enterprise.inject;
-                    public @interface Produces {}
-                    """;
+      """
+        package jakarta.enterprise.inject;
+        public @interface Produces {}
+        """;
 
     @Language("java")
     private static final String jakarta_stateless =
-            """
-                    package jakarta.ejb;
-                    public @interface Stateless {}
-                    """;
+      """
+        package jakarta.ejb;
+        public @interface Stateless {}
+        """;
 
     @Language("java")
     private static final String jakarta_stateful =
-            """
-                    package jakarta.ejb;
-                    public @interface Stateful {}
-                    """;
+      """
+        package jakarta.ejb;
+        public @interface Stateful {}
+        """;
 
     @Language("java")
     private static final String jakarta_singleton =
-            """
-                    package jakarta.ejb;
-                    public @interface Singleton {}
-                    """;
+      """
+        package jakarta.ejb;
+        public @interface Singleton {}
+        """;
 
     @Language("java")
     private static final String someDependency =
-            """
-                    package com.test;
-                    public class SomeDependency {}
-                    """;
+      """
+        package com.test;
+        public class SomeDependency {}
+        """;
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -71,38 +71,38 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     @DocumentExample
     void addStaticOnProducesMarkedStateless() {
         rewriteRun(
-                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateless, someDependency)),
-                //language=java
-                java(
-                        """
-                                package com.test;
-                                import jakarta.ejb.Stateless;
-                                import jakarta.enterprise.inject.Produces;
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateless, someDependency)),
+          //language=java
+          java(
+            """
+              package com.test;
+              import jakarta.ejb.Stateless;
+              import jakarta.enterprise.inject.Produces;
 
-                                @Stateless
-                                public class MySessionBean {
-                                    @Produces
-                                    private SomeDependency someDependency;
-                                    void exampleMethod() {
-                                       return;
-                                    }
-                                }
-                                """,
-                        """
-                                package com.test;
-                                import jakarta.ejb.Stateless;
-                                import jakarta.enterprise.inject.Produces;
+              @Stateless
+              public class MySessionBean {
+                  @Produces
+                  private SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """,
+            """
+              package com.test;
+              import jakarta.ejb.Stateless;
+              import jakarta.enterprise.inject.Produces;
 
-                                @Stateless
-                                public class MySessionBean {
-                                    @Produces
-                                    private static SomeDependency someDependency;
-                                    void exampleMethod() {
-                                       return;
-                                    }
-                                }
-                                """
-                )
+              @Stateless
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
+          )
         );
     }
 
@@ -110,38 +110,38 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     @DocumentExample
     void addStaticOnProducesMarkedStateful() {
         rewriteRun(
-                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateful, someDependency)),
-                //language=java
-                java(
-                        """
-                                package com.test;
-                                import jakarta.ejb.Stateful;
-                                import jakarta.enterprise.inject.Produces;
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateful, someDependency)),
+          //language=java
+          java(
+            """
+              package com.test;
+              import jakarta.ejb.Stateful;
+              import jakarta.enterprise.inject.Produces;
 
-                                @Stateful
-                                public class MySessionBean {
-                                    @Produces
-                                    private SomeDependency someDependency;
-                                    void exampleMethod() {
-                                       return;
-                                    }
-                                }
-                                """,
-                        """
-                                package com.test;
-                                import jakarta.ejb.Stateful;
-                                import jakarta.enterprise.inject.Produces;
+              @Stateful
+              public class MySessionBean {
+                  @Produces
+                  private SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """,
+            """
+              package com.test;
+              import jakarta.ejb.Stateful;
+              import jakarta.enterprise.inject.Produces;
 
-                                @Stateful
-                                public class MySessionBean {
-                                    @Produces
-                                    private static SomeDependency someDependency;
-                                    void exampleMethod() {
-                                       return;
-                                    }
-                                }
-                                """
-                )
+              @Stateful
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
+          )
         );
     }
 
@@ -149,59 +149,59 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     @DocumentExample
     void addStaticOnProducesMarkedSingleton() {
         rewriteRun(
-                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
-                //language=java
-                java(
-                        """
-                                package com.test;
-                                import jakarta.ejb.Singleton;
-                                import jakarta.enterprise.inject.Produces;
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
+          //language=java
+          java(
+            """
+              package com.test;
+              import jakarta.ejb.Singleton;
+              import jakarta.enterprise.inject.Produces;
 
-                                @Singleton
-                                public class MySessionBean {
-                                    @Produces
-                                    private SomeDependency someDependency;
-                                    void exampleMethod() {
-                                       return;
-                                    }
-                                }
-                                """,
-                        """
-                                package com.test;
-                                import jakarta.ejb.Singleton;
-                                import jakarta.enterprise.inject.Produces;
+              @Singleton
+              public class MySessionBean {
+                  @Produces
+                  private SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """,
+            """
+              package com.test;
+              import jakarta.ejb.Singleton;
+              import jakarta.enterprise.inject.Produces;
 
-                                @Singleton
-                                public class MySessionBean {
-                                    @Produces
-                                    private static SomeDependency someDependency;
-                                    void exampleMethod() {
-                                       return;
-                                    }
-                                }
-                                """
-                )
+              @Singleton
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
+          )
         );
     }
 
     @Test
     void noChangeOnStaticVariable() {
         rewriteRun(
-                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
-                //language=java
-                java(
-                        """
-                                package com.test;
-                                import jakarta.ejb.Singleton;
-                                import jakarta.enterprise.inject.Produces;
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
+          //language=java
+          java(
+            """
+              package com.test;
+              import jakarta.ejb.Singleton;
+              import jakarta.enterprise.inject.Produces;
 
-                                @Singleton
-                                public class MySessionBean {
-                                    @Produces
-                                    private static SomeDependency someDependency;
-                                }
-                                """
-                )
+              @Singleton
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+              }
+              """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.migrate;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
@@ -25,53 +24,41 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
-    @Language("java")
-    private static final String jakarta_produces =
-      """
-        package jakarta.enterprise.inject;
-        public @interface Produces {}
-        """;
-
-    @Language("java")
-    private static final String jakarta_stateless =
-      """
-        package jakarta.ejb;
-        public @interface Stateless {}
-        """;
-
-    @Language("java")
-    private static final String jakarta_stateful =
-      """
-        package jakarta.ejb;
-        public @interface Stateful {}
-        """;
-
-    @Language("java")
-    private static final String jakarta_singleton =
-      """
-        package jakarta.ejb;
-        public @interface Singleton {}
-        """;
-
-    @Language("java")
-    private static final String someDependency =
-      """
-        package com.test;
-        public class SomeDependency {}
-        """;
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new AddStaticVariableOnProducerSessionBean())
+          //language=java
           .parser(JavaParser.fromJavaVersion()
-            .dependsOn(jakarta_produces, jakarta_stateless, someDependency));
+            .dependsOn(
+              """
+                package jakarta.enterprise.inject;
+                public @interface Produces {}
+                """,
+              """
+                package jakarta.ejb;
+                public @interface Stateless {}
+                """,
+              """
+                package jakarta.ejb;
+                public @interface Stateful {}
+                """,
+              """
+                package jakarta.ejb;
+                public @interface Singleton {}
+                """,
+              """
+                package com.test;
+                public class SomeDependency {}
+                """
+            )
+          );
     }
 
     @Test
     @DocumentExample
     void addStaticOnProducesMarkedStateless() {
         rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateless, someDependency)),
           //language=java
           java(
             """
@@ -107,10 +94,8 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     }
 
     @Test
-    @DocumentExample
     void addStaticOnProducesMarkedStateful() {
         rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateful, someDependency)),
           //language=java
           java(
             """
@@ -146,10 +131,8 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     }
 
     @Test
-    @DocumentExample
     void addStaticOnProducesMarkedSingleton() {
         rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
           //language=java
           java(
             """
@@ -187,7 +170,6 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     @Test
     void noChangeOnStaticVariable() {
         rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -27,24 +27,38 @@ import static org.openrewrite.java.Assertions.java;
 class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     @Language("java")
     private static final String jakarta_produces =
-      """
-        package jakarta.enterprise.inject;
-        public @interface Produces {}
-        """;
+            """
+                    package jakarta.enterprise.inject;
+                    public @interface Produces {}
+                    """;
 
     @Language("java")
     private static final String jakarta_stateless =
-      """
-        package jakarta.ejb;
-        public @interface Stateless {}
-        """;
+            """
+                    package jakarta.ejb;
+                    public @interface Stateless {}
+                    """;
+
+    @Language("java")
+    private static final String jakarta_stateful =
+            """
+                    package jakarta.ejb;
+                    public @interface Stateful {}
+                    """;
+
+    @Language("java")
+    private static final String jakarta_singleton =
+            """
+                    package jakarta.ejb;
+                    public @interface Singleton {}
+                    """;
 
     @Language("java")
     private static final String someDependency =
-      """
-        package com.test;
-        public class SomeDependency {}
-        """;
+            """
+                    package com.test;
+                    public class SomeDependency {}
+                    """;
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -55,60 +69,139 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
 
     @Test
     @DocumentExample
-    void addProducesFieldStaticOnSessionBean() {
+    void addStaticOnProducesMarkedStateless() {
         rewriteRun(
-          //language=java
-          java(
-            """
-              package com.test;
-              import jakarta.ejb.Stateless;
-              import jakarta.enterprise.inject.Produces;
+                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateless, someDependency)),
+                //language=java
+                java(
+                        """
+                                package com.test;
+                                import jakarta.ejb.Stateless;
+                                import jakarta.enterprise.inject.Produces;
 
-              @Stateless
-              public class MySessionBean {
-                  @Produces
-                  private SomeDependency someDependency;
-                  void exampleMethod() {
-                     return;
-                  }
-              }
-              """,
-            """
-              package com.test;
-              import jakarta.ejb.Stateless;
-              import jakarta.enterprise.inject.Produces;
+                                @Stateless
+                                public class MySessionBean {
+                                    @Produces
+                                    private SomeDependency someDependency;
+                                    void exampleMethod() {
+                                       return;
+                                    }
+                                }
+                                """,
+                        """
+                                package com.test;
+                                import jakarta.ejb.Stateless;
+                                import jakarta.enterprise.inject.Produces;
 
-              @Stateless
-              public class MySessionBean {
-                  @Produces
-                  private static SomeDependency someDependency;
-                  void exampleMethod() {
-                     return;
-                  }
-              }
-              """
-          )
+                                @Stateless
+                                public class MySessionBean {
+                                    @Produces
+                                    private static SomeDependency someDependency;
+                                    void exampleMethod() {
+                                       return;
+                                    }
+                                }
+                                """
+                )
+        );
+    }
+
+    @Test
+    @DocumentExample
+    void addStaticOnProducesMarkedStateful() {
+        rewriteRun(
+                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_stateful, someDependency)),
+                //language=java
+                java(
+                        """
+                                package com.test;
+                                import jakarta.ejb.Stateful;
+                                import jakarta.enterprise.inject.Produces;
+
+                                @Stateful
+                                public class MySessionBean {
+                                    @Produces
+                                    private SomeDependency someDependency;
+                                    void exampleMethod() {
+                                       return;
+                                    }
+                                }
+                                """,
+                        """
+                                package com.test;
+                                import jakarta.ejb.Stateful;
+                                import jakarta.enterprise.inject.Produces;
+
+                                @Stateful
+                                public class MySessionBean {
+                                    @Produces
+                                    private static SomeDependency someDependency;
+                                    void exampleMethod() {
+                                       return;
+                                    }
+                                }
+                                """
+                )
+        );
+    }
+
+    @Test
+    @DocumentExample
+    void addStaticOnProducesMarkedSingleton() {
+        rewriteRun(
+                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
+                //language=java
+                java(
+                        """
+                                package com.test;
+                                import jakarta.ejb.Singleton;
+                                import jakarta.enterprise.inject.Produces;
+
+                                @Singleton
+                                public class MySessionBean {
+                                    @Produces
+                                    private SomeDependency someDependency;
+                                    void exampleMethod() {
+                                       return;
+                                    }
+                                }
+                                """,
+                        """
+                                package com.test;
+                                import jakarta.ejb.Singleton;
+                                import jakarta.enterprise.inject.Produces;
+
+                                @Singleton
+                                public class MySessionBean {
+                                    @Produces
+                                    private static SomeDependency someDependency;
+                                    void exampleMethod() {
+                                       return;
+                                    }
+                                }
+                                """
+                )
         );
     }
 
     @Test
     void noChangeOnStaticVariable() {
         rewriteRun(
-          //language=java
-          java(
-            """
-              package com.test;
+                spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(jakarta_produces, jakarta_singleton, someDependency)),
+                //language=java
+                java(
+                        """
+                                package com.test;
+                                import jakarta.ejb.Singleton;
+                                import jakarta.enterprise.inject.Produces;
 
-              import jakarta.ejb.Stateless;
-              import jakarta.enterprise.inject.Produces;
-
-              @Stateless
-              public class MySessionBean {
-                  @Produces
-                  private static SomeDependency someDependency;
-              }
-              """
-          )
+                                @Singleton
+                                public class MySessionBean {
+                                    @Produces
+                                    private static SomeDependency someDependency;
+                                }
+                                """
+                )
         );
     }
 }


### PR DESCRIPTION

## What's changed?

- Added a recipe to modify session beans that have `@Produces`-annotated fields by making them `static`.
- Ensured the recipe only targets classes annotated with `@Stateless`, `@Stateful`, or `@Singleton`.
- Created a unit test to verify the behavior of the recipe using `JavaParser.fromJavaVersion().dependsOn(...)`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Any additional context
- Used mock annotations in tests (`@Stateless`, `@Produces`) via `dependsOn()` to avoid runtime dependencies.
- The recipe applies a JavaTemplate that rewrites `private SomeDependency someDependency;` to `private static SomeDependency someDependency;`.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
