### PR TITLE
Only add null case when all values covered

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-21.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-21.yml
@@ -40,6 +40,7 @@ recipeList:
   - org.openrewrite.java.migrate.DeleteDeprecatedFinalize
   - org.openrewrite.java.migrate.RemovedSubjectMethods
   - org.openrewrite.java.migrate.SwitchPatternMatching
+  - org.openrewrite.java.migrate.lang.NullCheckAsSwitchCase
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -141,6 +142,5 @@ description: ->-
 tags:
   - java21
 recipeList:
-  - org.openrewrite.java.migrate.lang.NullCheckAsSwitchCase
   - org.openrewrite.java.migrate.lang.RefineSwitchCases
   - org.openrewrite.java.migrate.lang.SwitchCaseEnumGuardToLabel


### PR DESCRIPTION
## What's changed?
We now only add the null case if all possible input values are covered to avoid compilation issues

## What's your motivation?
Missed this in the original PR casuign compilation to break.

## Anyone you would like to review specifically?
@knutwannheden 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
