### PR TITLE
Correct groupId for `jakarta.annotation:jakarta.annotation-api` upgrade

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -391,7 +391,7 @@ displayName: Update Jakarta EE annotation Dependencies to 2.1.x.
 description: Update Jakarta EE annotation Dependencies to 2.1.x.
 recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: jakarta.annotations
+      groupId: jakarta.annotation
       artifactId: jakarta.annotation-api
       newVersion: 2.1.x
   - org.openrewrite.java.ChangeType:


### PR DESCRIPTION
The `groupId` was listed as `jakarta.annotations`, but the actual `groupId` is `jakarta.annotation`
