### PR TITLE
Adapting to AddDependencyVisitor constructor change

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/javax/AddJaxbRuntime.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AddJaxbRuntime.java
@@ -160,7 +160,7 @@ public class AddJaxbRuntime extends ScanningRecipe<AtomicBoolean> {
                         artifactId = SUN_JAXB_RUNTIME_ARTIFACT;
                     }
                     if (rc.findResolvedDependency(groupId, artifactId) == null) {
-                        g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(groupId, artifactId, version, null, "runtimeOnly", null, null, null, null)
+                        g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(groupId, artifactId, version, null, "runtimeOnly", null, null, null, null, null)
                                 .visitNonNull(g, ctx);
                     }
                     return g;

--- a/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
@@ -116,11 +116,11 @@ public class AddJaxwsRuntime extends Recipe {
                         Set<String> runtimeConfigurations = getTransitiveDependencyConfiguration(gp, SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT);
                         if (runtimeConfigurations.isEmpty()) {
                             if (gp.getConfiguration("compileOnly") != null) {
-                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "compileOnly", null, null, null, null)
+                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "compileOnly", null, null, null, null, null)
                                         .visitNonNull(g, ctx);
                             }
                             if (gp.getConfiguration("testImplementation") != null) {
-                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "testImplementation", null, null, null, null)
+                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "testImplementation", null, null, null, null, null)
                                         .visitNonNull(g, ctx);
                             }
                         } else {
@@ -131,7 +131,7 @@ public class AddJaxwsRuntime extends Recipe {
                                     GradleDependencyConfiguration runtimeGdc = gp.getConfiguration(runtimeConfiguration);
                                     List<GradleDependencyConfiguration> runtimeTransitives = gp.configurationsExtendingFrom(runtimeGdc, true);
                                     if (apiTransitives.stream().noneMatch(runtimeTransitives::contains)) {
-                                        g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, apiConfiguration, null, null, null, null)
+                                        g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, apiConfiguration, null, null, null, null, null)
                                                 .visitNonNull(g, ctx);
                                     }
                                 }


### PR DESCRIPTION
## What's changed?

Adding an extra argument to `AddDependencyVisitor` constructor calls.

## What's your motivation?

Fix broken CI after 
https://github.com/openrewrite/rewrite/pull/5371

```
/home/runner/work/rewrite-migrate-java/rewrite-migrate-java/src/main/java/org/openrewrite/java/migrate/javax/AddJaxbRuntime.java:163: error: constructor AddDependencyVisitor in class AddDependencyVisitor cannot be applied to given types;
                        g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(groupId, artifactId, version, null, "runtimeOnly", null, null, null, null)
                                                ^
```