### PR TITLE
Update AddStaticVariableOnProducerSessionBean to modify XML defined EJBs

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -49,6 +49,7 @@ public class AddStaticVariableOnProducerSessionBean extends ScanningRecipe<Set<S
 
     @Override
     public Set<String> getInitialValue(ExecutionContext ctx) {
+        // Class names of session beans found in XML
         return new HashSet<>();
     }
 
@@ -57,7 +58,6 @@ public class AddStaticVariableOnProducerSessionBean extends ScanningRecipe<Set<S
         return Preconditions.check(
                 new FindSourceFiles("**/ejb-jar.xml"),
                 new XmlVisitor<ExecutionContext>() {
-
                     @Override
                     public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
                         if (EJB_PATH.matches(getCursor())) {
@@ -107,10 +107,8 @@ public class AddStaticVariableOnProducerSessionBean extends ScanningRecipe<Set<S
 
                     private boolean isInXml() {
                         J.ClassDeclaration parentClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                        if (parentClass.getType() instanceof JavaType.FullyQualified) {
-                            JavaType.FullyQualified fqType = parentClass.getType();
-                            String fqName = fqType.getFullyQualifiedName();
-                            return acc.contains(fqName);
+                        if (parentClass != null && parentClass.getType() != null) {
+                            return acc.contains(parentClass.getType().getFullyQualifiedName());
                         }
                         return false;
                     }

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -54,7 +54,7 @@ public class AddStaticVariableOnProducerSessionBean extends ScanningRecipe<AddSt
     public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
         return new XmlVisitor<ExecutionContext>() {
             @Override
-            public Xml visitTag(Xml.Tag tag, ExecutionContext executionContext) {
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 String className = null;
                 String sessionType = null;
                 for (Xml.Tag child : tag.getChildren()) {
@@ -67,7 +67,7 @@ public class AddStaticVariableOnProducerSessionBean extends ScanningRecipe<AddSt
                 if (className != null && sessionType != null) {
                     acc.getSessionBeanClasses().put(className, sessionType);
                 }
-                return super.visitTag(tag, executionContext);
+                return super.visitTag(tag, ctx);
             }
         };
     }

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -105,7 +105,7 @@ public class AddStaticVariableOnProducerSessionBean extends ScanningRecipe<Set<S
 
                     private boolean isInXml() {
                         J.ClassDeclaration parentClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                        if (parentClass != null && parentClass.getType() instanceof JavaType.FullyQualified) {
+                        if (parentClass.getType() instanceof JavaType.FullyQualified) {
                             JavaType.FullyQualified fqType = parentClass.getType();
                             String fqName = fqType.getFullyQualifiedName();
                             return acc.contains(fqName);

--- a/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBean.java
@@ -28,7 +28,8 @@ import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.xml.Assertions.xml;
 
 class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
 
@@ -53,6 +54,59 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
                 """
             )
           );
+    }
+
+    @Test
+    @DocumentExample
+    void addStaticToProducesFieldFromXml() {
+        rewriteRun(
+          xml(
+            //language=xml
+            """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd" version="3.1">
+                    	<display-name>testTransaction</display-name>
+                    	<enterprise-beans>
+                            <session>
+                                <ejb-name>MySessionBean</ejb-name>
+                                <ejb-class>com.test.MySessionBean</ejb-class>
+                                <session-type>Stateless</session-type>
+                                <transaction-type>Container</transaction-type>
+                            </session>
+                        </enterprise-beans>
+                    </ejb-jar>
+                    """,
+            sourceSpecs -> sourceSpecs.path("ejb-jar.xml")
+          ),
+          //language=java
+          java(
+            """
+              package com.test;
+              import jakarta.enterprise.inject.Produces;
+
+              public class MySessionBean {
+                  @Produces
+                  private SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """,
+            """
+              package com.test;
+              import jakarta.enterprise.inject.Produces;
+
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
+          )
+        );
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -63,20 +63,26 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
           xml(
             //language=xml
             """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd" version="3.1">
-                    	<display-name>testTransaction</display-name>
-                    	<enterprise-beans>
-                            <session>
-                                <ejb-name>MySessionBean</ejb-name>
-                                <ejb-class>com.test.MySessionBean</ejb-class>
-                                <session-type>Stateless</session-type>
-                                <transaction-type>Container</transaction-type>
-                            </session>
-                        </enterprise-beans>
-                    </ejb-jar>
-                    """,
+              <?xml version="1.0" encoding="UTF-8"?>
+              <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd" version="3.1">
+              	<display-name>testTransaction</display-name>
+              	<enterprise-beans>
+                      <session>
+                          <ejb-name>MySessionBean</ejb-name>
+                          <ejb-class>com.test.MySessionBean</ejb-class>
+                          <session-type>Stateless</session-type>
+                          <transaction-type>Container</transaction-type>
+                      </session>
+                      <session>
+                           <ejb-name>TestProducerFieldNonStaticOnSessionBean</ejb-name>
+                           <ejb-class>org.test.ejb.TestProducerFieldNonStaticOnSessionBean</ejb-class>
+                           <session-type>Stateless</session-type>
+                           <transaction-type>Container</transaction-type>
+                      </session>
+                  </enterprise-beans>
+              </ejb-jar>
+              """,
             sourceSpecs -> sourceSpecs.path("ejb-jar.xml")
           ),
           //language=java

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -56,8 +56,45 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
           );
     }
 
-    @Test
     @DocumentExample
+    @Test
+    void addStaticOnProducesMarkedStateless() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.test;
+              import jakarta.ejb.Stateless;
+              import jakarta.enterprise.inject.Produces;
+
+              @Stateless
+              public class MySessionBean {
+                  @Produces
+                  private SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """,
+            """
+              package com.test;
+              import jakarta.ejb.Stateless;
+              import jakarta.enterprise.inject.Produces;
+
+              @Stateless
+              public class MySessionBean {
+                  @Produces
+                  private static SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void addStaticToProducesFieldFromXml() {
         rewriteRun(
           xml(
@@ -73,12 +110,6 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
                           <ejb-class>com.test.MySessionBean</ejb-class>
                           <session-type>Stateless</session-type>
                           <transaction-type>Container</transaction-type>
-                      </session>
-                      <session>
-                           <ejb-name>TestProducerFieldNonStaticOnSessionBean</ejb-name>
-                           <ejb-class>org.test.ejb.TestProducerFieldNonStaticOnSessionBean</ejb-class>
-                           <session-type>Stateless</session-type>
-                           <transaction-type>Container</transaction-type>
                       </session>
                   </enterprise-beans>
               </ejb-jar>
@@ -116,7 +147,6 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
     }
 
     @Test
-    @DocumentExample
     void noChangeWhenBeanNotMentionedInXml() {
         rewriteRun(
           xml(
@@ -153,44 +183,6 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
               public class MySessionBean {
                   @Produces
                   private SomeDependency someDependency;
-                  void exampleMethod() {
-                     return;
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    @DocumentExample
-    void addStaticOnProducesMarkedStateless() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              package com.test;
-              import jakarta.ejb.Stateless;
-              import jakarta.enterprise.inject.Produces;
-
-              @Stateless
-              public class MySessionBean {
-                  @Produces
-                  private SomeDependency someDependency;
-                  void exampleMethod() {
-                     return;
-                  }
-              }
-              """,
-            """
-              package com.test;
-              import jakarta.ejb.Stateless;
-              import jakarta.enterprise.inject.Produces;
-
-              @Stateless
-              public class MySessionBean {
-                  @Produces
-                  private static SomeDependency someDependency;
                   void exampleMethod() {
                      return;
                   }

--- a/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddStaticVariableOnProducerSessionBeanTest.java
@@ -117,6 +117,53 @@ class AddStaticVariableOnProducerSessionBeanTest implements RewriteTest {
 
     @Test
     @DocumentExample
+    void noChangeWhenBeanNotMentionedInXml() {
+        rewriteRun(
+          xml(
+            //language=xml
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd" version="3.1">
+              	<display-name>testTransaction</display-name>
+              	<enterprise-beans>
+                      <session>
+                          <ejb-name>TestProducerFieldStaticOnSessionBean</ejb-name>
+                          <ejb-class>org.test.ejb.TestProducerFieldStaticOnSessionBean</ejb-class>
+                          <session-type>Stateless</session-type>
+                          <transaction-type>Container</transaction-type>
+                      </session>
+                      <session>
+                           <ejb-name>TestProducerFieldNonStaticOnSessionBean</ejb-name>
+                           <ejb-class>org.test.ejb.TestProducerFieldNonStaticOnSessionBean</ejb-class>
+                           <session-type>Singleton</session-type>
+                           <transaction-type>Container</transaction-type>
+                      </session>
+                  </enterprise-beans>
+              </ejb-jar>
+              """,
+            sourceSpecs -> sourceSpecs.path("ejb-jar.xml")
+          ),
+          //language=java
+          java(
+            """
+              package com.test;
+              import jakarta.enterprise.inject.Produces;
+
+              public class MySessionBean {
+                  @Produces
+                  private SomeDependency someDependency;
+                  void exampleMethod() {
+                     return;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @DocumentExample
     void addStaticOnProducesMarkedStateless() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What's changed?

- Added a xml scanning to detect the session beans and also apply the recipe to those classes.
- Recipe now updates the classes that are specified in the `ejb-jar.xml` file
- Added new test case to test the xml scanning functionality.

## What's your motivation?

- To create a recipe that can not only be used to add a static variable to session beans  annotated with `@Stateless`, `@Stateful`, or `@Singleton`, but also to those defined in the xml file.

## Any additional context

- Extended the recipe to scan `ejb-jar.xml` for session bean definitions and incorporate these beans in the recipe processing.
- This way it allows the recipe to apply changes to classes that does not have `@Stateless`, `@Stateful`, or `@Singleton`
annotation but are specified as session beans in the XML configuration.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
