### PR TITLE
Change net.wasdev.maven.parent:java8-parent to :parent

### DIFF
--- a/src/main/resources/META-INF/rewrite/ibm-java.yml
+++ b/src/main/resources/META-INF/rewrite/ibm-java.yml
@@ -159,3 +159,14 @@ recipeList:
       groupId: javax.activation
       artifactId: activation
       newConfiguration: compileOnly
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.WasDevMvnChangeParentArtifactId
+displayName: Change `net.wasdev.maven.parent:java8-parent` to `:parent`
+description: This recipe changes the artifactId of the `<parent>` tag in the `pom.xml` from `java8-parent` to `parent`.
+recipeList:
+  - org.openrewrite.maven.ChangeParentPom:
+      oldGroupId: net.wasdev.maven.parent
+      oldArtifactId: java8-parent
+      newArtifactId: parent
+      newVersion: 1.4

--- a/src/test/java/org/openrewrite/java/migrate/WasDevMvnChangeParentArtifactIdTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/WasDevMvnChangeParentArtifactIdTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class WasDevMvnChangeParentArtifactIdTest implements RewriteTest {
+
+    @DocumentExample
+    @Test
+    void mvnChangeParentArtifactId() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.migrate.WasDevMvnChangeParentArtifactId"),
+          //language=XML
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                        <groupId>net.wasdev.maven.parent</groupId>
+                         <artifactId>java8-parent</artifactId>
+                         <version>1.4</version>
+                   </parent>
+                   <artifactId>my-artifact</artifactId>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                        <groupId>net.wasdev.maven.parent</groupId>
+                         <artifactId>parent</artifactId>
+                         <version>1.4</version>
+                   </parent>
+                   <artifactId>my-artifact</artifactId>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeParentArtifactId() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.migrate.WasDevMvnChangeParentArtifactId"),
+          //language=XML
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                        <groupId>net.wasdev.maven.parent</groupId>
+                         <artifactId>parent</artifactId>
+                         <version>1.4</version>
+                   </parent>
+                   <artifactId>my-artifact</artifactId>
+              </project>
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
This PR contains recipe - org.openrewrite.java.migrate.WasDevMvnChangeParentArtifactId.
**Changes** 
```
<parent>
  <groupId>net.wasdev.maven.parent</groupId>
  <artifactId>java8-parent</artifactId>
  <version>1.4</version>
 </parent>
```
```
<parent>
  <groupId>net.wasdev.maven.parent</groupId>
  <artifactId>parent</artifactId>
  <version>1.4</version>
</parent>
```
## What's your motivation?
I have used org.openrewrite.maven.ChangeParentPom for writing this recipe.

## Anything in particular you'd like reviewers to focus on?
This is not a new recipe. I am moving this recipe ```org.openrewrite.maven.liberty.WasDevMvnChangeParentArtifactId``` from ```rewrite-liberty``` repository to this one as it's not closely tied to Liberty migration.

## Anyone you would like to review specifically?
@timtebeek @rlsanders4 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
