### PR TITLE
Fix NPE in IteratorNext recipe when iterator() has no explicit receiver

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/IteratorNext.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/IteratorNext.java
@@ -59,7 +59,7 @@ public class IteratorNext extends Recipe {
                         if (NEXT_MATCHER.matches(nextInvocation) && ITERATOR_MATCHER.matches(nextInvocation.getSelect())) {
                             J.MethodInvocation iteratorInvocation = (J.MethodInvocation) nextInvocation.getSelect();
                             Expression iteratorSelect = iteratorInvocation.getSelect();
-                            if (TypeUtils.isAssignableTo("java.util.SequencedCollection", iteratorSelect.getType())) {
+                            if (iteratorSelect != null && TypeUtils.isAssignableTo("java.util.SequencedCollection", iteratorSelect.getType())) {
                                 JavaType.Method getFirst = iteratorInvocation.getMethodType().withName("getFirst");
                                 return iteratorInvocation
                                         .withName(iteratorInvocation.getName().withSimpleName("getFirst").withType(getFirst))

--- a/src/test/java/org/openrewrite/java/migrate/util/IteratorNextTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/IteratorNextTest.java
@@ -140,4 +140,22 @@ class IteratorNextTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void implicitThisIteratorNextUnchanged() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Foo extends ArrayList<String> {
+                  void bar() {
+                      String first = iterator().next();
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes a NullPointerException in the `IteratorNext` recipe when encountering `iterator().next()` calls without an explicit receiver
- Adds null check for `iteratorSelect` before attempting to check its type

## Test plan
- [x] Added test case `implicitThisIteratorNextUnchanged()` to verify the recipe handles implicit receiver cases
- [x] All existing tests pass
- [x] The recipe no longer throws NPE on code like the one found in classgraph's MethodInfoList.java:205

🤖 Generated with [Claude Code](https://claude.ai/code)