### PR TITLE
Migrate Traits class usage to constructor calls

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/jakarta/UpdateAnnotationAttributeJavaxToJakarta.java
+++ b/src/main/java/org/openrewrite/java/migrate/jakarta/UpdateAnnotationAttributeJavaxToJakarta.java
@@ -22,7 +22,7 @@ import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.java.trait.Traits;
+import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
@@ -50,7 +50,7 @@ public class UpdateAnnotationAttributeJavaxToJakarta extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Traits.annotated(signature).asVisitor(ann -> ann.getTree()
+        return new Annotated.Matcher(signature).asVisitor(ann -> ann.getTree()
                 .withArguments(ListUtils.map(ann.getTree().getArguments(), arg -> {
                     if (arg instanceof J.Assignment) {
                         J.Assignment as = (J.Assignment) arg;

--- a/src/main/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamed.java
+++ b/src/main/java/org/openrewrite/java/migrate/jakarta/UpdateManagedBeanToNamed.java
@@ -34,8 +34,6 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.openrewrite.java.trait.Traits.annotated;
-
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class UpdateManagedBeanToNamed extends Recipe {
@@ -64,7 +62,7 @@ public class UpdateManagedBeanToNamed extends Recipe {
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                        Optional<Annotated> annotated = annotated(MANAGED_BEAN_MATCHER).get(getCursor());
+                        Optional<Annotated> annotated = new Annotated.Matcher(MANAGED_BEAN_MATCHER).get(getCursor());
                         if (annotated.isPresent()) {
                             maybeAddImport("jakarta.inject.Named");
                             maybeRemoveImport("javax.faces.bean.ManagedBean");


### PR DESCRIPTION
## What's changed?
remove `Traits` factory method usage.

## What's your motivation?
See https://github.com/openrewrite/rewrite-rewrite/pull/16
