### PR TITLE
Some compilation issues are occuring after running switch pattern matching recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -192,34 +192,19 @@ public class IfElseIfConstructToSwitch extends Recipe {
             StringBuilder switchBody = new StringBuilder("switch (#{any()}) {\n");
             int i = 1;
             if (nullCheckedParameter != null) {
-                Statement statement = getStatement(Objects.requireNonNull(nullCheckedStatement));
-                if (statement instanceof J.Block) {
-                    switchBody.append("case null -> #{}\n");
-                } else {
-                    switchBody.append("case null -> #{any()};\n");
-                }
-                arguments[i++] = statement;
+                switchBody.append("case null -> #{any()};\n");
+                arguments[i++] = getStatement(Objects.requireNonNull(nullCheckedStatement));
             }
             for (Map.Entry<J.InstanceOf, Statement> entry : patternMatchers.entrySet()) {
                 J.InstanceOf instanceOf = entry.getKey();
-                Statement statement = getStatement(entry.getValue());
-                if (statement instanceof J.Block) {
-                    switchBody.append("case #{}#{} -> #{}\n");
-                } else {
-                    switchBody.append("case #{}#{} -> #{any()};\n");
-                }
+                switchBody.append("case #{}#{} -> #{any()};\n");
                 arguments[i++] = getClassName(instanceOf);
                 arguments[i++] = getPattern(instanceOf);
-                arguments[i++] = statement;
+                arguments[i++] = getStatement(entry.getValue());
             }
             if (else_ != null) {
-                Statement statement = getStatement(else_);
-                if (statement instanceof J.Block) {
-                    switchBody.append("default -> #{}\n");
-                } else {
-                    switchBody.append("default -> #{any()};\n");
-                }
-                arguments[i] = statement;
+                switchBody.append("default -> #{any()};\n");
+                arguments[i] = getStatement(else_);
             } else {
                 switchBody.append("default -> #{}\n");
                 arguments[i] = createEmptyBlock();

--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -76,7 +76,9 @@ public class IfElseIfConstructToSwitch extends Recipe {
                             if (case_.getBody() instanceof J.Block &&
                                     ((J.Block) case_.getBody()).getStatements().isEmpty() &&
                                     !((J.Block) case_.getBody()).getEnd().isEmpty()) {
-                                return case_.withBody(((J.Block) case_.getBody()).withPrefix(Space.SINGLE_SPACE).withEnd(Space.EMPTY));
+                                return case_.withBody(((J.Block) case_.getBody())
+                                        .withPrefix(Space.SINGLE_SPACE)
+                                        .withEnd(Space.EMPTY));
                             }
                             return case_.withBody(case_.getBody().withPrefix(Space.SINGLE_SPACE));
                         }
@@ -218,7 +220,7 @@ public class IfElseIfConstructToSwitch extends Recipe {
             if (else_ != null) {
                 arguments[i] = getStatement(else_);
             } else {
-                arguments[i] = createEmptyBlock().withPrefix(Space.SINGLE_SPACE);
+                arguments[i] = createEmptyBlock();
             }
             switchBody.append("}\n");
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -75,7 +75,7 @@ public class IfElseIfConstructToSwitch extends Recipe {
                             if (case_.getBody() instanceof J.Block &&
                                     ((J.Block) case_.getBody()).getStatements().isEmpty() &&
                                     !((J.Block) case_.getBody()).getEnd().isEmpty()) {
-                                return case_.withBody(((J.Block) case_.getBody()).withEnd(Space.EMPTY));
+                                return case_.withBody(((J.Block) case_.getBody()).withPrefix(Space.SINGLE_SPACE).withEnd(Space.EMPTY));
                             }
                             return case_.withBody(case_.getBody().withPrefix(Space.SINGLE_SPACE));
                         }
@@ -202,12 +202,11 @@ public class IfElseIfConstructToSwitch extends Recipe {
                 arguments[i++] = getPattern(instanceOf);
                 arguments[i++] = getStatement(entry.getValue());
             }
+            switchBody.append("default -> #{any()};\n");
             if (else_ != null) {
-                switchBody.append("default -> #{any()};\n");
                 arguments[i] = getStatement(else_);
             } else {
-                switchBody.append("default -> #{}\n");
-                arguments[i] = createEmptyBlock();
+                arguments[i] = createEmptyBlock().withPrefix(Space.SINGLE_SPACE);
             }
             switchBody.append("}\n");
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/NullCheckAsSwitchCase.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/NullCheckAsSwitchCase.java
@@ -107,7 +107,10 @@ public class NullCheckAsSwitchCase extends Recipe {
 
             private J.Case createNullCase(J.Switch aSwitch, Statement whenNull) {
                 if (whenNull instanceof J.Block && ((J.Block) whenNull).getStatements().size() == 1) {
-                    whenNull = ((J.Block) whenNull).getStatements().get(0);
+                    Statement firstStatement = ((J.Block) whenNull).getStatements().get(0);
+                    if (firstStatement instanceof Expression || firstStatement instanceof J.Throw) {
+                        whenNull = firstStatement;
+                    }
                 }
                 String semicolon = whenNull instanceof J.Block ? "" : ";";
                 J.Switch switchWithNullCase = JavaTemplate.apply(

--- a/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
@@ -245,52 +245,52 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
     @Test
     void worksWithGenericsAndArrays() {
         rewriteRun(
-                //language=java
-                java(
-                """
-                        public class AnotherClass {
-                            public static class SubClass<T> {}
-                        }
-                        """
-                ),
-                //language=java
-                java(
-                        """
-                          class Test {
-                              static String formatter(Object obj) {
-                                  String formatted = "initialValue";
-                                  if (obj == null) {
-                                      formatted = "null";
-                                  } else if (obj instanceof String str)
-                                      formatted = String.format("string %s", str);
-                                  else if (obj instanceof String[] strings) {
-                                      formatted = String.format("strings %s", (Object) strings);
-                                  } else if (obj instanceof Class<?> clazz) {
-                                      formatted = String.format("class %s", clazz.getSimpleName());
-                                  } else if (obj instanceof AnotherClass.SubClass<?> subClazz) {
-                                      formatted = String.format("sub-class %s", subClazz);
-                                  }
-                                  return formatted;
-                              }
-                          }
-                          """,
-                        """
-                          class Test {
-                              static String formatter(Object obj) {
-                                  String formatted = "initialValue";
-                                  switch (obj) {
-                                      case null -> formatted = "null";
-                                      case String str -> formatted = String.format("string %s", str);
-                                      case String[] strings -> formatted = String.format("strings %s", (Object) strings);
-                                      case Class<?> clazz -> formatted = String.format("class %s", clazz.getSimpleName());
-                                      case AnotherClass.SubClass<?> subClazz -> formatted = String.format("sub-class %s", subClazz);
-                                      default -> {}
-                                  }
-                                  return formatted;
-                              }
-                          }
-                          """
-                )
+          //language=java
+          java(
+            """
+              public class AnotherClass {
+                  public static class SubClass<T> {}
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      if (obj == null) {
+                          formatted = "null";
+                      } else if (obj instanceof String str)
+                          formatted = String.format("string %s", str);
+                      else if (obj instanceof String[] strings) {
+                          formatted = String.format("strings %s", (Object) strings);
+                      } else if (obj instanceof Class<?> clazz) {
+                          formatted = String.format("class %s", clazz.getSimpleName());
+                      } else if (obj instanceof AnotherClass.SubClass<?> subClazz) {
+                          formatted = String.format("sub-class %s", subClazz);
+                      }
+                      return formatted;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case null -> formatted = "null";
+                          case String str -> formatted = String.format("string %s", str);
+                          case String[] strings -> formatted = String.format("strings %s", (Object) strings);
+                          case Class<?> clazz -> formatted = String.format("class %s", clazz.getSimpleName());
+                          case AnotherClass.SubClass<?> subClazz -> formatted = String.format("sub-class %s", subClazz);
+                          default -> {}
+                      }
+                      return formatted;
+                  }
+              }
+              """
+          )
         );
     }
 
@@ -393,83 +393,83 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
     @Test
     void singleExpressionsUnwrapped() {
         rewriteRun(
-                //language=java
-                java(
-                        """
-                          class Test {
-                              static String formatter(Object obj) {
-                                  String formatted = "initialValue";
-                                  if (obj == null) {
-                                      formatted = "null";
-                                  } else if (obj instanceof Integer i)
-                                      formatted = String.format("int %d", i);
-                                  else if (obj instanceof Long l) {
-                                      formatted = String.format("long %d", l);
-                                  } else {
-                                      formatted = "unknown";
-                                  }
-                                  return formatted;
-                              }
-                          }
-                          """,
-                        """
-                          class Test {
-                              static String formatter(Object obj) {
-                                  String formatted = "initialValue";
-                                  switch (obj) {
-                                      case null -> formatted = "null";
-                                      case Integer i -> formatted = String.format("int %d", i);
-                                      case Long l -> formatted = String.format("long %d", l);
-                                      default -> formatted = "unknown";
-                                  }
-                                  return formatted;
-                              }
-                          }
-                          """
-                )
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      if (obj == null) {
+                          formatted = "null";
+                      } else if (obj instanceof Integer i)
+                          formatted = String.format("int %d", i);
+                      else if (obj instanceof Long l) {
+                          formatted = String.format("long %d", l);
+                      } else {
+                          formatted = "unknown";
+                      }
+                      return formatted;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case null -> formatted = "null";
+                          case Integer i -> formatted = String.format("int %d", i);
+                          case Long l -> formatted = String.format("long %d", l);
+                          default -> formatted = "unknown";
+                      }
+                      return formatted;
+                  }
+              }
+              """
+          )
         );
     }
 
     @Test
     void singleStatementsNotUnwrapped() {
         rewriteRun(
-                //language=java
-                java(
-                        """
-                          class Test {
-                              static String formatter(Object obj) {
-                                  String formatted = "initialValue";
-                                  if (obj == null) {
-                                      formatted = "null";
-                                  } else if (obj instanceof Long l) {
-                                      if (formatted.equals("initialValue")) {
-                                          formatted = String.format("long %d", l);
-                                      }
-                                  } else {
-                                      formatted = "unknown";
-                                  }
-                                  return formatted;
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      if (obj == null) {
+                          formatted = "null";
+                      } else if (obj instanceof Long l) {
+                          if (formatted.equals("initialValue")) {
+                              formatted = String.format("long %d", l);
+                          }
+                      } else {
+                          formatted = "unknown";
+                      }
+                      return formatted;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case null -> formatted = "null";
+                          case Long l -> {
+                              if (formatted.equals("initialValue")) {
+                                  formatted = String.format("long %d", l);
                               }
                           }
-                          """,
-                        """
-                          class Test {
-                              static String formatter(Object obj) {
-                                  String formatted = "initialValue";
-                                  switch (obj) {
-                                      case null -> formatted = "null";
-                                      case Long l -> {
-                                          if (formatted.equals("initialValue")) {
-                                              formatted = String.format("long %d", l);
-                                          }
-                                      }
-                                      default -> formatted = "unknown";
-                                  }
-                                  return formatted;
-                              }
-                          }
-                          """
-                )
+                          default -> formatted = "unknown";
+                      }
+                      return formatted;
+                  }
+              }
+              """
+          )
         );
     }
 
@@ -478,74 +478,74 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
         @Test
         void throwsSingleLine() {
             rewriteRun(
-                    //language=java
-                    java(
-                            """
-                              class Test {
-                                  static String formatter(Object obj) {
-                                      String formatted = "initialValue";
-                                      if (obj == null)
-                                          throw new IllegalArgumentException("You did not enter the test yet");
-                                      else if (obj instanceof Long l) {
-                                          formatted = String.format("long %d", l);
-                                      } else {
-                                          formatted = "unknown";
-                                      }
-                                      return formatted;
-                                  }
-                              }
-                              """,
-                            """
-                              class Test {
-                                  static String formatter(Object obj) {
-                                      String formatted = "initialValue";
-                                      switch (obj) {
-                                          case null -> throw new IllegalArgumentException("You did not enter the test yet");
-                                          case Long l -> formatted = String.format("long %d", l);
-                                          default -> formatted = "unknown";
-                                      }
-                                      return formatted;
-                                  }
-                              }
-                              """
-                    )
+              //language=java
+              java(
+                """
+                  class Test {
+                      static String formatter(Object obj) {
+                          String formatted = "initialValue";
+                          if (obj == null)
+                              throw new IllegalArgumentException("You did not enter the test yet");
+                          else if (obj instanceof Long l) {
+                              formatted = String.format("long %d", l);
+                          } else {
+                              formatted = "unknown";
+                          }
+                          return formatted;
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      static String formatter(Object obj) {
+                          String formatted = "initialValue";
+                          switch (obj) {
+                              case null -> throw new IllegalArgumentException("You did not enter the test yet");
+                              case Long l -> formatted = String.format("long %d", l);
+                              default -> formatted = "unknown";
+                          }
+                          return formatted;
+                      }
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void throwsFromBlock() {
             rewriteRun(
-                    //language=java
-                    java(
-                            """
-                              class Test {
-                                  static String formatter(Object obj) {
-                                      String formatted = "initialValue";
-                                      if (obj == null) {
-                                          throw new IllegalArgumentException("You did not enter the test yet");
-                                      } else if (obj instanceof Long l) {
-                                          formatted = String.format("long %d", l);
-                                      } else {
-                                          formatted = "unknown";
-                                      }
-                                      return formatted;
-                                  }
-                              }
-                              """,
-                            """
-                              class Test {
-                                  static String formatter(Object obj) {
-                                      String formatted = "initialValue";
-                                      switch (obj) {
-                                          case null -> throw new IllegalArgumentException("You did not enter the test yet");
-                                          case Long l -> formatted = String.format("long %d", l);
-                                          default -> formatted = "unknown";
-                                      }
-                                      return formatted;
-                                  }
-                              }
-                              """
-                    )
+              //language=java
+              java(
+                """
+                  class Test {
+                      static String formatter(Object obj) {
+                          String formatted = "initialValue";
+                          if (obj == null) {
+                              throw new IllegalArgumentException("You did not enter the test yet");
+                          } else if (obj instanceof Long l) {
+                              formatted = String.format("long %d", l);
+                          } else {
+                              formatted = "unknown";
+                          }
+                          return formatted;
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      static String formatter(Object obj) {
+                          String formatted = "initialValue";
+                          switch (obj) {
+                              case null -> throw new IllegalArgumentException("You did not enter the test yet");
+                              case Long l -> formatted = String.format("long %d", l);
+                              default -> formatted = "unknown";
+                          }
+                          return formatted;
+                      }
+                  }
+                  """
+              )
             );
         }
 
@@ -743,89 +743,89 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
         @Test
         void noSwitchBlockWhenNullBlockReturns() {
             rewriteRun(
-                    //language=java
-                    java(
-                        """
-                        class Test {
-                            static String formatter(Object obj) {
-                                String formatted = "initialValue";
-                                if (obj == null) {
-                                    return "null";
-                                } else if (obj instanceof Integer i)
-                                    formatted = String.format("int %d", i);
-                                else if (obj instanceof Long l) {
-                                    formatted = String.format("long %d", l);
-                                } else if (obj instanceof Double d) {
-                                    formatted = String.format("double %f", d);
-                                } else if (obj instanceof String s) {
-                                    String str = "String";
-                                    formatted = String.format("%s %s", str, s);
-                                }
-                                return formatted;
-                            }
-                        }
-                        """
-                    )
+              //language=java
+              java(
+                """
+                  class Test {
+                      static String formatter(Object obj) {
+                          String formatted = "initialValue";
+                          if (obj == null) {
+                              return "null";
+                          } else if (obj instanceof Integer i)
+                              formatted = String.format("int %d", i);
+                          else if (obj instanceof Long l) {
+                              formatted = String.format("long %d", l);
+                          } else if (obj instanceof Double d) {
+                              formatted = String.format("double %f", d);
+                          } else if (obj instanceof String s) {
+                              String str = "String";
+                              formatted = String.format("%s %s", str, s);
+                          }
+                          return formatted;
+                      }
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void noSwitchBlockWhenInstanceOfBlockReturns() {
             rewriteRun(
-                    //language=java
-                    java(
-                         """
-                         class Test {
-                             static String formatter(Object obj) {
-                                 String formatted = "initialValue";
-                                 if (obj == null) {
-                                     formatted = "null";
-                                 } else if (obj instanceof Integer i)
-                                     return String.format("int %d", i);
-                                 else if (obj instanceof Long l) {
-                                     formatted = String.format("long %d", l);
-                                 } else if (obj instanceof Double d) {
-                                     formatted = String.format("double %f", d);
-                                 } else if (obj instanceof String s) {
-                                     String str = "String";
-                                     formatted = String.format("%s %s", str, s);
-                                 }
-                                 return formatted;
-                             }
-                         }
-                         """
-                    )
+              //language=java
+              java(
+                """
+                  class Test {
+                      static String formatter(Object obj) {
+                          String formatted = "initialValue";
+                          if (obj == null) {
+                              formatted = "null";
+                          } else if (obj instanceof Integer i)
+                              return String.format("int %d", i);
+                          else if (obj instanceof Long l) {
+                              formatted = String.format("long %d", l);
+                          } else if (obj instanceof Double d) {
+                              formatted = String.format("double %f", d);
+                          } else if (obj instanceof String s) {
+                              String str = "String";
+                              formatted = String.format("%s %s", str, s);
+                          }
+                          return formatted;
+                      }
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void noSwitchBlockWhenElseBlockReturns() {
             rewriteRun(
-                    //language=java
-                    java(
-                            """
-                            class Test {
-                                static String formatter(Object obj) {
-                                    String formatted = "initialValue";
-                                    if (obj == null) {
-                                        formatted = "null";
-                                    } else if (obj instanceof Integer i)
-                                        formatted = String.format("int %d", i);
-                                    else if (obj instanceof Long l) {
-                                        formatted = String.format("long %d", l);
-                                    } else if (obj instanceof Double d) {
-                                        formatted = String.format("double %f", d);
-                                    } else if (obj instanceof String s) {
-                                        String str = "String";
-                                        formatted = String.format("%s %s", str, s);
-                                    } else {
-                                        return "Unknown test result";
-                                    }
-                                    return formatted;
-                                }
-                            }
-                            """
-                    )
+              //language=java
+              java(
+                """
+                  class Test {
+                      static String formatter(Object obj) {
+                          String formatted = "initialValue";
+                          if (obj == null) {
+                              formatted = "null";
+                          } else if (obj instanceof Integer i)
+                              formatted = String.format("int %d", i);
+                          else if (obj instanceof Long l) {
+                              formatted = String.format("long %d", l);
+                          } else if (obj instanceof Double d) {
+                              formatted = String.format("double %f", d);
+                          } else if (obj instanceof String s) {
+                              String str = "String";
+                              formatted = String.format("%s %s", str, s);
+                          } else {
+                              return "Unknown test result";
+                          }
+                          return formatted;
+                      }
+                  }
+                  """
+              )
             );
         }
     }

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMapTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMapTest.java
@@ -105,5 +105,5 @@ class MigrateCollectionsSingletonMapTest implements RewriteTest {
             9
           )
         );
-    }    
+    }
 }


### PR DESCRIPTION
## What's changed?
If any of the branches returns a value, we do (for now) not convert it to a switch as it is invalid. 
Besides this change: If any of the values throws, we do allow this. 
We used to unwrap if-statements if they were the only one -> no longer happening as only expressions and Throws are allowed to be written in that syntax.

I know we can enhance to do return from switch but I first want to stabilize the existing recipe before working on: 
- https://github.com/openrewrite/rewrite-migrate-java/issues/776
- https://github.com/openrewrite/rewrite-migrate-java/issues/718 

## What's your motivation?
Clean up compilation issues occuring during run of the recipe.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
