### PR TITLE
Use ParameterizedClass in test

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
@@ -15,8 +15,9 @@
  */
 package org.openrewrite.java.migrate.jakarta;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -24,7 +25,9 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class UpdateManagedBeanToNamedTest implements RewriteTest {
+@ParameterizedClass
+@CsvSource({ "javax", "jakarta" })
+record UpdateManagedBeanToNamedTest(String j) implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()
@@ -32,9 +35,8 @@ class UpdateManagedBeanToNamedTest implements RewriteTest {
           .recipe(new UpdateManagedBeanToNamed());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"javax", "jakarta"})
-    void updateManagedBeanToNamed(String pkg) {
+    @Test
+    void updateManagedBeanToNamed() {
         rewriteRun(
           //language=java
           java(
@@ -44,7 +46,7 @@ class UpdateManagedBeanToNamedTest implements RewriteTest {
               @ManagedBean
               public class ApplicationBean2 {
               }
-              """.formatted(pkg),
+              """.formatted(j),
             """
               import jakarta.inject.Named;
 
@@ -56,9 +58,8 @@ class UpdateManagedBeanToNamedTest implements RewriteTest {
         );
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"javax", "jakarta"})
-    void updateManagedBeanToNamedWithArg(String pkg) {
+    @Test
+    void updateManagedBeanToNamedWithArg() {
         rewriteRun(
           //language=java
           java(
@@ -68,7 +69,7 @@ class UpdateManagedBeanToNamedTest implements RewriteTest {
               @ManagedBean(name="myBean")
               public class ApplicationBean2 {
               }
-              """.formatted(pkg),
+              """.formatted(j),
             """
               import jakarta.inject.Named;
 

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.migrate.jakarta;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.migrate.jakarta;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -26,8 +27,8 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 @ParameterizedClass
-@CsvSource({"javax", "jakarta"})
-record UpdateManagedBeanToNamedTest(String j) implements RewriteTest {
+@ValueSource(strings = {"javax", "jakarta"})
+record UpdateManagedBeanToNamedTest(String pkg) implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()
@@ -46,7 +47,7 @@ record UpdateManagedBeanToNamedTest(String j) implements RewriteTest {
               @ManagedBean
               public class ApplicationBean2 {
               }
-              """.formatted(j),
+              """.formatted(pkg),
             """
               import jakarta.inject.Named;
 
@@ -69,7 +70,7 @@ record UpdateManagedBeanToNamedTest(String j) implements RewriteTest {
               @ManagedBean(name="myBean")
               public class ApplicationBean2 {
               }
-              """.formatted(j),
+              """.formatted(pkg),
             """
               import jakarta.inject.Named;
 

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamedTest.java
@@ -26,7 +26,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 @ParameterizedClass
-@CsvSource({ "javax", "jakarta" })
+@CsvSource({"javax", "jakarta"})
 record UpdateManagedBeanToNamedTest(String j) implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Use single `@ParameterizedClass` instead of multiple `@ParameterizedTest` in test case that uses it for each test.

## What's your motivation?
Wanted to try, and can maybe be used as a code example for https://github.com/openrewrite/rewrite-testing-frameworks/issues/743

## Anyone you would like to review specifically?
<!-- @mention them here -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
