### PR TITLE
fix test due to change in `ChangeTagAttribute`

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxBeansXmlToJakartaBeansXmlTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxBeansXmlToJakartaBeansXmlTest.java
@@ -39,7 +39,6 @@ class JavaxBeansXmlToJakartaBeansXmlTest implements RewriteTest {
     @Test
     void noSchemaCD1() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
           //language=xml
           xml(
             """
@@ -64,7 +63,6 @@ class JavaxBeansXmlToJakartaBeansXmlTest implements RewriteTest {
     @Test
     void noSchemaCD12() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
           //language=xml
           xml(
             """


### PR DESCRIPTION
## What's changed?
Test were 

## What's your motivation?
Tests [were failing](https://ge.openrewrite.org/s/2dycsj3ll2neg) since openrewrite/rewrite#5769 got merged
> java.lang.AssertionError: Expected recipe to complete in 2 cycles, but took 1 cycle. This usually indicates the recipe is making changes after it should have stabilized.

`JavaxBeansXmlToJakartaBeansXmlTest`:
* `noSchemaCD12`
* `noSchemaCD1`
### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
