### PR TITLE
The quick fix for the tests for Jaxws Dependencies

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -138,12 +138,6 @@ recipeList:
       newGroupId: jakarta.xml.ws
       newArtifactId: jakarta.xml.ws-api
       newVersion: 2.3.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: javax.xml.ws
-      oldArtifactId: jaxws-api
-      newGroupId: jakarta.xml.ws
-      newArtifactId: jakarta.xml.ws-api
-      newVersion: 2.3.x
   # Add the jakarta JAXB artifact if it is missing but a project uses types in either javax.jws or javax.xml.ws
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: jakarta.xml.ws
@@ -168,11 +162,11 @@ recipeList:
   - org.openrewrite.maven.RemoveRedundantDependencyVersions:
       groupPattern: jakarta.xml.ws
       artifactPattern: "*"
-      onlyIfVersionsMatch: true
+      onlyIfManagedVersionIs: EQ
   - org.openrewrite.maven.RemoveRedundantDependencyVersions:
       groupPattern: com.sun.xml.ws
       artifactPattern: "*"
-      onlyIfVersionsMatch: true
+      onlyIfManagedVersionIs: EQ
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.InternalBindPackages

--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -143,7 +143,7 @@ class UpdateSdkManTest implements RewriteTest {
               java=11.0.25.fx-zulu
               """,
             """
-              java=17.0.15.fx-zulu
+              java=17.0.16.fx-zulu
               """,
             spec -> spec.path(".sdkmanrc")
           )

--- a/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddJaxwsDependenciesTest.java
@@ -198,11 +198,13 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   }
 
                   dependencies {
-                      implementation "com.sun.xml.ws:jaxws-rt:%s"
+                      compileOnly "com.sun.xml.ws:jaxws-rt:%s"
 
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
+
+                      testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
-                  """.formatted(rtVersion, wsApiVersion);
+                  """.formatted(rtVersion, wsApiVersion, rtVersion);
             })
           ),
           pomXml(
@@ -299,11 +301,13 @@ class AddJaxwsDependenciesTest implements RewriteTest {
                   }
 
                   dependencies {
-                      implementation "com.sun.xml.ws:jaxws-rt:%s"
+                      compileOnly "com.sun.xml.ws:jaxws-rt:%s"
 
                       implementation "jakarta.xml.ws:jakarta.xml.ws-api:%s"
+
+                      testImplementation "com.sun.xml.ws:jaxws-rt:%s"
                   }
-                  """.formatted(rtVersion, wsApiVersion);
+                  """.formatted(rtVersion, wsApiVersion, rtVersion);
             })
           ),
           pomXml(


### PR DESCRIPTION
## What's changed?
- Changes the expectation based on what the actual `AddJaxwsRuntime` behaves like.

## What's your motivation?
Broken tests

## Any additional context
There are a couple things that I think need to be reworked around the recipe `AddJaxwsRuntime` and the composite recipe `AddJaxwsDependencies` that calls it, but I can make that into a separate issue.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
