### PR TITLE
Do not add explicit `Record` class import if using `var` keyword

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/lang/ExplicitRecordImportTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/ExplicitRecordImportTest.java
@@ -23,7 +23,6 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.javaVersion;
 
 class ExplicitRecordImportTest implements RewriteTest {
 
@@ -91,8 +90,7 @@ class ExplicitRecordImportTest implements RewriteTest {
                       }
                   }
               }
-              """,
-            s -> s.markers(javaVersion(17))
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/lang/ExplicitRecordImportTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/ExplicitRecordImportTest.java
@@ -98,7 +98,37 @@ class ExplicitRecordImportTest implements RewriteTest {
     }
 
     @Test
-    void noChangeIfAlreadyFullyQualified() {
+    void genericUseOfRecordClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.acme.music;
+
+              import java.util.List;
+
+              class Test {
+                  List<Record> records;
+              }
+              """,
+            """
+              package com.acme.music;
+
+              import com.acme.music.Record;
+
+              import java.util.List;
+
+              class Test {
+                  List<Record> records;
+              }
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void documentChangeWhenFullyQualified() {
         rewriteRun(
           //language=java
           java(


### PR DESCRIPTION
## What's changed?
Use `FindTypes.findAssignable` to find how record classes are being used, and exclude usages of `var` before adding import.

## What's your motivation?
We saw imports added when using `var someImpliedRecord`, which was unnecessary.

## Anything in particular you'd like reviewers to focus on?
Possible there's other places `Record` could be present, like `List<Record>` that we still need to handle.