### PR TITLE
feat: add recipe that prefers guava ranges

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
@@ -27,13 +27,11 @@ import org.openrewrite.java.template.RecipeDescriptor;
         description = "Simplifies hand crafted range checks."
 )
 public class UseRanges {
-
     @RecipeDescriptor(
             name = "Replace `from.compareTo(candidate) <= 0 && candidate.compareTo(to) <= 0` with a guava `Range.closed(from, to).contains(candidate)`",
             description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
     )
     public static class RangeClosed<T extends Comparable<T>> {
-
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
             return from.compareTo(candidate) <= 0 &&
@@ -42,21 +40,18 @@ public class UseRanges {
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
-
             return from.compareTo(candidate) <= 0 &&
                     to.compareTo(candidate) >= 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
-
             return candidate.compareTo(from) >= 0 &&
                     candidate.compareTo(to) <= 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
-
             return candidate.compareTo(to) <= 0 &&
                     from.compareTo(candidate) <= 0;
         }
@@ -69,37 +64,32 @@ public class UseRanges {
     }
 
     @RecipeDescriptor(
-        name = "Replace `from.compareTo(candidate) < 0 && candidate.compareTo(to) < 0` with a guava `Range.open(from, to).contains(candidate)`",
-        description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
+            name = "Replace `from.compareTo(candidate) < 0 && candidate.compareTo(to) < 0` with a guava `Range.open(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
     )
     public static class RangeOpen<T extends Comparable<T>> {
-
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
-
             return from.compareTo(candidate) < 0 &&
-                candidate.compareTo(to) < 0;
+                    candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
-
             return from.compareTo(candidate) < 0 &&
-                to.compareTo(candidate) > 0;
+                    to.compareTo(candidate) > 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
-
             return candidate.compareTo(from) > 0 &&
-                candidate.compareTo(to) < 0;
+                    candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
-
             return candidate.compareTo(to) < 0 &&
-                from.compareTo(candidate) < 0;
+                    from.compareTo(candidate) < 0;
         }
 
         @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
@@ -110,37 +100,32 @@ public class UseRanges {
     }
 
     @RecipeDescriptor(
-        name = "Replace `from.compareTo(candidate) <= 0 && candidate.compareTo(to) < 0` with a guava `Range.closedOpen(from, to).contains(candidate)`",
-        description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
+            name = "Replace `from.compareTo(candidate) <= 0 && candidate.compareTo(to) < 0` with a guava `Range.closedOpen(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
     )
     public static class RangeClosedOpen<T extends Comparable<T>> {
-
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
-
             return from.compareTo(candidate) <= 0 &&
-                candidate.compareTo(to) < 0;
+                    candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
-
             return from.compareTo(candidate) <= 0 &&
-                to.compareTo(candidate) > 0;
+                    to.compareTo(candidate) > 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
-
             return candidate.compareTo(from) >= 0 &&
-                candidate.compareTo(to) < 0;
+                    candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
-
             return candidate.compareTo(to) < 0 &&
-                from.compareTo(candidate) <= 0;
+                    from.compareTo(candidate) <= 0;
         }
 
         @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
@@ -151,37 +136,32 @@ public class UseRanges {
     }
 
     @RecipeDescriptor(
-        name = "Replace `from.compareTo(candidate) < 0 && candidate.compareTo(to) <= 0` with a guava `Range.openClosed(from, to).contains(candidate)`",
-        description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
+            name = "Replace `from.compareTo(candidate) < 0 && candidate.compareTo(to) <= 0` with a guava `Range.openClosed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
     )
     public static class RangeOpenClosed<T extends Comparable<T>> {
-
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
-
             return from.compareTo(candidate) < 0 &&
-                candidate.compareTo(to) <= 0;
+                    candidate.compareTo(to) <= 0;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
-
             return from.compareTo(candidate) < 0 &&
-                to.compareTo(candidate) >= 0;
+                    to.compareTo(candidate) >= 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
-
             return candidate.compareTo(from) > 0 &&
-                candidate.compareTo(to) <= 0;
+                    candidate.compareTo(to) <= 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
-
             return candidate.compareTo(to) <= 0 &&
-                from.compareTo(candidate) < 0;
+                    from.compareTo(candidate) < 0;
         }
 
         @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
@@ -196,28 +176,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
     )
     public static class RangeClosedPrimitiveInt {
-
         @BeforeTemplate
         boolean simple(int from, int candidate, int to) {
-
             return from <= candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(int from, int candidate, int to) {
-
             return from <= candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(int from, int candidate, int to) {
-
             return candidate >= from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(int from, int candidate, int to) {
-
             return candidate <= to && from <= candidate;
         }
 
@@ -233,28 +208,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
     )
     public static class RangeOpenPrimitiveInt {
-
         @BeforeTemplate
         boolean simple(int from, int candidate, int to) {
-
             return from < candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(int from, int candidate, int to) {
-
             return from < candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(int from, int candidate, int to) {
-
             return candidate > from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(int from, int candidate, int to) {
-
             return candidate < to && from < candidate;
         }
 
@@ -270,28 +240,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
     )
     public static class RangeClosedOpenPrimitiveInt {
-
         @BeforeTemplate
         boolean simple(int from, int candidate, int to) {
-
             return from <= candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(int from, int candidate, int to) {
-
             return from <= candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(int from, int candidate, int to) {
-
             return candidate >= from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(int from, int candidate, int to) {
-
             return candidate < to && from <= candidate;
         }
 
@@ -307,28 +272,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
     )
     public static class RangeOpenClosedPrimitiveInt {
-
         @BeforeTemplate
         boolean simple(int from, int candidate, int to) {
-
             return from < candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(int from, int candidate, int to) {
-
             return from < candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(int from, int candidate, int to) {
-
             return candidate > from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean flipped(int from, int candidate, int to) {
-
             return candidate <= to && from < candidate;
         }
 
@@ -344,28 +304,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
     )
     public static class RangeClosedPrimitiveDouble {
-
         @BeforeTemplate
         boolean simple(double from, double candidate, double to) {
-
             return from <= candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(double from, double candidate, double to) {
-
             return from <= candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(double from, double candidate, double to) {
-
             return candidate >= from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(double from, double candidate, double to) {
-
             return candidate <= to && from <= candidate;
         }
 
@@ -381,28 +336,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
     )
     public static class RangeOpenPrimitiveDouble {
-
         @BeforeTemplate
         boolean simple(double from, double candidate, double to) {
-
             return from < candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(double from, double candidate, double to) {
-
             return from < candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(double from, double candidate, double to) {
-
             return candidate > from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(double from, double candidate, double to) {
-
             return candidate < to && from < candidate;
         }
 
@@ -418,28 +368,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
     )
     public static class RangeClosedOpenPrimitiveDouble {
-
         @BeforeTemplate
         boolean simple(double from, double candidate, double to) {
-
             return from <= candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(double from, double candidate, double to) {
-
             return from <= candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(double from, double candidate, double to) {
-
             return candidate >= from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(double from, double candidate, double to) {
-
             return candidate < to && from <= candidate;
         }
 
@@ -455,28 +400,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
     )
     public static class RangeOpenClosedPrimitiveDouble {
-
         @BeforeTemplate
         boolean simple(double from, double candidate, double to) {
-
             return from < candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(double from, double candidate, double to) {
-
             return from < candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(double from, double candidate, double to) {
-
             return candidate > from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean flipped(double from, double candidate, double to) {
-
             return candidate <= to && from < candidate;
         }
 
@@ -492,28 +432,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
     )
     public static class RangeClosedPrimitiveFloat {
-
         @BeforeTemplate
         boolean simple(float from, float candidate, float to) {
-
             return from <= candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(float from, float candidate, float to) {
-
             return from <= candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(float from, float candidate, float to) {
-
             return candidate >= from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(float from, float candidate, float to) {
-
             return candidate <= to && from <= candidate;
         }
 
@@ -529,28 +464,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
     )
     public static class RangeOpenPrimitiveFloat {
-
         @BeforeTemplate
         boolean simple(float from, float candidate, float to) {
-
             return from < candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(float from, float candidate, float to) {
-
             return from < candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(float from, float candidate, float to) {
-
             return candidate > from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(float from, float candidate, float to) {
-
             return candidate < to && from < candidate;
         }
 
@@ -566,28 +496,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
     )
     public static class RangeClosedOpenPrimitiveFloat {
-
         @BeforeTemplate
         boolean simple(float from, float candidate, float to) {
-
             return from <= candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(float from, float candidate, float to) {
-
             return from <= candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(float from, float candidate, float to) {
-
             return candidate >= from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(float from, float candidate, float to) {
-
             return candidate < to && from <= candidate;
         }
 
@@ -603,28 +528,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
     )
     public static class RangeOpenClosedPrimitiveFloat {
-
         @BeforeTemplate
         boolean simple(float from, float candidate, float to) {
-
             return from < candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(float from, float candidate, float to) {
-
             return from < candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(float from, float candidate, float to) {
-
             return candidate > from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean flipped(float from, float candidate, float to) {
-
             return candidate <= to && from < candidate;
         }
 
@@ -640,28 +560,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
     )
     public static class RangeClosedPrimitiveShort {
-
         @BeforeTemplate
         boolean simple(short from, short candidate, short to) {
-
             return from <= candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(short from, short candidate, short to) {
-
             return from <= candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(short from, short candidate, short to) {
-
             return candidate >= from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(short from, short candidate, short to) {
-
             return candidate <= to && from <= candidate;
         }
 
@@ -677,28 +592,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
     )
     public static class RangeOpenPrimitiveShort {
-
         @BeforeTemplate
         boolean simple(short from, short candidate, short to) {
-
             return from < candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(short from, short candidate, short to) {
-
             return from < candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(short from, short candidate, short to) {
-
             return candidate > from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(short from, short candidate, short to) {
-
             return candidate < to && from < candidate;
         }
 
@@ -714,28 +624,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
     )
     public static class RangeClosedOpenPrimitiveShort {
-
         @BeforeTemplate
         boolean simple(short from, short candidate, short to) {
-
             return from <= candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(short from, short candidate, short to) {
-
             return from <= candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(short from, short candidate, short to) {
-
             return candidate >= from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(short from, short candidate, short to) {
-
             return candidate < to && from <= candidate;
         }
 
@@ -751,28 +656,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
     )
     public static class RangeOpenClosedPrimitiveShort {
-
         @BeforeTemplate
         boolean simple(short from, short candidate, short to) {
-
             return from < candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(short from, short candidate, short to) {
-
             return from < candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(short from, short candidate, short to) {
-
             return candidate > from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean flipped(short from, short candidate, short to) {
-
             return candidate <= to && from < candidate;
         }
 
@@ -788,28 +688,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
     )
     public static class RangeClosedPrimitiveLong {
-
         @BeforeTemplate
         boolean simple(long from, long candidate, long to) {
-
             return from <= candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(long from, long candidate, long to) {
-
             return from <= candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(long from, long candidate, long to) {
-
             return candidate >= from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(long from, long candidate, long to) {
-
             return candidate <= to && from <= candidate;
         }
 
@@ -825,28 +720,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
     )
     public static class RangeOpenPrimitiveLong {
-
         @BeforeTemplate
         boolean simple(long from, long candidate, long to) {
-
             return from < candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(long from, long candidate, long to) {
-
             return from < candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(long from, long candidate, long to) {
-
             return candidate > from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(long from, long candidate, long to) {
-
             return candidate < to && from < candidate;
         }
 
@@ -862,28 +752,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
     )
     public static class RangeClosedOpenPrimitiveLong {
-
         @BeforeTemplate
         boolean simple(long from, long candidate, long to) {
-
             return from <= candidate && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOnTheRight(long from, long candidate, long to) {
-
             return from <= candidate && to > candidate;
         }
 
         @BeforeTemplate
         boolean candidateOnTheLeft(long from, long candidate, long to) {
-
             return candidate >= from && candidate < to;
         }
 
         @BeforeTemplate
         boolean candidateOutside(long from, long candidate, long to) {
-
             return candidate < to && from <= candidate;
         }
 
@@ -899,28 +784,23 @@ public class UseRanges {
             description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
     )
     public static class RangeOpenClosedPrimitiveLong {
-
         @BeforeTemplate
         boolean simple(long from, long candidate, long to) {
-
             return from < candidate && candidate <= to;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(long from, long candidate, long to) {
-
             return from < candidate && to >= candidate;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(long from, long candidate, long to) {
-
             return candidate > from && candidate <= to;
         }
 
         @BeforeTemplate
         boolean flipped(long from, long candidate, long to) {
-
             return candidate <= to && from < candidate;
         }
 
@@ -930,5 +810,4 @@ public class UseRanges {
             return Range.openClosed(from, to).contains(candidate);
         }
     }
-
 }

--- a/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
@@ -36,29 +36,29 @@ public class UseRanges {
 
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
-            return from.compareTo(candidate) <= 0
-                    && candidate.compareTo(to) <= 0;
+            return from.compareTo(candidate) <= 0 &&
+                    candidate.compareTo(to) <= 0;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
 
-            return from.compareTo(candidate) <= 0
-                    && to.compareTo(candidate) >= 0;
+            return from.compareTo(candidate) <= 0 &&
+                    to.compareTo(candidate) >= 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
 
-            return candidate.compareTo(from) >= 0
-                    && candidate.compareTo(to) <= 0;
+            return candidate.compareTo(from) >= 0 &&
+                    candidate.compareTo(to) <= 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
 
-            return candidate.compareTo(to) <= 0
-                    && from.compareTo(candidate) <= 0;
+            return candidate.compareTo(to) <= 0 &&
+                    from.compareTo(candidate) <= 0;
         }
 
         @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
@@ -77,29 +77,29 @@ public class UseRanges {
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
 
-            return from.compareTo(candidate) < 0
-                && candidate.compareTo(to) < 0;
+            return from.compareTo(candidate) < 0 &&
+                candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
 
-            return from.compareTo(candidate) < 0
-                && to.compareTo(candidate) > 0;
+            return from.compareTo(candidate) < 0 &&
+                to.compareTo(candidate) > 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
 
-            return candidate.compareTo(from) > 0
-                && candidate.compareTo(to) < 0;
+            return candidate.compareTo(from) > 0 &&
+                candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
 
-            return candidate.compareTo(to) < 0
-                && from.compareTo(candidate) < 0;
+            return candidate.compareTo(to) < 0 &&
+                from.compareTo(candidate) < 0;
         }
 
         @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
@@ -118,29 +118,29 @@ public class UseRanges {
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
 
-            return from.compareTo(candidate) <= 0
-                && candidate.compareTo(to) < 0;
+            return from.compareTo(candidate) <= 0 &&
+                candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
 
-            return from.compareTo(candidate) <= 0
-                && to.compareTo(candidate) > 0;
+            return from.compareTo(candidate) <= 0 &&
+                to.compareTo(candidate) > 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
 
-            return candidate.compareTo(from) >= 0
-                && candidate.compareTo(to) < 0;
+            return candidate.compareTo(from) >= 0 &&
+                candidate.compareTo(to) < 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
 
-            return candidate.compareTo(to) < 0
-                && from.compareTo(candidate) <= 0;
+            return candidate.compareTo(to) < 0 &&
+                from.compareTo(candidate) <= 0;
         }
 
         @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
@@ -159,29 +159,29 @@ public class UseRanges {
         @BeforeTemplate
         boolean simple(T from, T candidate, T to) {
 
-            return from.compareTo(candidate) < 0
-                && candidate.compareTo(to) <= 0;
+            return from.compareTo(candidate) < 0 &&
+                candidate.compareTo(to) <= 0;
         }
 
         @BeforeTemplate
         boolean candidateAsArgument(T from, T candidate, T to) {
 
-            return from.compareTo(candidate) < 0
-                && to.compareTo(candidate) >= 0;
+            return from.compareTo(candidate) < 0 &&
+                to.compareTo(candidate) >= 0;
         }
 
         @BeforeTemplate
         boolean candidateAsBase(T from, T candidate, T to) {
 
-            return candidate.compareTo(from) > 0
-                && candidate.compareTo(to) <= 0;
+            return candidate.compareTo(from) > 0 &&
+                candidate.compareTo(to) <= 0;
         }
 
         @BeforeTemplate
         boolean flipped(T from, T candidate, T to) {
 
-            return candidate.compareTo(to) <= 0
-                && from.compareTo(candidate) < 0;
+            return candidate.compareTo(to) <= 0 &&
+                from.compareTo(candidate) < 0;
         }
 
         @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)

--- a/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
+ * https://docs.moderne.io/licensing/moderne-source-available-license
  * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
@@ -1,0 +1,934 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import com.google.common.collect.Range;
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+@RecipeDescriptor(
+        name = "Use Guava Ranges",
+        description = "Simplifies hand crafted range checks."
+)
+public class UseRanges {
+
+    @RecipeDescriptor(
+            name = "Replace `from.compareTo(candidate) <= 0 && candidate.compareTo(to) <= 0` with a guava `Range.closed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
+    )
+    public static class RangeClosed<T extends Comparable<T>> {
+
+        @BeforeTemplate
+        boolean simple(T from, T candidate, T to) {
+            return from.compareTo(candidate) <= 0
+                    && candidate.compareTo(to) <= 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(T from, T candidate, T to) {
+
+            return from.compareTo(candidate) <= 0
+                    && to.compareTo(candidate) >= 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(T from, T candidate, T to) {
+
+            return candidate.compareTo(from) >= 0
+                    && candidate.compareTo(to) <= 0;
+        }
+
+        @BeforeTemplate
+        boolean flipped(T from, T candidate, T to) {
+
+            return candidate.compareTo(to) <= 0
+                    && from.compareTo(candidate) <= 0;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(T from, T candidate, T to) {
+            return Range.closed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace `from.compareTo(candidate) < 0 && candidate.compareTo(to) < 0` with a guava `Range.open(from, to).contains(candidate)`",
+        description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
+    )
+    public static class RangeOpen<T extends Comparable<T>> {
+
+        @BeforeTemplate
+        boolean simple(T from, T candidate, T to) {
+
+            return from.compareTo(candidate) < 0
+                && candidate.compareTo(to) < 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(T from, T candidate, T to) {
+
+            return from.compareTo(candidate) < 0
+                && to.compareTo(candidate) > 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(T from, T candidate, T to) {
+
+            return candidate.compareTo(from) > 0
+                && candidate.compareTo(to) < 0;
+        }
+
+        @BeforeTemplate
+        boolean flipped(T from, T candidate, T to) {
+
+            return candidate.compareTo(to) < 0
+                && from.compareTo(candidate) < 0;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(T from, T candidate, T to) {
+            return Range.open(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace `from.compareTo(candidate) <= 0 && candidate.compareTo(to) < 0` with a guava `Range.closedOpen(from, to).contains(candidate)`",
+        description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
+    )
+    public static class RangeClosedOpen<T extends Comparable<T>> {
+
+        @BeforeTemplate
+        boolean simple(T from, T candidate, T to) {
+
+            return from.compareTo(candidate) <= 0
+                && candidate.compareTo(to) < 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(T from, T candidate, T to) {
+
+            return from.compareTo(candidate) <= 0
+                && to.compareTo(candidate) > 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(T from, T candidate, T to) {
+
+            return candidate.compareTo(from) >= 0
+                && candidate.compareTo(to) < 0;
+        }
+
+        @BeforeTemplate
+        boolean flipped(T from, T candidate, T to) {
+
+            return candidate.compareTo(to) < 0
+                && from.compareTo(candidate) <= 0;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(T from, T candidate, T to) {
+            return Range.closedOpen(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+        name = "Replace `from.compareTo(candidate) < 0 && candidate.compareTo(to) <= 0` with a guava `Range.openClosed(from, to).contains(candidate)`",
+        description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
+    )
+    public static class RangeOpenClosed<T extends Comparable<T>> {
+
+        @BeforeTemplate
+        boolean simple(T from, T candidate, T to) {
+
+            return from.compareTo(candidate) < 0
+                && candidate.compareTo(to) <= 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(T from, T candidate, T to) {
+
+            return from.compareTo(candidate) < 0
+                && to.compareTo(candidate) >= 0;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(T from, T candidate, T to) {
+
+            return candidate.compareTo(from) > 0
+                && candidate.compareTo(to) <= 0;
+        }
+
+        @BeforeTemplate
+        boolean flipped(T from, T candidate, T to) {
+
+            return candidate.compareTo(to) <= 0
+                && from.compareTo(candidate) < 0;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(T from, T candidate, T to) {
+            return Range.openClosed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate <= to` with a guava `Range.closed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
+    )
+    public static class RangeClosedPrimitiveInt {
+
+        @BeforeTemplate
+        boolean simple(int from, int candidate, int to) {
+
+            return from <= candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(int from, int candidate, int to) {
+
+            return from <= candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(int from, int candidate, int to) {
+
+            return candidate >= from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(int from, int candidate, int to) {
+
+            return candidate <= to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(int from, int candidate, int to) {
+            return Range.closed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate < to` with a guava `Range.open(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
+    )
+    public static class RangeOpenPrimitiveInt {
+
+        @BeforeTemplate
+        boolean simple(int from, int candidate, int to) {
+
+            return from < candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(int from, int candidate, int to) {
+
+            return from < candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(int from, int candidate, int to) {
+
+            return candidate > from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(int from, int candidate, int to) {
+
+            return candidate < to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(int from, int candidate, int to) {
+            return Range.open(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate < to` with a guava `Range.closedOpen(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
+    )
+    public static class RangeClosedOpenPrimitiveInt {
+
+        @BeforeTemplate
+        boolean simple(int from, int candidate, int to) {
+
+            return from <= candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(int from, int candidate, int to) {
+
+            return from <= candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(int from, int candidate, int to) {
+
+            return candidate >= from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(int from, int candidate, int to) {
+
+            return candidate < to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(int from, int candidate, int to) {
+            return Range.closedOpen(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate <= to` with a guava `Range.openClosed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
+    )
+    public static class RangeOpenClosedPrimitiveInt {
+
+        @BeforeTemplate
+        boolean simple(int from, int candidate, int to) {
+
+            return from < candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(int from, int candidate, int to) {
+
+            return from < candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(int from, int candidate, int to) {
+
+            return candidate > from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean flipped(int from, int candidate, int to) {
+
+            return candidate <= to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(int from, int candidate, int to) {
+            return Range.openClosed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate <= to` with a guava `Range.closed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
+    )
+    public static class RangeClosedPrimitiveDouble {
+
+        @BeforeTemplate
+        boolean simple(double from, double candidate, double to) {
+
+            return from <= candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(double from, double candidate, double to) {
+
+            return from <= candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(double from, double candidate, double to) {
+
+            return candidate >= from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(double from, double candidate, double to) {
+
+            return candidate <= to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(double from, double candidate, double to) {
+            return Range.closed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate < to` with a guava `Range.open(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
+    )
+    public static class RangeOpenPrimitiveDouble {
+
+        @BeforeTemplate
+        boolean simple(double from, double candidate, double to) {
+
+            return from < candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(double from, double candidate, double to) {
+
+            return from < candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(double from, double candidate, double to) {
+
+            return candidate > from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(double from, double candidate, double to) {
+
+            return candidate < to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(double from, double candidate, double to) {
+            return Range.open(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate < to` with a guava `Range.closedOpen(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
+    )
+    public static class RangeClosedOpenPrimitiveDouble {
+
+        @BeforeTemplate
+        boolean simple(double from, double candidate, double to) {
+
+            return from <= candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(double from, double candidate, double to) {
+
+            return from <= candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(double from, double candidate, double to) {
+
+            return candidate >= from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(double from, double candidate, double to) {
+
+            return candidate < to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(double from, double candidate, double to) {
+            return Range.closedOpen(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate <= to` with a guava `Range.openClosed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
+    )
+    public static class RangeOpenClosedPrimitiveDouble {
+
+        @BeforeTemplate
+        boolean simple(double from, double candidate, double to) {
+
+            return from < candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(double from, double candidate, double to) {
+
+            return from < candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(double from, double candidate, double to) {
+
+            return candidate > from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean flipped(double from, double candidate, double to) {
+
+            return candidate <= to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(double from, double candidate, double to) {
+            return Range.openClosed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate <= to` with a guava `Range.closed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
+    )
+    public static class RangeClosedPrimitiveFloat {
+
+        @BeforeTemplate
+        boolean simple(float from, float candidate, float to) {
+
+            return from <= candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(float from, float candidate, float to) {
+
+            return from <= candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(float from, float candidate, float to) {
+
+            return candidate >= from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(float from, float candidate, float to) {
+
+            return candidate <= to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(float from, float candidate, float to) {
+            return Range.closed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate < to` with a guava `Range.open(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
+    )
+    public static class RangeOpenPrimitiveFloat {
+
+        @BeforeTemplate
+        boolean simple(float from, float candidate, float to) {
+
+            return from < candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(float from, float candidate, float to) {
+
+            return from < candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(float from, float candidate, float to) {
+
+            return candidate > from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(float from, float candidate, float to) {
+
+            return candidate < to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(float from, float candidate, float to) {
+            return Range.open(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate < to` with a guava `Range.closedOpen(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
+    )
+    public static class RangeClosedOpenPrimitiveFloat {
+
+        @BeforeTemplate
+        boolean simple(float from, float candidate, float to) {
+
+            return from <= candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(float from, float candidate, float to) {
+
+            return from <= candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(float from, float candidate, float to) {
+
+            return candidate >= from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(float from, float candidate, float to) {
+
+            return candidate < to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(float from, float candidate, float to) {
+            return Range.closedOpen(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate <= to` with a guava `Range.openClosed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
+    )
+    public static class RangeOpenClosedPrimitiveFloat {
+
+        @BeforeTemplate
+        boolean simple(float from, float candidate, float to) {
+
+            return from < candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(float from, float candidate, float to) {
+
+            return from < candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(float from, float candidate, float to) {
+
+            return candidate > from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean flipped(float from, float candidate, float to) {
+
+            return candidate <= to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(float from, float candidate, float to) {
+            return Range.openClosed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate <= to` with a guava `Range.closed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
+    )
+    public static class RangeClosedPrimitiveShort {
+
+        @BeforeTemplate
+        boolean simple(short from, short candidate, short to) {
+
+            return from <= candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(short from, short candidate, short to) {
+
+            return from <= candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(short from, short candidate, short to) {
+
+            return candidate >= from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(short from, short candidate, short to) {
+
+            return candidate <= to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(short from, short candidate, short to) {
+            return Range.closed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate < to` with a guava `Range.open(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
+    )
+    public static class RangeOpenPrimitiveShort {
+
+        @BeforeTemplate
+        boolean simple(short from, short candidate, short to) {
+
+            return from < candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(short from, short candidate, short to) {
+
+            return from < candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(short from, short candidate, short to) {
+
+            return candidate > from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(short from, short candidate, short to) {
+
+            return candidate < to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(short from, short candidate, short to) {
+            return Range.open(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate < to` with a guava `Range.closedOpen(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
+    )
+    public static class RangeClosedOpenPrimitiveShort {
+
+        @BeforeTemplate
+        boolean simple(short from, short candidate, short to) {
+
+            return from <= candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(short from, short candidate, short to) {
+
+            return from <= candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(short from, short candidate, short to) {
+
+            return candidate >= from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(short from, short candidate, short to) {
+
+            return candidate < to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(short from, short candidate, short to) {
+            return Range.closedOpen(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate <= to` with a guava `Range.openClosed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
+    )
+    public static class RangeOpenClosedPrimitiveShort {
+
+        @BeforeTemplate
+        boolean simple(short from, short candidate, short to) {
+
+            return from < candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(short from, short candidate, short to) {
+
+            return from < candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(short from, short candidate, short to) {
+
+            return candidate > from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean flipped(short from, short candidate, short to) {
+
+            return candidate <= to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(short from, short candidate, short to) {
+            return Range.openClosed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate <= to` with a guava `Range.closed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in a closed interval ( candidate ∈ [from, to] ) with a guava range expression`."
+    )
+    public static class RangeClosedPrimitiveLong {
+
+        @BeforeTemplate
+        boolean simple(long from, long candidate, long to) {
+
+            return from <= candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(long from, long candidate, long to) {
+
+            return from <= candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(long from, long candidate, long to) {
+
+            return candidate >= from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(long from, long candidate, long to) {
+
+            return candidate <= to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(long from, long candidate, long to) {
+            return Range.closed(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate < to` with a guava `Range.open(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an open interval ( candidate ∈ (from, to) ) with a guava range expression`."
+    )
+    public static class RangeOpenPrimitiveLong {
+
+        @BeforeTemplate
+        boolean simple(long from, long candidate, long to) {
+
+            return from < candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(long from, long candidate, long to) {
+
+            return from < candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(long from, long candidate, long to) {
+
+            return candidate > from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(long from, long candidate, long to) {
+
+            return candidate < to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(long from, long candidate, long to) {
+            return Range.open(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from <= candidate && candidate < to` with a guava `Range.closedOpen(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the right ( candidate ∈ [from, to) ) with a guava range expression`."
+    )
+    public static class RangeClosedOpenPrimitiveLong {
+
+        @BeforeTemplate
+        boolean simple(long from, long candidate, long to) {
+
+            return from <= candidate && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheRight(long from, long candidate, long to) {
+
+            return from <= candidate && to > candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateOnTheLeft(long from, long candidate, long to) {
+
+            return candidate >= from && candidate < to;
+        }
+
+        @BeforeTemplate
+        boolean candidateOutside(long from, long candidate, long to) {
+
+            return candidate < to && from <= candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(long from, long candidate, long to) {
+            return Range.closedOpen(from, to).contains(candidate);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `from < candidate && candidate <= to` with a guava `Range.openClosed(from, to).contains(candidate)`",
+            description = "Replace a hand crafted range check for membership in an interval that is open to the left ( candidate ∈ (from, to] ) with a guava range expression`."
+    )
+    public static class RangeOpenClosedPrimitiveLong {
+
+        @BeforeTemplate
+        boolean simple(long from, long candidate, long to) {
+
+            return from < candidate && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsArgument(long from, long candidate, long to) {
+
+            return from < candidate && to >= candidate;
+        }
+
+        @BeforeTemplate
+        boolean candidateAsBase(long from, long candidate, long to) {
+
+            return candidate > from && candidate <= to;
+        }
+
+        @BeforeTemplate
+        boolean flipped(long from, long candidate, long to) {
+
+            return candidate <= to && from < candidate;
+        }
+
+        @UseImportPolicy(ImportPolicy.IMPORT_TOP_LEVEL)
+        @AfterTemplate
+        boolean after(long from, long candidate, long to) {
+            return Range.openClosed(from, to).contains(candidate);
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/UseRanges.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2025 the original author or authors.
  * <p>
- * Licensed under the Moderne Source Available License (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- * https://docs.moderne.io/licensing/moderne-source-available-license
+ * https://www.apache.org/licenses/LICENSE-2.0
  * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -3343,25 +3343,6 @@ examples:
 - description: ''
   sources:
   - before: |
-      import com.google.common.base.MoreObjects;
-
-      class A {
-          Object foo(Object obj) {
-              return MoreObjects.firstNonNull(obj, "default");
-          }
-      }
-    after: |
-      import java.util.Objects;
-
-      class A {
-          Object foo(Object obj) {
-              return Objects.requireNonNullElse(obj, "default");
-          }
-      }
-    language: java
-- description: ''
-  sources:
-  - before: |
       import com.google.common.base.Optional;
 
       class A {
@@ -3402,6 +3383,25 @@ examples:
               } catch (NoSuchElementException e) {
                   return "";
               }
+          }
+      }
+    language: java
+- description: ''
+  sources:
+  - before: |
+      import com.google.common.base.MoreObjects;
+
+      class A {
+          Object foo(Object obj) {
+              return MoreObjects.firstNonNull(obj, "default");
+          }
+      }
+    after: |
+      import java.util.Objects;
+
+      class A {
+          Object foo(Object obj) {
+              return Objects.requireNonNullElse(obj, "default");
           }
       }
     language: java
@@ -3824,6 +3824,40 @@ examples:
                   }
               };
           }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.java.migrate.guava.UseRangesRecipes
+examples:
+- description: ''
+  sources:
+  - before: |
+      import java.math.BigDecimal;
+
+      class Test {
+
+        void foo() {
+          BigDecimal from = new BigDecimal("0");
+          BigDecimal candidate = new BigDecimal("0");
+          BigDecimal to = new BigDecimal("2");
+          boolean trueCondition = from.compareTo(candidate) <= 0
+                                && candidate.compareTo(to) <= 0;
+        }
+      }
+    after: |
+      import com.google.common.collect.Range;
+
+      import java.math.BigDecimal;
+
+      class Test {
+
+        void foo() {
+          BigDecimal from = new BigDecimal("0");
+          BigDecimal candidate = new BigDecimal("0");
+          BigDecimal to = new BigDecimal("2");
+          boolean trueCondition = Range.closed(from, to).contains(candidate);
+        }
       }
     language: java
 ---
@@ -5939,7 +5973,7 @@ examples:
   - before: |
       package com.acme.music;
 
-      public class Test {
+      class Test {
           Record record;
       }
     after: |
@@ -5947,7 +5981,7 @@ examples:
 
       import com.acme.music.Record;
 
-      public class Test {
+      class Test {
           Record record;
       }
     language: java

--- a/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
@@ -1,0 +1,1241 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.guava;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UseRangesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("guava"))
+          .recipe(new UseRangesRecipes());
+    }
+
+    @Test
+    @DocumentExample
+    void simple() {
+        rewriteRun(
+                //language=java
+                java(//todo add other cases
+                        """
+                          import java.math.BigDecimal;
+
+                          class Test {
+
+                            void foo() {
+                              BigDecimal from = new BigDecimal("0");
+                              BigDecimal candidate = new BigDecimal("0");
+                              BigDecimal to = new BigDecimal("2");
+                              boolean trueCondition = from.compareTo(candidate) <= 0
+                                                    && candidate.compareTo(to) <= 0;
+                            }
+                          }
+                          """,
+                        """
+                          import com.google.common.collect.Range;
+
+                          import java.math.BigDecimal;
+
+                          class Test {
+
+                            void foo() {
+                              BigDecimal from = new BigDecimal("0");
+                              BigDecimal candidate = new BigDecimal("0");
+                              BigDecimal to = new BigDecimal("2");
+                              boolean trueCondition = Range.closed(from, to).contains(candidate);
+                            }
+                          }
+                          """
+                )
+        );
+    }
+
+    @Nested
+    class Generic {
+
+        @Test
+        void closed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = from.compareTo(candidate) <= 0
+                                              && candidate.compareTo(to) <= 0;
+                        boolean condition2 = from.compareTo(candidate) <= 0
+                                              && to.compareTo(candidate) >= 0;
+                        boolean condition3 = candidate.compareTo(from) >= 0
+                                              && candidate.compareTo(to) <= 0;
+                        boolean condition4 = candidate.compareTo(to) <= 0
+                                              && from.compareTo(candidate) <= 0;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = Range.closed(from, to).contains(candidate);
+                        boolean condition2 = Range.closed(from, to).contains(candidate);
+                        boolean condition3 = Range.closed(from, to).contains(candidate);
+                        boolean condition4 = Range.closed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void open() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = from.compareTo(candidate) < 0
+                                              && candidate.compareTo(to) < 0;
+                        boolean condition2 = from.compareTo(candidate) < 0
+                                              && to.compareTo(candidate) > 0;
+                        boolean condition3 = candidate.compareTo(from) > 0
+                                              && candidate.compareTo(to) < 0;
+                        boolean condition4 = candidate.compareTo(to) < 0
+                                              && from.compareTo(candidate) < 0;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = Range.open(from, to).contains(candidate);
+                        boolean condition2 = Range.open(from, to).contains(candidate);
+                        boolean condition3 = Range.open(from, to).contains(candidate);
+                        boolean condition4 = Range.open(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void closedOpen() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = from.compareTo(candidate) <= 0
+                                              && candidate.compareTo(to) < 0;
+                        boolean condition2 = from.compareTo(candidate) <= 0
+                                              && to.compareTo(candidate) > 0;
+                        boolean condition3 = candidate.compareTo(from) >= 0
+                                              && candidate.compareTo(to) < 0;
+                        boolean condition4 = candidate.compareTo(to) < 0
+                                              && from.compareTo(candidate) <= 0;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void openClosed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = from.compareTo(candidate) < 0
+                                              && candidate.compareTo(to) <= 0;
+                        boolean condition2 = from.compareTo(candidate) < 0
+                                              && to.compareTo(candidate) >= 0;
+                        boolean condition3 = candidate.compareTo(from) > 0
+                                              && candidate.compareTo(to) <= 0;
+                        boolean condition4 = candidate.compareTo(to) <= 0
+                                              && from.compareTo(candidate) < 0;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    import java.math.BigDecimal;
+
+                    class Test {
+
+                      void foo() {
+                        BigDecimal from = new BigDecimal("0");
+                        BigDecimal candidate = new BigDecimal("0");
+                        BigDecimal to = new BigDecimal("2");
+                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+    }
+
+    @Nested
+    class Int {
+
+        @Test
+        void closed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate <= to;
+                        boolean condition2 = from <= candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = Range.closed(from, to).contains(candidate);
+                        boolean condition2 = Range.closed(from, to).contains(candidate);
+                        boolean condition3 = Range.closed(from, to).contains(candidate);
+                        boolean condition4 = Range.closed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void open() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate < to;
+                        boolean condition2 = from < candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = Range.open(from, to).contains(candidate);
+                        boolean condition2 = Range.open(from, to).contains(candidate);
+                        boolean condition3 = Range.open(from, to).contains(candidate);
+                        boolean condition4 = Range.open(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void closedOpen() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate < to;
+                        boolean condition2 = from <= candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void openClosed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate <= to;
+                        boolean condition2 = from < candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        int from = 0;
+                        int candidate = 0;
+                        int to = 2;
+                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+    }
+
+    @Nested
+    class Short {
+
+        @Test
+        void closed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        short from = 0;
+                        short candidate = 0;
+                        short to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate <= to;
+                        boolean condition2 = from <= candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        short from = 0;
+                        short candidate = 0;
+                        short to = 2;
+                        boolean condition1 = Range.closed(from, to).contains(candidate);
+                        boolean condition2 = Range.closed(from, to).contains(candidate);
+                        boolean condition3 = Range.closed(from, to).contains(candidate);
+                        boolean condition4 = Range.closed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void open() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        short from = 0;
+                        short candidate = 0;
+                        short to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate < to;
+                        boolean condition2 = from < candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        short from = 0;
+                        short candidate = 0;
+                        short to = 2;
+                        boolean condition1 = Range.open(from, to).contains(candidate);
+                        boolean condition2 = Range.open(from, to).contains(candidate);
+                        boolean condition3 = Range.open(from, to).contains(candidate);
+                        boolean condition4 = Range.open(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void closedOpen() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        short from = 0;
+                        short candidate = 0;
+                        short to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate < to;
+                        boolean condition2 = from <= candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        short from = 0;
+                        short candidate = 0;
+                        short to = 2;
+                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void openClosed() {
+            rewriteRun(
+                    //language=java
+                    java(
+                            """
+                              class Test {
+
+                                void foo() {
+                                  short from = 0;
+                                  short candidate = 0;
+                                  short to = 2;
+                                  boolean condition1 = from < candidate
+                                                        && candidate <= to;
+                                  boolean condition2 = from < candidate
+                                                        && to >= candidate;
+                                  boolean condition3 = candidate > from
+                                                        && candidate <= to;
+                                  boolean condition4 = candidate <= to
+                                                        && from < candidate;
+                                }
+                              }
+                              """,
+                            """
+                              import com.google.common.collect.Range;
+
+                              class Test {
+
+                                void foo() {
+                                  short from = 0;
+                                  short candidate = 0;
+                                  short to = 2;
+                                  boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                                  boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                                  boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                                  boolean condition4 = Range.openClosed(from, to).contains(candidate);
+                                }
+                              }
+                              """
+                    )
+            );
+        }
+    }
+
+    @Nested
+    class Long {
+
+        @Test
+        void closed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate <= to;
+                        boolean condition2 = from <= candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = Range.closed(from, to).contains(candidate);
+                        boolean condition2 = Range.closed(from, to).contains(candidate);
+                        boolean condition3 = Range.closed(from, to).contains(candidate);
+                        boolean condition4 = Range.closed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void open() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate < to;
+                        boolean condition2 = from < candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = Range.open(from, to).contains(candidate);
+                        boolean condition2 = Range.open(from, to).contains(candidate);
+                        boolean condition3 = Range.open(from, to).contains(candidate);
+                        boolean condition4 = Range.open(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void closedOpen() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate < to;
+                        boolean condition2 = from <= candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void openClosed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate <= to;
+                        boolean condition2 = from < candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        long from = 0;
+                        long candidate = 0;
+                        long to = 2;
+                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+    }
+
+    @Nested
+    class Float {
+
+        @Test
+        void closed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate <= to;
+                        boolean condition2 = from <= candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = Range.closed(from, to).contains(candidate);
+                        boolean condition2 = Range.closed(from, to).contains(candidate);
+                        boolean condition3 = Range.closed(from, to).contains(candidate);
+                        boolean condition4 = Range.closed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void open() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate < to;
+                        boolean condition2 = from < candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = Range.open(from, to).contains(candidate);
+                        boolean condition2 = Range.open(from, to).contains(candidate);
+                        boolean condition3 = Range.open(from, to).contains(candidate);
+                        boolean condition4 = Range.open(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void closedOpen() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate < to;
+                        boolean condition2 = from <= candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void openClosed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate <= to;
+                        boolean condition2 = from < candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        float from = 0;
+                        float candidate = 0;
+                        float to = 2;
+                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+    }
+
+    @Nested
+    class Double {
+
+        @Test
+        void closed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate <= to;
+                        boolean condition2 = from <= candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = Range.closed(from, to).contains(candidate);
+                        boolean condition2 = Range.closed(from, to).contains(candidate);
+                        boolean condition3 = Range.closed(from, to).contains(candidate);
+                        boolean condition4 = Range.closed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void open() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate < to;
+                        boolean condition2 = from < candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = Range.open(from, to).contains(candidate);
+                        boolean condition2 = Range.open(from, to).contains(candidate);
+                        boolean condition3 = Range.open(from, to).contains(candidate);
+                        boolean condition4 = Range.open(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void closedOpen() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = from <= candidate
+                                              && candidate < to;
+                        boolean condition2 = from <= candidate
+                                              && to > candidate;
+                        boolean condition3 = candidate >= from
+                                              && candidate < to;
+                        boolean condition4 = candidate < to
+                                              && from <= candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+
+        @Test
+        void openClosed() {
+            rewriteRun(
+                //language=java
+                java(
+                  """
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = from < candidate
+                                              && candidate <= to;
+                        boolean condition2 = from < candidate
+                                              && to >= candidate;
+                        boolean condition3 = candidate > from
+                                              && candidate <= to;
+                        boolean condition4 = candidate <= to
+                                              && from < candidate;
+                      }
+                    }
+                    """,
+                  """
+                    import com.google.common.collect.Range;
+
+                    class Test {
+
+                      void foo() {
+                        double from = 0;
+                        double candidate = 0;
+                        double to = 2;
+                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
+                      }
+                    }
+                    """
+                )
+            );
+        }
+    }
+
+    @Test
+    @DocumentExample
+    void regression1() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.math.BigDecimal;
+
+              class Test {
+
+                void foo() {
+                  boolean b = BigDecimal.ZERO.compareTo(BigDecimal.ONE) <= 0
+                           && BigDecimal.ONE.compareTo(BigDecimal.TEN) <= 0;
+                }
+              }
+              """,
+            """
+              import com.google.common.collect.Range;
+
+              import java.math.BigDecimal;
+
+              class Test {
+
+                void foo() {
+                  boolean b = Range.closed(BigDecimal.ZERO, BigDecimal.TEN).contains(BigDecimal.ONE);
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void real() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.math.BigDecimal;
+
+              class Test {
+
+                class T {
+                  BigDecimal getMinValue() { return null;}
+                  BigDecimal getMaxValue() { return null;}
+                }
+
+                private boolean isInRange(BigDecimal value, T t) {
+                  return t.getMinValue().compareTo(value) <= 0
+                      && t.getMaxValue().compareTo(value) >= 0;
+                }
+              }
+              """,
+            """
+              import com.google.common.collect.Range;
+
+              import java.math.BigDecimal;
+
+              class Test {
+
+                class T {
+                  BigDecimal getMinValue() { return null;}
+                  BigDecimal getMaxValue() { return null;}
+                }
+
+                private boolean isInRange(BigDecimal value, T t) {
+                  return Range.closed(t.getMinValue(), t.getMaxValue()).contains(value);
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void unchanged() {
+        rewriteRun(
+          spec -> spec.recipe(new UseRangesRecipes()),
+          //language=java
+          java(
+            """
+              class Test {
+                  boolean unchanged1 = booleanExpression() ? booleanExpression() : !booleanExpression();
+                  boolean unchanged2 = booleanExpression() ? true : !booleanExpression();
+                  boolean unchanged3 = booleanExpression() ? booleanExpression() : false;
+
+                  boolean booleanExpression() {
+                    return true;
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
@@ -36,38 +36,38 @@ class UseRangesTest implements RewriteTest {
     @DocumentExample
     void simple() {
         rewriteRun(
-                //language=java
-                java(
-                        """
-                          import java.math.BigDecimal;
+          //language=java
+          java(
+            """
+              import java.math.BigDecimal;
 
-                          class Test {
+              class Test {
 
-                            void foo() {
-                              BigDecimal from = new BigDecimal("0");
-                              BigDecimal candidate = new BigDecimal("0");
-                              BigDecimal to = new BigDecimal("2");
-                              boolean trueCondition = from.compareTo(candidate) <= 0
-                                                    && candidate.compareTo(to) <= 0;
-                            }
-                          }
-                          """,
-                        """
-                          import com.google.common.collect.Range;
+                void foo() {
+                  BigDecimal from = new BigDecimal("0");
+                  BigDecimal candidate = new BigDecimal("0");
+                  BigDecimal to = new BigDecimal("2");
+                  boolean trueCondition = from.compareTo(candidate) <= 0
+                                        && candidate.compareTo(to) <= 0;
+                }
+              }
+              """,
+            """
+              import com.google.common.collect.Range;
 
-                          import java.math.BigDecimal;
+              import java.math.BigDecimal;
 
-                          class Test {
+              class Test {
 
-                            void foo() {
-                              BigDecimal from = new BigDecimal("0");
-                              BigDecimal candidate = new BigDecimal("0");
-                              BigDecimal to = new BigDecimal("2");
-                              boolean trueCondition = Range.closed(from, to).contains(candidate);
-                            }
-                          }
-                          """
-                )
+                void foo() {
+                  BigDecimal from = new BigDecimal("0");
+                  BigDecimal candidate = new BigDecimal("0");
+                  BigDecimal to = new BigDecimal("2");
+                  boolean trueCondition = Range.closed(from, to).contains(candidate);
+                }
+              }
+              """
+          )
         );
     }
 
@@ -77,188 +77,188 @@ class UseRangesTest implements RewriteTest {
         @Test
         void closed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    import java.math.BigDecimal;
+              //language=java
+              java(
+                """
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = from.compareTo(candidate) <= 0
-                                              && candidate.compareTo(to) <= 0;
-                        boolean condition2 = from.compareTo(candidate) <= 0
-                                              && to.compareTo(candidate) >= 0;
-                        boolean condition3 = candidate.compareTo(from) >= 0
-                                              && candidate.compareTo(to) <= 0;
-                        boolean condition4 = candidate.compareTo(to) <= 0
-                                              && from.compareTo(candidate) <= 0;
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = from.compareTo(candidate) <= 0
+                                            && candidate.compareTo(to) <= 0;
+                      boolean condition2 = from.compareTo(candidate) <= 0
+                                            && to.compareTo(candidate) >= 0;
+                      boolean condition3 = candidate.compareTo(from) >= 0
+                                            && candidate.compareTo(to) <= 0;
+                      boolean condition4 = candidate.compareTo(to) <= 0
+                                            && from.compareTo(candidate) <= 0;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    import java.math.BigDecimal;
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = Range.closed(from, to).contains(candidate);
-                        boolean condition2 = Range.closed(from, to).contains(candidate);
-                        boolean condition3 = Range.closed(from, to).contains(candidate);
-                        boolean condition4 = Range.closed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = Range.closed(from, to).contains(candidate);
+                      boolean condition2 = Range.closed(from, to).contains(candidate);
+                      boolean condition3 = Range.closed(from, to).contains(candidate);
+                      boolean condition4 = Range.closed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void open() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    import java.math.BigDecimal;
+              //language=java
+              java(
+                """
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = from.compareTo(candidate) < 0
-                                              && candidate.compareTo(to) < 0;
-                        boolean condition2 = from.compareTo(candidate) < 0
-                                              && to.compareTo(candidate) > 0;
-                        boolean condition3 = candidate.compareTo(from) > 0
-                                              && candidate.compareTo(to) < 0;
-                        boolean condition4 = candidate.compareTo(to) < 0
-                                              && from.compareTo(candidate) < 0;
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = from.compareTo(candidate) < 0
+                                            && candidate.compareTo(to) < 0;
+                      boolean condition2 = from.compareTo(candidate) < 0
+                                            && to.compareTo(candidate) > 0;
+                      boolean condition3 = candidate.compareTo(from) > 0
+                                            && candidate.compareTo(to) < 0;
+                      boolean condition4 = candidate.compareTo(to) < 0
+                                            && from.compareTo(candidate) < 0;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    import java.math.BigDecimal;
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = Range.open(from, to).contains(candidate);
-                        boolean condition2 = Range.open(from, to).contains(candidate);
-                        boolean condition3 = Range.open(from, to).contains(candidate);
-                        boolean condition4 = Range.open(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = Range.open(from, to).contains(candidate);
+                      boolean condition2 = Range.open(from, to).contains(candidate);
+                      boolean condition3 = Range.open(from, to).contains(candidate);
+                      boolean condition4 = Range.open(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void closedOpen() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    import java.math.BigDecimal;
+              //language=java
+              java(
+                """
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = from.compareTo(candidate) <= 0
-                                              && candidate.compareTo(to) < 0;
-                        boolean condition2 = from.compareTo(candidate) <= 0
-                                              && to.compareTo(candidate) > 0;
-                        boolean condition3 = candidate.compareTo(from) >= 0
-                                              && candidate.compareTo(to) < 0;
-                        boolean condition4 = candidate.compareTo(to) < 0
-                                              && from.compareTo(candidate) <= 0;
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = from.compareTo(candidate) <= 0
+                                            && candidate.compareTo(to) < 0;
+                      boolean condition2 = from.compareTo(candidate) <= 0
+                                            && to.compareTo(candidate) > 0;
+                      boolean condition3 = candidate.compareTo(from) >= 0
+                                            && candidate.compareTo(to) < 0;
+                      boolean condition4 = candidate.compareTo(to) < 0
+                                            && from.compareTo(candidate) <= 0;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    import java.math.BigDecimal;
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition4 = Range.closedOpen(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void openClosed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    import java.math.BigDecimal;
+              //language=java
+              java(
+                """
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = from.compareTo(candidate) < 0
-                                              && candidate.compareTo(to) <= 0;
-                        boolean condition2 = from.compareTo(candidate) < 0
-                                              && to.compareTo(candidate) >= 0;
-                        boolean condition3 = candidate.compareTo(from) > 0
-                                              && candidate.compareTo(to) <= 0;
-                        boolean condition4 = candidate.compareTo(to) <= 0
-                                              && from.compareTo(candidate) < 0;
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = from.compareTo(candidate) < 0
+                                            && candidate.compareTo(to) <= 0;
+                      boolean condition2 = from.compareTo(candidate) < 0
+                                            && to.compareTo(candidate) >= 0;
+                      boolean condition3 = candidate.compareTo(from) > 0
+                                            && candidate.compareTo(to) <= 0;
+                      boolean condition4 = candidate.compareTo(to) <= 0
+                                            && from.compareTo(candidate) < 0;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    import java.math.BigDecimal;
+                  import java.math.BigDecimal;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        BigDecimal from = new BigDecimal("0");
-                        BigDecimal candidate = new BigDecimal("0");
-                        BigDecimal to = new BigDecimal("2");
-                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      BigDecimal from = new BigDecimal("0");
+                      BigDecimal candidate = new BigDecimal("0");
+                      BigDecimal to = new BigDecimal("2");
+                      boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition4 = Range.openClosed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
     }
@@ -269,218 +269,218 @@ class UseRangesTest implements RewriteTest {
         @Test
         void closed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate <= to;
-                        boolean condition2 = from <= candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate <= to;
+                      boolean condition2 = from <= candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = Range.closed(from, to).contains(candidate);
-                        boolean condition2 = Range.closed(from, to).contains(candidate);
-                        boolean condition3 = Range.closed(from, to).contains(candidate);
-                        boolean condition4 = Range.closed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = Range.closed(from, to).contains(candidate);
+                      boolean condition2 = Range.closed(from, to).contains(candidate);
+                      boolean condition3 = Range.closed(from, to).contains(candidate);
+                      boolean condition4 = Range.closed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void open() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate < to;
-                        boolean condition2 = from < candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate < to;
+                      boolean condition2 = from < candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = Range.open(from, to).contains(candidate);
-                        boolean condition2 = Range.open(from, to).contains(candidate);
-                        boolean condition3 = Range.open(from, to).contains(candidate);
-                        boolean condition4 = Range.open(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = Range.open(from, to).contains(candidate);
+                      boolean condition2 = Range.open(from, to).contains(candidate);
+                      boolean condition3 = Range.open(from, to).contains(candidate);
+                      boolean condition4 = Range.open(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void closedOpen() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate < to;
-                        boolean condition2 = from <= candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate < to;
+                      boolean condition2 = from <= candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition4 = Range.closedOpen(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void openClosed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate <= to;
-                        boolean condition2 = from < candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate <= to;
+                      boolean condition2 = from < candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        int from = 0;
-                        int candidate = 0;
-                        int to = 2;
-                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      int from = 0;
+                      int candidate = 0;
+                      int to = 2;
+                      boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition4 = Range.openClosed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void literals() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        boolean condition1 = 0 <= 1 && 1 <= 2;
-                        boolean condition2 = 0 <= 0 && 2 >= 0;
-                      }
+                    void foo() {
+                      boolean condition1 = 0 <= 1 && 1 <= 2;
+                      boolean condition2 = 0 <= 0 && 2 >= 0;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        boolean condition1 = Range.closed(0, 2).contains(1);
-                        boolean condition2 = Range.closed(0, 2).contains(0);
-                      }
+                    void foo() {
+                      boolean condition1 = Range.closed(0, 2).contains(1);
+                      boolean condition2 = Range.closed(0, 2).contains(0);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void noUniqueCandidate() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        boolean condition1 = 0 <= 1 && 2 <= 3;
-                      }
+                    void foo() {
+                      boolean condition1 = 0 <= 1 && 2 <= 3;
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
@@ -543,172 +543,172 @@ class UseRangesTest implements RewriteTest {
         @Test
         void closed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        short from = 0;
-                        short candidate = 0;
-                        short to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate <= to;
-                        boolean condition2 = from <= candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate <= to;
+                      boolean condition2 = from <= candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        short from = 0;
-                        short candidate = 0;
-                        short to = 2;
-                        boolean condition1 = Range.closed(from, to).contains(candidate);
-                        boolean condition2 = Range.closed(from, to).contains(candidate);
-                        boolean condition3 = Range.closed(from, to).contains(candidate);
-                        boolean condition4 = Range.closed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = Range.closed(from, to).contains(candidate);
+                      boolean condition2 = Range.closed(from, to).contains(candidate);
+                      boolean condition3 = Range.closed(from, to).contains(candidate);
+                      boolean condition4 = Range.closed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void open() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        short from = 0;
-                        short candidate = 0;
-                        short to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate < to;
-                        boolean condition2 = from < candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate < to;
+                      boolean condition2 = from < candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        short from = 0;
-                        short candidate = 0;
-                        short to = 2;
-                        boolean condition1 = Range.open(from, to).contains(candidate);
-                        boolean condition2 = Range.open(from, to).contains(candidate);
-                        boolean condition3 = Range.open(from, to).contains(candidate);
-                        boolean condition4 = Range.open(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = Range.open(from, to).contains(candidate);
+                      boolean condition2 = Range.open(from, to).contains(candidate);
+                      boolean condition3 = Range.open(from, to).contains(candidate);
+                      boolean condition4 = Range.open(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void closedOpen() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        short from = 0;
-                        short candidate = 0;
-                        short to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate < to;
-                        boolean condition2 = from <= candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate < to;
+                      boolean condition2 = from <= candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        short from = 0;
-                        short candidate = 0;
-                        short to = 2;
-                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition4 = Range.closedOpen(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void openClosed() {
             rewriteRun(
-                    //language=java
-                    java(
-                            """
-                              class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                                void foo() {
-                                  short from = 0;
-                                  short candidate = 0;
-                                  short to = 2;
-                                  boolean condition1 = from < candidate
-                                                        && candidate <= to;
-                                  boolean condition2 = from < candidate
-                                                        && to >= candidate;
-                                  boolean condition3 = candidate > from
-                                                        && candidate <= to;
-                                  boolean condition4 = candidate <= to
-                                                        && from < candidate;
-                                }
-                              }
-                              """,
-                            """
-                              import com.google.common.collect.Range;
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate <= to;
+                      boolean condition2 = from < candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from < candidate;
+                    }
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                              class Test {
+                  class Test {
 
-                                void foo() {
-                                  short from = 0;
-                                  short candidate = 0;
-                                  short to = 2;
-                                  boolean condition1 = Range.openClosed(from, to).contains(candidate);
-                                  boolean condition2 = Range.openClosed(from, to).contains(candidate);
-                                  boolean condition3 = Range.openClosed(from, to).contains(candidate);
-                                  boolean condition4 = Range.openClosed(from, to).contains(candidate);
-                                }
-                              }
-                              """
-                    )
+                    void foo() {
+                      short from = 0;
+                      short candidate = 0;
+                      short to = 2;
+                      boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition4 = Range.openClosed(from, to).contains(candidate);
+                    }
+                  }
+                  """
+              )
             );
         }
     }
@@ -719,172 +719,172 @@ class UseRangesTest implements RewriteTest {
         @Test
         void closed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate <= to;
-                        boolean condition2 = from <= candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate <= to;
+                      boolean condition2 = from <= candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = Range.closed(from, to).contains(candidate);
-                        boolean condition2 = Range.closed(from, to).contains(candidate);
-                        boolean condition3 = Range.closed(from, to).contains(candidate);
-                        boolean condition4 = Range.closed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = Range.closed(from, to).contains(candidate);
+                      boolean condition2 = Range.closed(from, to).contains(candidate);
+                      boolean condition3 = Range.closed(from, to).contains(candidate);
+                      boolean condition4 = Range.closed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void open() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate < to;
-                        boolean condition2 = from < candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate < to;
+                      boolean condition2 = from < candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = Range.open(from, to).contains(candidate);
-                        boolean condition2 = Range.open(from, to).contains(candidate);
-                        boolean condition3 = Range.open(from, to).contains(candidate);
-                        boolean condition4 = Range.open(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = Range.open(from, to).contains(candidate);
+                      boolean condition2 = Range.open(from, to).contains(candidate);
+                      boolean condition3 = Range.open(from, to).contains(candidate);
+                      boolean condition4 = Range.open(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void closedOpen() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate < to;
-                        boolean condition2 = from <= candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate < to;
+                      boolean condition2 = from <= candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition4 = Range.closedOpen(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void openClosed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate <= to;
-                        boolean condition2 = from < candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate <= to;
+                      boolean condition2 = from < candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        long from = 0;
-                        long candidate = 0;
-                        long to = 2;
-                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      long from = 0;
+                      long candidate = 0;
+                      long to = 2;
+                      boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition4 = Range.openClosed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
     }
@@ -895,172 +895,172 @@ class UseRangesTest implements RewriteTest {
         @Test
         void closed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate <= to;
-                        boolean condition2 = from <= candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate <= to;
+                      boolean condition2 = from <= candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = Range.closed(from, to).contains(candidate);
-                        boolean condition2 = Range.closed(from, to).contains(candidate);
-                        boolean condition3 = Range.closed(from, to).contains(candidate);
-                        boolean condition4 = Range.closed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = Range.closed(from, to).contains(candidate);
+                      boolean condition2 = Range.closed(from, to).contains(candidate);
+                      boolean condition3 = Range.closed(from, to).contains(candidate);
+                      boolean condition4 = Range.closed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void open() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate < to;
-                        boolean condition2 = from < candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate < to;
+                      boolean condition2 = from < candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = Range.open(from, to).contains(candidate);
-                        boolean condition2 = Range.open(from, to).contains(candidate);
-                        boolean condition3 = Range.open(from, to).contains(candidate);
-                        boolean condition4 = Range.open(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = Range.open(from, to).contains(candidate);
+                      boolean condition2 = Range.open(from, to).contains(candidate);
+                      boolean condition3 = Range.open(from, to).contains(candidate);
+                      boolean condition4 = Range.open(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void closedOpen() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate < to;
-                        boolean condition2 = from <= candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate < to;
+                      boolean condition2 = from <= candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition4 = Range.closedOpen(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void openClosed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate <= to;
-                        boolean condition2 = from < candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate <= to;
+                      boolean condition2 = from < candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        float from = 0;
-                        float candidate = 0;
-                        float to = 2;
-                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      float from = 0;
+                      float candidate = 0;
+                      float to = 2;
+                      boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition4 = Range.openClosed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
     }
@@ -1071,172 +1071,172 @@ class UseRangesTest implements RewriteTest {
         @Test
         void closed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate <= to;
-                        boolean condition2 = from <= candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate <= to;
+                      boolean condition2 = from <= candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = Range.closed(from, to).contains(candidate);
-                        boolean condition2 = Range.closed(from, to).contains(candidate);
-                        boolean condition3 = Range.closed(from, to).contains(candidate);
-                        boolean condition4 = Range.closed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = Range.closed(from, to).contains(candidate);
+                      boolean condition2 = Range.closed(from, to).contains(candidate);
+                      boolean condition3 = Range.closed(from, to).contains(candidate);
+                      boolean condition4 = Range.closed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void open() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate < to;
-                        boolean condition2 = from < candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate < to;
+                      boolean condition2 = from < candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = Range.open(from, to).contains(candidate);
-                        boolean condition2 = Range.open(from, to).contains(candidate);
-                        boolean condition3 = Range.open(from, to).contains(candidate);
-                        boolean condition4 = Range.open(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = Range.open(from, to).contains(candidate);
+                      boolean condition2 = Range.open(from, to).contains(candidate);
+                      boolean condition3 = Range.open(from, to).contains(candidate);
+                      boolean condition4 = Range.open(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void closedOpen() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = from <= candidate
-                                              && candidate < to;
-                        boolean condition2 = from <= candidate
-                                              && to > candidate;
-                        boolean condition3 = candidate >= from
-                                              && candidate < to;
-                        boolean condition4 = candidate < to
-                                              && from <= candidate;
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = from <= candidate
+                                            && candidate < to;
+                      boolean condition2 = from <= candidate
+                                            && to > candidate;
+                      boolean condition3 = candidate >= from
+                                            && candidate < to;
+                      boolean condition4 = candidate < to
+                                            && from <= candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition2 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition3 = Range.closedOpen(from, to).contains(candidate);
-                        boolean condition4 = Range.closedOpen(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition2 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition3 = Range.closedOpen(from, to).contains(candidate);
+                      boolean condition4 = Range.closedOpen(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
 
         @Test
         void openClosed() {
             rewriteRun(
-                //language=java
-                java(
-                  """
-                    class Test {
+              //language=java
+              java(
+                """
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = from < candidate
-                                              && candidate <= to;
-                        boolean condition2 = from < candidate
-                                              && to >= candidate;
-                        boolean condition3 = candidate > from
-                                              && candidate <= to;
-                        boolean condition4 = candidate <= to
-                                              && from < candidate;
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = from < candidate
+                                            && candidate <= to;
+                      boolean condition2 = from < candidate
+                                            && to >= candidate;
+                      boolean condition3 = candidate > from
+                                            && candidate <= to;
+                      boolean condition4 = candidate <= to
+                                            && from < candidate;
                     }
-                    """,
-                  """
-                    import com.google.common.collect.Range;
+                  }
+                  """,
+                """
+                  import com.google.common.collect.Range;
 
-                    class Test {
+                  class Test {
 
-                      void foo() {
-                        double from = 0;
-                        double candidate = 0;
-                        double to = 2;
-                        boolean condition1 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition2 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition3 = Range.openClosed(from, to).contains(candidate);
-                        boolean condition4 = Range.openClosed(from, to).contains(candidate);
-                      }
+                    void foo() {
+                      double from = 0;
+                      double candidate = 0;
+                      double to = 2;
+                      boolean condition1 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition2 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition3 = Range.openClosed(from, to).contains(candidate);
+                      boolean condition4 = Range.openClosed(from, to).contains(candidate);
                     }
-                    """
-                )
+                  }
+                  """
+              )
             );
         }
     }

--- a/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
+ * https://docs.moderne.io/licensing/moderne-source-available-license
  * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
@@ -37,7 +37,7 @@ class UseRangesTest implements RewriteTest {
     void simple() {
         rewriteRun(
                 //language=java
-                java(//todo add other cases
+                java(
                         """
                           import java.math.BigDecimal;
 

--- a/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/UseRangesTest.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2025 the original author or authors.
  * <p>
- * Licensed under the Moderne Source Available License (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- * https://docs.moderne.io/licensing/moderne-source-available-license
+ * https://www.apache.org/licenses/LICENSE-2.0
  * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

adds recipe that converts `from.compareTo(candidate) <= 0 && candidate.compareTo(to) <= 0` into more idiomatic guava ranges.
Covers opened, closed and half-open intervals of `Comparable`s and primitives.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Make code more readable

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

1) I chose `candidate` as a name for the object that is tested for its membership. Maybe there is a better name.
2) `from <= candidate && candidate <= to` is fairly easy to read. For uniformity, I chose to have it converted to `Range.closed(from, to).contains(candidate)` anyway.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
