### PR TITLE
feat: Prevent migration of singletonMap with null value or null key

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
@@ -70,8 +70,8 @@ public class MigrateCollectionsSingletonMap extends Recipe {
             }
 
             private boolean isNotLiteralNull(J.MethodInvocation m) {
-                return !J.Literal.isLiteralValue(m.getArguments().get(0), null) &&
-                       !J.Literal.isLiteralValue(m.getArguments().get(1), null);
+                return !(J.Literal.isLiteralValue(m.getArguments().get(0), null) ||
+                         J.Literal.isLiteralValue(m.getArguments().get(1), null));
             }            
         });
     }

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
@@ -40,7 +40,7 @@ public class MigrateCollectionsSingletonMap extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Prefer `Map.Of(..)` instead of using `Collections.singletonMap()` in Java 9 or higher.";
+        return "Prefer `Map.of(..)` instead of using `Collections.singletonMap()` in Java 9 or higher.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
@@ -72,7 +72,7 @@ public class MigrateCollectionsSingletonMap extends Recipe {
             private boolean isNotLiteralNull(J.MethodInvocation m) {
                 return !(J.Literal.isLiteralValue(m.getArguments().get(0), null) ||
                          J.Literal.isLiteralValue(m.getArguments().get(1), null));
-            }            
+            }
         });
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
@@ -49,7 +49,7 @@ public class MigrateCollectionsSingletonMap extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                if (SINGLETON_MAP.matches(method)) {
+                if (SINGLETON_MAP.matches(method) && isNotLiteralNull(m)) {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.Map");
                     StringJoiner mapOf = new StringJoiner(", ", "Map.of(", ")");
@@ -68,6 +68,13 @@ public class MigrateCollectionsSingletonMap extends Recipe {
 
                 return m;
             }
+
+            private boolean isNotLiteralNull(J.MethodInvocation m) {
+                return !(m.getArguments().get(0) instanceof J.Literal &&
+                         ((J.Literal) m.getArguments().get(0)).getValue() == null ||
+                         m.getArguments().get(1) instanceof J.Literal &&
+                         ((J.Literal) m.getArguments().get(1)).getValue() == null);
+            }            
         });
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
@@ -70,10 +70,8 @@ public class MigrateCollectionsSingletonMap extends Recipe {
             }
 
             private boolean isNotLiteralNull(J.MethodInvocation m) {
-                return !(m.getArguments().get(0) instanceof J.Literal &&
-                         ((J.Literal) m.getArguments().get(0)).getValue() == null ||
-                         m.getArguments().get(1) instanceof J.Literal &&
-                         ((J.Literal) m.getArguments().get(1)).getValue() == null);
+                return !J.Literal.isLiteralValue(m.getArguments().get(0), null) &&
+                       !J.Literal.isLiteralValue(m.getArguments().get(1), null);
             }            
         });
     }

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMapTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMapTest.java
@@ -85,4 +85,25 @@ class MigrateCollectionsSingletonMapTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/571")
+    @Test
+    void shouldNotConvertLiteralNull() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.*;
+
+                class Test {
+                    Map<String, String> mapWithNullKey = Collections.singletonMap(null, "foo");
+                    Map<String, String> mapWithNullValue = Collections.singletonMap("bar", null);
+                }
+                """
+            ),
+            9
+          )
+        );
+    }    
 }


### PR DESCRIPTION
## What's changed?
The rule `org.openrewrite.java.migrate.util.MigrateCollectionsSingletonMap` also migrated the following cases:
```java
Collections.singletonMap(null, "foo")
Collections.singletonMap("bar", null)
```
to
```java
Map.of(null, "foo")
Map.of("bar", null)
```
which leads to a NullPointerException

## What's your motivation?
There is a closed issue https://github.com/openrewrite/rewrite-migrate-java/issues/571 where it was even mentioned in the comments to apply the same to maps, but the changes were not done in the previous PR.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
