### PR TITLE
Fix for `UpdateSdkMan` allowing downgrade of Java version

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java
+++ b/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java
@@ -92,31 +92,25 @@ public class UpdateSdkMan extends Recipe {
                 Pattern pattern = Pattern.compile("java=(.*?)([.a-z]*-.*)");
                 Matcher matcher = pattern.matcher(plainText.getText());
                 if (matcher.find()) {
-                    if (!isRequestedDowngrade(matcher.group(1))) {
-                        String ver = newVersion == null ? matcher.group(1) : newVersion;
-                        String dist = newDistribution == null ? matcher.group(2) : "-" + newDistribution;
-                        String newBasis = ver + dist;
-                        Pattern majorPattern = Pattern.compile("^" + ver + "[.-].*");
-                        LatestRelease releaseComparator = new LatestRelease(dist);
-                        String idealCandidate = readSdkmanJavaCandidates().stream()
-                                .filter(candidate -> majorPattern.matcher(candidate).matches())
-                                .filter(candidate -> releaseComparator.isValid(newBasis, candidate))
-                                .max(releaseComparator)
-                                .orElse(null);
-                        if (idealCandidate != null) {
-                            return plainText.withText(matcher.replaceFirst("java=" + idealCandidate));
-                        }
+                    String ver = newVersion == null ? matcher.group(1) : newVersion;
+                    String dist = newDistribution == null ? matcher.group(2) : "-" + newDistribution;
+                    String newBasis = ver + dist;
+                    Pattern majorPattern = Pattern.compile("^" + ver + "[.-].*");
+                    LatestRelease releaseComparator = new LatestRelease(dist);
+                    String idealCandidate = readSdkmanJavaCandidates().stream()
+                            .filter(candidate -> majorPattern.matcher(candidate).matches())
+                            .filter(candidate -> releaseComparator.isValid(newBasis, candidate))
+                            .max(releaseComparator)
+                            .orElse(null);
+                    if (idealCandidate != null && !isRequestedDowngrade(matcher.group(1) + dist, idealCandidate, dist)) {
+                        return plainText.withText(matcher.replaceFirst("java=" + idealCandidate));
                     }
                 }
                 return sourceFile;
             }
 
-            private boolean isRequestedDowngrade(String currentVersion) {
-                if (newVersion == null || currentVersion.equals(newVersion)) {
-                    return false;
-                }
-                LatestRelease basisComparator = new LatestRelease(null);
-                return basisComparator.compare(null, currentVersion, newVersion) > 0;
+            private boolean isRequestedDowngrade(String currentVersionWithNewDist, String requestedVersionWithDist, String dist) {
+                return new LatestRelease(dist).compare(null, currentVersionWithNewDist, requestedVersionWithDist) > 0;
             }
 
             private List<String> readSdkmanJavaCandidates() {

--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -166,4 +166,17 @@ class UpdateSdkManTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotDowngradeVersionIfAlreadyHighEnough() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateSdkMan("17", null)),
+          text(
+            """
+              java=24-librca
+              """,
+            spec -> spec.path(".sdkmanrc")
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -168,6 +168,38 @@ class UpdateSdkManTest implements RewriteTest {
     }
 
     @Test
+    void upgradeIfNewVersionIsStillSameVersionBasisAndSameDistribution() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateSdkMan("21", null)),
+          text(
+            """
+              java=21.0.6-zulu
+              """,
+            """
+              java=21.0.7-zulu
+              """,
+            spec -> spec.path(".sdkmanrc")
+          )
+        );
+    }
+
+    @Test
+    void upgradeIfNewVersionIsStillSameVersionBasisAndDifferentDistribution() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateSdkMan("23", "amzn")),
+          text(
+            """
+              java=23.0.1-open
+              """,
+            """
+              java=23.0.2-amzn
+              """,
+            spec -> spec.path(".sdkmanrc")
+          )
+        );
+    }
+
+    @Test
     void doNotDowngradeVersionIfAlreadyHighEnoughSameDistribution() {
         rewriteRun(
           spec -> spec.recipe(new UpdateSdkMan("17", null)),

--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -168,12 +168,25 @@ class UpdateSdkManTest implements RewriteTest {
     }
 
     @Test
-    void doNotDowngradeVersionIfAlreadyHighEnough() {
+    void doNotDowngradeVersionIfAlreadyHighEnoughSameDistribution() {
         rewriteRun(
           spec -> spec.recipe(new UpdateSdkMan("17", null)),
           text(
             """
               java=24-librca
+              """,
+            spec -> spec.path(".sdkmanrc")
+          )
+        );
+    }
+
+    @Test
+    void doNotDowngradeVersionIfAlreadyHighEnoughDifferentDistribution() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateSdkMan("23", "zulu")),
+          text(
+            """
+              java=24-amzn
               """,
             spec -> spec.path(".sdkmanrc")
           )


### PR DESCRIPTION
## What's changed?
- Added check for that will compare a potential candidate version & distribution against the current version if it were under the candidate distribution to ensure that it isn't a downgrade in overall version number.

## What's your motivation?
[UpdateSdkMan](https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java) recipe (used by [UpgradeJavaVersion](https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/java/org/openrewrite/java/migrate/UpgradeJavaVersion.java)) can cause a downgrade of Java version when provided with a version number that is lower than the one already in use.

The behaviour should instead mirror that of other version updates called by UpgradeJavaVersion (such as [UpdateMavenProjectPropertyJavaVersion](https://github.com/openrewrite/rewrite/blob/main/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java)), guarding against making changes if the version number already in use is higher than what is requested.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
