### PR TITLE
Add Bouncy Castle upgrade recipe for Java < 8

### DIFF
--- a/src/main/resources/META-INF/rewrite/bouncycastle-jdk15to18.yml
+++ b/src/main/resources/META-INF/rewrite/bouncycastle-jdk15to18.yml
@@ -17,9 +17,11 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.BouncyCastleFromJdk15OnToJdk15to18
-displayName: Migrate BouncyCastle from jdk15on to jdk15to18 for Java < 8
+displayName: Migrate Bouncy Castle from `jdk15on` to `jdk15to18` for Java < 8
 description: >-
-  This recipe replaces the Bouncycastle artifacts from `jdk15on` to `jdk15to18`. `jdk15on` isn't maintained anymore and `jdk18on` is only for Java 8 and above. The `jdk15to18` artifact is the up-to-date replacement of the unmaintained `jdk15on` for java < 8.
+  This recipe replaces the Bouncy Castle artifacts from `jdk15on` to `jdk15to18`.
+  `jdk15on` isn't maintained anymore and `jdk18on` is only for Java 8 and above.
+  The `jdk15to18` artifact is the up-to-date replacement of the unmaintained `jdk15on` for Java < 8.
 tags:
   - bouncycastle
 recipeList:

--- a/src/main/resources/META-INF/rewrite/bouncycastle-jdk15to18.yml
+++ b/src/main/resources/META-INF/rewrite/bouncycastle-jdk15to18.yml
@@ -1,0 +1,60 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.BouncyCastleFromJdk15OnToJdk15to18
+displayName: Migrate BouncyCastle from jdk15on to jdk15to18 for Java < 8
+description: >-
+  This recipe replaces the Bouncycastle artifacts from jdk15on to jdk15to18. jdk15on isn't maintained anymore and jdk18on is only for Java 8 and above. The jdk15to18 artifact is the up-to-date replacement of the unmaintained jdk15on for java < 8.
+tags:
+  - bouncycastle
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcprov-jdk15on
+      newArtifactId: bcprov-jdk15to18
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcutil-jdk15on
+      newArtifactId: bcutil-jdk15to18
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcpkix-jdk15on
+      newArtifactId: bcpkix-jdk15to18
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcmail-jdk15on
+      newArtifactId: bcmail-jdk15to18
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcjmail-jdk15on
+      newArtifactId: bcjmail-jdk15to18
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcpg-jdk15on
+      newArtifactId: bcpg-jdk15to18
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bctls-jdk15on
+      newArtifactId: bctls-jdk15to18
+      newVersion: latest.release

--- a/src/main/resources/META-INF/rewrite/bouncycastle-jdk15to18.yml
+++ b/src/main/resources/META-INF/rewrite/bouncycastle-jdk15to18.yml
@@ -19,7 +19,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.BouncyCastleFromJdk15OnToJdk15to18
 displayName: Migrate BouncyCastle from jdk15on to jdk15to18 for Java < 8
 description: >-
-  This recipe replaces the Bouncycastle artifacts from jdk15on to jdk15to18. jdk15on isn't maintained anymore and jdk18on is only for Java 8 and above. The jdk15to18 artifact is the up-to-date replacement of the unmaintained jdk15on for java < 8.
+  This recipe replaces the Bouncycastle artifacts from `jdk15on` to `jdk15to18`. `jdk15on` isn't maintained anymore and `jdk18on` is only for Java 8 and above. The `jdk15to18` artifact is the up-to-date replacement of the unmaintained `jdk15on` for java < 8.
 tags:
   - bouncycastle
 recipeList:

--- a/src/main/resources/META-INF/rewrite/bouncycastle-jdk18on.yml
+++ b/src/main/resources/META-INF/rewrite/bouncycastle-jdk18on.yml
@@ -19,10 +19,11 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On
 displayName: Migrate BouncyCastle to jdk18on
 description: >-
-  This recipe will upgrade BouncyCastle dependencies from -jdk15on to -jdk18on.
+  This recipe will upgrade BouncyCastle dependencies from -jdk15on or -jdk15to18 to -jdk18on.
 tags:
   - bouncycastle
 recipeList:
+  # -jdk15on migration
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.bouncycastle
       oldArtifactId: bcprov-jdk15on
@@ -56,5 +57,42 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.bouncycastle
       oldArtifactId: bctls-jdk15on
+      newArtifactId: bctls-jdk18on
+      newVersion: latest.release
+
+  # -jdk15to18 migration
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcprov-jdk15to18
+      newArtifactId: bcprov-jdk18on
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcutil-jdk15to18
+      newArtifactId: bcutil-jdk18on
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcpkix-jdk15to18
+      newArtifactId: bcpkix-jdk18on
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcmail-jdk15to18
+      newArtifactId: bcmail-jdk18on
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcjmail-jdk15to18
+      newArtifactId: bcjmail-jdk18on
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bcpg-jdk15to18
+      newArtifactId: bcpg-jdk18on
+      newVersion: latest.release
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.bouncycastle
+      oldArtifactId: bctls-jdk15to18
       newArtifactId: bctls-jdk18on
       newVersion: latest.release

--- a/src/main/resources/META-INF/rewrite/bouncycastle-jdk18on.yml
+++ b/src/main/resources/META-INF/rewrite/bouncycastle-jdk18on.yml
@@ -17,9 +17,9 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On
-displayName: Migrate BouncyCastle to jdk18on
+displayName: Migrate Bouncy Castle to `jdk18on`
 description: >-
-  This recipe will upgrade BouncyCastle dependencies from -jdk15on or -jdk15to18 to -jdk18on.
+  This recipe will upgrade Bouncy Castle dependencies from `-jdk15on` or `-jdk15to18` to `-jdk18on`.
 tags:
   - bouncycastle
 recipeList:

--- a/src/main/resources/META-INF/rewrite/java-version-7.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-7.yml
@@ -28,6 +28,7 @@ recipeList:
   - org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods
   - org.openrewrite.java.migrate.JREThrowableFinalMethods
   - org.openrewrite.java.migrate.util.ReplaceMathRandomWithThreadLocalRandomRecipe
+  - org.openrewrite.java.migrate.BouncyCastleFromJdk15OnToJdk15to18
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.JREJdbcInterfaceNewMethods

--- a/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
@@ -134,7 +134,7 @@ class BouncyCastleTest implements RewriteTest {
 
     @ParameterizedTest
     @MethodSource("artifactBaseNames")
-    void testJdk15onToJdk18on(String artifactBaseName) {
+    void jdk15onToJdk18on(String artifactBaseName) {
         testBouncyCastleArtifactUpgradeRecipe(
           "/META-INF/rewrite/bouncycastle-jdk18on.yml",
           "org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On",
@@ -146,7 +146,7 @@ class BouncyCastleTest implements RewriteTest {
 
     @ParameterizedTest
     @MethodSource("artifactBaseNames")
-    void testJdk15to18ToJdk18on(String artifactBaseName) {
+    void jdk15to18ToJdk18on(String artifactBaseName) {
         testBouncyCastleArtifactUpgradeRecipe(
           "/META-INF/rewrite/bouncycastle-jdk18on.yml",
           "org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On",
@@ -158,7 +158,7 @@ class BouncyCastleTest implements RewriteTest {
 
     @ParameterizedTest
     @MethodSource("artifactBaseNames")
-    void testJdk15onToJdk15To18(String artifactBaseName) {
+    void jdk15onToJdk15To18(String artifactBaseName) {
         testBouncyCastleArtifactUpgradeRecipe(
           "/META-INF/rewrite/bouncycastle-jdk15to18.yml",
           "org.openrewrite.java.migrate.BouncyCastleFromJdk15OnToJdk15to18",

--- a/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
@@ -33,6 +33,10 @@ import static org.openrewrite.maven.Assertions.pomXml;
 
 class BouncyCastleTest implements RewriteTest {
 
+    static List<String> artifactBaseNames() {
+        return Arrays.asList("bcprov", "bcutil", "bcpkix", "bcmail", "bcjmail", "bcpg", "bctls");
+    }
+
     @DocumentExample
     @Test
     void document() {
@@ -80,10 +84,6 @@ class BouncyCastleTest implements RewriteTest {
             )
           )
         );
-    }
-
-    static List<String> artifactBaseNames() {
-        return Arrays.asList("bcprov", "bcutil", "bcpkix", "bcmail", "bcjmail", "bcpg", "bctls");
     }
 
     @ParameterizedTest

--- a/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
@@ -33,10 +33,6 @@ import static org.openrewrite.maven.Assertions.pomXml;
 
 class BouncyCastleTest implements RewriteTest {
 
-    static List<String> artifactBaseNames() {
-        return Arrays.asList("bcprov", "bcutil", "bcpkix", "bcmail", "bcjmail", "bcpg", "bctls");
-    }
-
     @DocumentExample
     @Test
     void document() {
@@ -50,11 +46,9 @@ class BouncyCastleTest implements RewriteTest {
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>org.bouncycastle</groupId>
@@ -88,13 +82,52 @@ class BouncyCastleTest implements RewriteTest {
         );
     }
 
-    void testBouncyCastleArtifactUpgradeRecipe(
+    static List<String> artifactBaseNames() {
+        return Arrays.asList("bcprov", "bcutil", "bcpkix", "bcmail", "bcjmail", "bcpg", "bctls");
+    }
+
+    @ParameterizedTest
+    @MethodSource("artifactBaseNames")
+    void jdk15onToJdk18on(String artifactBaseName) {
+        runBouncyCastleArtifactUpgradeRecipe(
+          "/META-INF/rewrite/bouncycastle-jdk18on.yml",
+          "org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On",
+          artifactBaseName,
+          "jdk15on",
+          "jdk18on"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("artifactBaseNames")
+    void jdk15to18ToJdk18on(String artifactBaseName) {
+        runBouncyCastleArtifactUpgradeRecipe(
+          "/META-INF/rewrite/bouncycastle-jdk18on.yml",
+          "org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On",
+          artifactBaseName,
+          "jdk15to18",
+          "jdk18on"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("artifactBaseNames")
+    void jdk15onToJdk15To18(String artifactBaseName) {
+        runBouncyCastleArtifactUpgradeRecipe(
+          "/META-INF/rewrite/bouncycastle-jdk15to18.yml",
+          "org.openrewrite.java.migrate.BouncyCastleFromJdk15OnToJdk15to18",
+          artifactBaseName,
+          "jdk15on",
+          "jdk15to18"
+        );
+    }
+
+    void runBouncyCastleArtifactUpgradeRecipe(
       String yamlFile,
       String recipe,
       String baseArtifactId,
       String originalArtifactSuffix,
-      String expectedArtifactSuffix
-    ) {
+      String expectedArtifactSuffix) {
         rewriteRun(
           recipeSpec -> recipeSpec.recipeFromResource(yamlFile, recipe),
           mavenProject("project",
@@ -103,11 +136,9 @@ class BouncyCastleTest implements RewriteTest {
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>org.bouncycastle</groupId>
@@ -129,42 +160,6 @@ class BouncyCastleTest implements RewriteTest {
                   }))
             )
           )
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("artifactBaseNames")
-    void jdk15onToJdk18on(String artifactBaseName) {
-        testBouncyCastleArtifactUpgradeRecipe(
-          "/META-INF/rewrite/bouncycastle-jdk18on.yml",
-          "org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On",
-          artifactBaseName,
-          "jdk15on",
-          "jdk18on"
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("artifactBaseNames")
-    void jdk15to18ToJdk18on(String artifactBaseName) {
-        testBouncyCastleArtifactUpgradeRecipe(
-          "/META-INF/rewrite/bouncycastle-jdk18on.yml",
-          "org.openrewrite.java.migrate.BounceCastleFromJdk15OntoJdk18On",
-          artifactBaseName,
-          "jdk15to18",
-          "jdk18on"
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("artifactBaseNames")
-    void jdk15onToJdk15To18(String artifactBaseName) {
-        testBouncyCastleArtifactUpgradeRecipe(
-          "/META-INF/rewrite/bouncycastle-jdk15to18.yml",
-          "org.openrewrite.java.migrate.BouncyCastleFromJdk15OnToJdk15to18",
-          artifactBaseName,
-          "jdk15on",
-          "jdk15to18"
         );
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
A new recipe to replace the Bouncycastle artifacts from `jdk15on` to `jdk15to18`. `jdk15on` isn't maintained anymore and `jdk18on` is only for Java 8 and above. The `jdk15to18` artifact is the up-to-date replacement of the unmaintained `jdk15on` for java < 8

## What's your motivation?
- Fix https://github.com/openrewrite/rewrite-migrate-java/issues/286

## Any additional context
### Existing recipe
The recipe to migrate from `-jdk15on` to `-jdk18on` [was added 3 months ago](https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/resources/META-INF/rewrite/bouncycastle-jdk18on.yml). That existing recipe assumes the target code is >= java8.

I've copied over the existing recipe YAML and changed the versions and description, and copied the main test.

Because there won't be more of that issue with bouncycastle anytime soon if ever, I don't think it's worth investing to deduplicate that code, i.e. options support for declarative recipes.


### Precondition
I couldn't find a way to reuse existing precondition recipes to restrict this new recipe to only java < 8.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
