### PR TITLE
Add only declarable Gradle jax-ws runtime dependencies

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
@@ -152,7 +152,7 @@ public class AddJaxwsRuntime extends Recipe {
                     for (GradleDependencyConfiguration configuration : tmpConfigurations) {
                         GradleDependencyConfiguration gdc = gp.getConfiguration(configuration.getName());
                         for (GradleDependencyConfiguration extendsFrom : gdc.allExtendsFrom()) {
-                            if (configurations.contains(extendsFrom.getName())) {
+                            if (configurations.contains(extendsFrom)) {
                                 configurations.remove(configuration);
                             }
                         }

--- a/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
@@ -46,13 +46,8 @@ public class AddJaxwsRuntime extends Recipe {
     private static final String SUN_JAXWS_RUNTIME_GROUP = "com.sun.xml.ws";
     private static final String SUN_JAXWS_RUNTIME_ARTIFACT = "jaxws-rt";
 
-    private final AddJaxwsRuntimeGradle addJaxwsRuntimeGradle;
-    private final AddJaxwsRuntimeMaven addJaxwsRuntimeMaven;
-
-    public AddJaxwsRuntime() {
-        this.addJaxwsRuntimeGradle = new AddJaxwsRuntimeGradle();
-        this.addJaxwsRuntimeMaven = new AddJaxwsRuntimeMaven();
-    }
+    private final AddJaxwsRuntimeGradle addJaxwsRuntimeGradle = new AddJaxwsRuntimeGradle();
+    private final AddJaxwsRuntimeMaven addJaxwsRuntimeMaven = new AddJaxwsRuntimeMaven();
 
     @Override
     public String getDisplayName() {
@@ -226,7 +221,7 @@ public class AddJaxwsRuntime extends Recipe {
          * Finds the highest scope for a given group/artifact.
          *
          * @param mavenModel The maven model to search for a dependency.
-         * @param groupId The group ID of the dependency
+         * @param groupId    The group ID of the dependency
          * @param artifactId The artifact ID of the dependency
          * @return The highest scope of the given dependency or null if the dependency does not exist.
          */

--- a/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
@@ -116,12 +116,10 @@ public class AddJaxwsRuntime extends Recipe {
                         Set<String> runtimeConfigurations = getTransitiveDependencyConfiguration(gp, SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT);
                         if (runtimeConfigurations.isEmpty()) {
                             if (gp.getConfiguration("compileOnly") != null) {
-                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "compileOnly", null, null, null, null, null)
-                                        .visitNonNull(g, ctx);
+                                g = addJaxWsRuntimeDependency("compileOnly", g, ctx);
                             }
                             if (gp.getConfiguration("testImplementation") != null) {
-                                g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, "testImplementation", null, null, null, null, null)
-                                        .visitNonNull(g, ctx);
+                                g = addJaxWsRuntimeDependency("testImplementation", g, ctx);
                             }
                         } else {
                             for (String apiConfiguration : apiConfigurations) {
@@ -131,8 +129,7 @@ public class AddJaxwsRuntime extends Recipe {
                                     GradleDependencyConfiguration runtimeGdc = gp.getConfiguration(runtimeConfiguration);
                                     List<GradleDependencyConfiguration> runtimeTransitives = gp.configurationsExtendingFrom(runtimeGdc, true);
                                     if (apiTransitives.stream().noneMatch(runtimeTransitives::contains)) {
-                                        g = (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, apiConfiguration, null, null, null, null, null)
-                                                .visitNonNull(g, ctx);
+                                        g = addJaxWsRuntimeDependency(apiConfiguration, g, ctx);
                                     }
                                 }
                             }
@@ -169,6 +166,14 @@ public class AddJaxwsRuntime extends Recipe {
                     }
 
                     return configurations;
+                }
+
+                private G.CompilationUnit addJaxWsRuntimeDependency(String apiConfiguration, G.CompilationUnit g, ExecutionContext ctx) {
+                    if (apiConfiguration.endsWith("Classpath")) {
+                        return g;
+                    }
+                    return (G.CompilationUnit) new org.openrewrite.gradle.AddDependencyVisitor(SUN_JAXWS_RUNTIME_GROUP, SUN_JAXWS_RUNTIME_ARTIFACT, "2.3.x", null, apiConfiguration, null, null, null, null, null)
+                            .visitNonNull(g, ctx);
                 }
             });
         }

--- a/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AddJaxwsRuntime.java
@@ -118,11 +118,9 @@ public class AddJaxwsRuntime extends Recipe {
                             }
                         } else {
                             for (GradleDependencyConfiguration apiConfiguration : apiConfigurations) {
-                                GradleDependencyConfiguration apiGdc = gp.getConfiguration(apiConfiguration.getName());
-                                List<GradleDependencyConfiguration> apiTransitives = gp.configurationsExtendingFrom(apiGdc, true);
+                                List<GradleDependencyConfiguration> apiTransitives = gp.configurationsExtendingFrom(apiConfiguration, true);
                                 for (GradleDependencyConfiguration runtimeConfiguration : runtimeConfigurations) {
-                                    GradleDependencyConfiguration runtimeGdc = gp.getConfiguration(runtimeConfiguration.getName());
-                                    List<GradleDependencyConfiguration> runtimeTransitives = gp.configurationsExtendingFrom(runtimeGdc, true);
+                                    List<GradleDependencyConfiguration> runtimeTransitives = gp.configurationsExtendingFrom(runtimeConfiguration, true);
                                     if (apiTransitives.stream().noneMatch(runtimeTransitives::contains) && apiConfiguration.isCanBeDeclared()) {
                                         g = addJaxWsRuntimeDependency(apiConfiguration.getName(), g, ctx);
                                     }

--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -162,7 +162,7 @@ recipeList:
       groupId: jakarta.xml.ws
       artifactId: jakarta.xml.ws-api
       newVersion: 2.3.x
-  # Add the jaxb runtime to any projects that have a transitive dependency on the api
+  # Add the jax-ws runtime to any projects that have a transitive dependency on the api
   - org.openrewrite.java.migrate.javax.AddJaxwsRuntime
   # Remove the version from added dependencies when a managed version exists.
   - org.openrewrite.maven.RemoveRedundantDependencyVersions:

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.migrate.javax;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -127,6 +128,32 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   </project>
                   """.formatted(wsApiVersion, rtVersion);
             })
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/760")
+    void dontAddGradleResolutionOnlyDependencies() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          buildGradle(
+            //language=gradle
+            """
+              plugins {
+                   id 'java'
+               }
+               repositories {
+                   mavenCentral()
+               }
+               dependencies {
+                   compileOnly "com.sun.xml.ws:jaxws-rt:2.3.7"
+
+                   implementation "org.springframework.boot:spring-boot-starter-web-services:2.5.15"
+
+                   testImplementation "com.sun.xml.ws:jaxws-rt:2.3.7"
+               }
+              """
           )
         );
     }


### PR DESCRIPTION
## What's changed?
For the `AddJaxwsRuntimeGradle` recipe the resolution-only dependencies are no longer added.

- Fixes https://github.com/openrewrite/rewrite-migrate-java/issues/760