### PR TITLE
Let all change-to-var recipes use a created var-Identifier instead of using a JavaTemplate

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -15,20 +15,27 @@
  */
 package org.openrewrite.java.migrate.lang.var;
 
+import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
 
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.java.tree.Space.EMPTY;
 
+@UtilityClass
 final class DeclarationCheck {
 
-    private DeclarationCheck() {
-
-    }
-
     /**
-     * Determine if var is applicable with regard to location and decleation type.
+     * Determine if var is applicable with regard to location and declaration type.
      * <p>
      * Var is applicable inside methods and initializer blocks for single variable definition.
      * Var is *not* applicable to method definitions.
@@ -119,7 +126,7 @@ final class DeclarationCheck {
     }
 
     /**
-     * Determin if the initilizer uses the ternary operator <code>Expression ? if-then : else</code>
+     * Determine if the initializer uses the ternary operator <code>Expression ? if-then : else</code>
      *
      * @param vd variable declaration at hand
      * @return true iff the ternary operator is used in the initialization
@@ -224,5 +231,30 @@ final class DeclarationCheck {
         }
 
         return invocation.getMethodType().hasFlags(Flag.Static);
+    }
+
+    public static J.VariableDeclarations transformToVar(J.VariableDeclarations vd) {
+        return transformToVar(vd, it -> it);
+    }
+
+    public static <T extends Expression> J.VariableDeclarations transformToVar(J.VariableDeclarations vd, UnaryOperator<T> transformerInitializer) {
+        T initializer = (T) vd.getVariables().get(0).getInitializer();
+        if (initializer == null) {
+            return vd;
+        }
+
+        Expression transformedInitializer = transformerInitializer.apply(initializer);
+
+        List<J.VariableDeclarations.NamedVariable> variables = ListUtils.mapFirst(vd.getVariables(), it -> {
+            JavaType.Variable variableType = it.getVariableType() == null ? null : it.getVariableType().withOwner(null);
+            return it
+                    .withName(it.getName().withType(transformedInitializer.getType()).withFieldType(variableType))
+                    .withInitializer(transformedInitializer)
+                    .withVariableType(variableType);
+        });
+        J.Identifier typeExpression = new J.Identifier(randomId(), vd.getTypeExpression() == null ? EMPTY : vd.getTypeExpression().getPrefix(),
+                Markers.build(singleton(JavaVarKeyword.build())), emptyList(), "var", transformedInitializer.getType(), null);
+
+        return vd.withVariables(variables).withTypeExpression(typeExpression);
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -84,7 +84,8 @@ public class UseVarForGenericMethodInvocations extends Recipe {
 
             return DeclarationCheck.transformToVar(vd);
             // TODO implement to support cases like `var strs = List.<String>of();`
-            /*return DeclarationCheck.<J.MethodInvocation>transformToVar(vd, it -> {
+            /*J.VariableDeclarations finalVd = vd;
+            return DeclarationCheck.<J.MethodInvocation>transformToVar(vd, it -> {
                 // if left is defined but not right, copy types to initializer
                 if (finalVd.getTypeExpression() instanceof J.ParameterizedType && !((J.ParameterizedType) finalVd.getTypeExpression()).getTypeParameters().isEmpty() && it.getTypeParameters() == null) {
                     return it.withTypeParameters(((J.ParameterizedType) finalVd.getTypeExpression()).getPadding().getTypeParameters());

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -71,7 +71,7 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 return vd;
             }
 
-            // If no type paramters are present and no arguments we assume the type is hard to determine a needs manual action
+            // If no type parameters and no arguments are present, we assume the type is too hard to determine
             boolean hasNoTypeParams = ((J.MethodInvocation) initializer).getTypeParameters() == null;
             boolean argumentsEmpty = allArgumentsEmpty((J.MethodInvocation) initializer);
             if (hasNoTypeParams && argumentsEmpty) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -82,14 +82,15 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 maybeRemoveImport((JavaType.FullyQualified) vd.getType());
             }
 
-            return DeclarationCheck.<J.MethodInvocation>transformToVar(vd, it -> {
+            return DeclarationCheck.transformToVar(vd);
+            // TODO implement to support cases like `var strs = List.<String>of();`
+            /*return DeclarationCheck.<J.MethodInvocation>transformToVar(vd, it -> {
                 // if left is defined but not right, copy types to initializer
-                // TODO implement to support cases like `var strs = List.<String>of();`
-                /*if (finalVd.getTypeExpression() instanceof J.ParameterizedType && !((J.ParameterizedType) finalVd.getTypeExpression()).getTypeParameters().isEmpty() && it.getTypeParameters() == null) {
+                if (finalVd.getTypeExpression() instanceof J.ParameterizedType && !((J.ParameterizedType) finalVd.getTypeExpression()).getTypeParameters().isEmpty() && it.getTypeParameters() == null) {
                     return it.withTypeParameters(((J.ParameterizedType) finalVd.getTypeExpression()).getPadding().getTypeParameters());
-                }*/
+                }
                 return it;
-            });
+            });*/
         }
 
         private static boolean allArgumentsEmpty(J.MethodInvocation invocation) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -86,7 +86,7 @@ public class UseVarForGenericMethodInvocations extends Recipe {
             // TODO implement to support cases like `var strs = List.<String>of();`
             /*J.VariableDeclarations finalVd = vd;
             return DeclarationCheck.<J.MethodInvocation>transformToVar(vd, it -> {
-                // if left is defined but not right, copy types to initializer
+                // If left has generics but right has not, copy types parameters
                 if (finalVd.getTypeExpression() instanceof J.ParameterizedType && !((J.ParameterizedType) finalVd.getTypeExpression()).getTypeParameters().isEmpty() && it.getTypeParameters() == null) {
                     return it.withTypeParameters(((J.ParameterizedType) finalVd.getTypeExpression()).getPadding().getTypeParameters());
                 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
@@ -20,19 +20,15 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesJavaVersion;
-import org.openrewrite.java.tree.*;
-import org.openrewrite.marker.Markers;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeTree;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
-import static org.openrewrite.Tree.randomId;
 
 public class UseVarForGenericsConstructors extends Recipe {
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -22,13 +22,10 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeTree;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -58,11 +55,6 @@ public class UseVarForObject extends Recipe {
 
 
     static final class UseVarForObjectVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private final JavaTemplate template = JavaTemplate.builder("var #{} = #{any()};")
-                .contextSensitive()
-                .javaParser(JavaParser.fromJavaVersion()).build();
-
-
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations vd, ExecutionContext ctx) {
             vd = super.visitVariableDeclarations(vd, ctx);
@@ -82,30 +74,11 @@ public class UseVarForObject extends Recipe {
                 return vd;
             }
 
-            // mark imports for removal if unused
             if (vd.getType() instanceof JavaType.FullyQualified) {
                 maybeRemoveImport( (JavaType.FullyQualified) vd.getType() );
             }
 
-            return transformToVar(vd);
-        }
-
-
-        private J.VariableDeclarations transformToVar(J.VariableDeclarations vd) {
-            Expression initializer = vd.getVariables().get(0).getInitializer();
-            String simpleName = vd.getVariables().get(0).getSimpleName();
-
-            if (vd.getModifiers().isEmpty()) {
-                return template.apply(getCursor(), vd.getCoordinates().replace(), simpleName, initializer)
-                        .withPrefix(vd.getPrefix());
-            } else {
-                J.VariableDeclarations result = template.<J.VariableDeclarations>apply(getCursor(), vd.getCoordinates().replace(), simpleName, initializer)
-                        .withModifiers(vd.getModifiers())
-                        .withPrefix(vd.getPrefix());
-                TypeTree typeExpression = result.getTypeExpression();
-                //noinspection DataFlowIssue
-                return typeExpression != null ? result.withTypeExpression(typeExpression.withPrefix(vd.getTypeExpression().getPrefix())) : vd;
-            }
+            return DeclarationCheck.transformToVar(vd);
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitive.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitive.java
@@ -22,14 +22,12 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
 
 import static java.lang.String.format;
+import static org.openrewrite.java.tree.JavaType.Primitive.*;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -58,14 +56,6 @@ public class UseVarForPrimitive extends Recipe {
     }
 
     static final class VarForPrimitivesVisitor extends JavaIsoVisitor<ExecutionContext> {
-
-        private final JavaType.Primitive SHORT_TYPE = JavaType.Primitive.Short;
-        private final JavaType.Primitive BYTE_TYPE = JavaType.Primitive.Byte;
-
-        private final JavaTemplate template = JavaTemplate.builder("var #{} = #{any()}")
-                .javaParser(JavaParser.fromJavaVersion()).build();
-
-
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations vd, ExecutionContext ctx) {
             vd = super.visitVariableDeclarations(vd, ctx);
@@ -75,40 +65,17 @@ public class UseVarForPrimitive extends Recipe {
                 return vd;
             }
 
-            // recipe specific
+            // Recipe specific
             boolean isNoPrimitive = !DeclarationCheck.isPrimitive(vd);
-            boolean isByteVariable = DeclarationCheck.declarationHasType(vd, BYTE_TYPE);
-            boolean isShortVariable = DeclarationCheck.declarationHasType(vd, SHORT_TYPE);
+            boolean isByteVariable = DeclarationCheck.declarationHasType(vd, Byte);
+            boolean isShortVariable = DeclarationCheck.declarationHasType(vd, Short);
             if (isNoPrimitive || isByteVariable || isShortVariable) {
                 return vd;
             }
 
-            // no need to remove imports, because primitives are never imported
-
-            return transformToVar(vd);
+            J.VariableDeclarations finalVd = vd;
+            return DeclarationCheck.transformToVar(vd, it -> it instanceof J.Literal ? expandWithPrimitivTypeHint(finalVd, it) : it);
         }
-
-
-        private J.VariableDeclarations transformToVar(J.VariableDeclarations vd) {
-            Expression initializer = vd.getVariables().get(0).getInitializer();
-            String simpleName = vd.getVariables().get(0).getSimpleName();
-
-            if (initializer instanceof J.Literal) {
-                initializer = expandWithPrimitivTypeHint(vd, initializer);
-            }
-
-            if (vd.getModifiers().isEmpty()) {
-                return template.apply(getCursor(), vd.getCoordinates().replace(), simpleName, initializer)
-                        .withPrefix(vd.getPrefix());
-            } else {
-                J.VariableDeclarations result = template.<J.VariableDeclarations>apply(getCursor(), vd.getCoordinates().replace(), simpleName, initializer)
-                        .withModifiers(vd.getModifiers())
-                        .withPrefix(vd.getPrefix());
-                //noinspection DataFlowIssue
-                return result.withTypeExpression(result.getTypeExpression().withPrefix(vd.getTypeExpression().getPrefix()));
-            }
-        }
-
 
         private Expression expandWithPrimitivTypeHint(J.VariableDeclarations vd, Expression initializer) {
             String valueSource = ((J.Literal) initializer).getValueSource();
@@ -117,11 +84,11 @@ public class UseVarForPrimitive extends Recipe {
                 return initializer;
             }
 
-            boolean isLongLiteral = JavaType.Primitive.Long == vd.getType();
+            boolean isLongLiteral = Long == vd.getType();
             boolean inferredAsLong = valueSource.endsWith("l") || valueSource.endsWith("L");
-            boolean isFloatLiteral = JavaType.Primitive.Float == vd.getType();
+            boolean isFloatLiteral = Float == vd.getType();
             boolean inferredAsFloat = valueSource.endsWith("f") || valueSource.endsWith("F");
-            boolean isDoubleLiteral = JavaType.Primitive.Double == vd.getType();
+            boolean isDoubleLiteral = Double == vd.getType();
             boolean inferredAsDouble = valueSource.endsWith("d") || valueSource.endsWith("D") || valueSource.contains(".");
 
             String typNotation = null;

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -85,7 +85,7 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
 
             @Test
             void withEmptyOnwNonStaticFactoryMethods() {
-                //if detectable this could be `var strs = this.<String>myList();`
+                // TODO: this could be `var strs = this.<String>myList();`
                 //language=java
                 rewriteRun(
                   version(
@@ -110,7 +110,7 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
 
             @Test
             void withEmptyOnwFactoryMethods() {
-                // if detectable this could be `var strs = A.<String>myList();`
+                // TODO: this could be `var strs = A.<String>myList();`
                 //language=java
                 rewriteRun(
                   version(
@@ -135,7 +135,7 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
 
             @Test
             void forEmptyJDKFactoryMethod() {
-                // if detectable this could be `var strs = List.<String>of();`
+                // TODO: this could be `var strs = List.<String>of();`
                 //language=java
                 rewriteRun(
                   version(


### PR DESCRIPTION
## What's changed?
Nothing, just refactoring.

## What's your motivation?
- https://github.com/openrewrite/rewrite-migrate-java/pull/789#discussion_r2194267438

## Any additional context
The `UseVarForGenericMethodInvocations` recipe is actually not complete of yet. I didn't want to change any logic, so I wrote a small incomplete implementation in comments.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
