### PR TITLE
Joda-time: Make safe migration optional

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -15,12 +15,12 @@
  */
 package org.openrewrite.java.migrate.joda;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Value;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
-import org.openrewrite.ScanningRecipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
+import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.J.VariableDeclarations.NamedVariable;
@@ -30,7 +30,22 @@ import java.util.*;
 
 import static java.util.Collections.emptyList;
 
+@EqualsAndHashCode(callSuper = false)
+@Value
 public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
+
+    /**
+     * Controls whether additional safety checks are performed during the migration process.
+     * When enabled, the recipe will verify that expressions are safe to migrate before performing the migration.
+     * This helps prevent potential issues or bugs that might arise from automatic migration.
+     */
+    @Option(displayName = "Enable safe migration",
+      description = "When enabled, performs additional safety checks to verify that expressions are safe to migrate before converting them. " +
+                    "Safety checks include analyzing method parameters, return values, and variable usages across class boundaries.",
+      required = false
+    )
+    Boolean safeMigration;
+
     @Override
     public String getDisplayName() {
         return "Migrate Joda-Time to Java time";
@@ -53,7 +68,7 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
-        JodaTimeVisitor jodaTimeVisitor = new JodaTimeVisitor(acc, true, new LinkedList<>());
+        JodaTimeVisitor jodaTimeVisitor = new JodaTimeVisitor(acc, safeMigration, new LinkedList<>());
         return Preconditions.check(new UsesType<>("org.joda.time.*", true), jodaTimeVisitor);
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -20,7 +20,6 @@ import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.J.VariableDeclarations.NamedVariable;

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -44,6 +44,7 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
                     "Safety checks include analyzing method parameters, return values, and variable usages across class boundaries.",
       required = false
     )
+    @Nullable
     Boolean safeMigration;
 
     @Override
@@ -63,12 +64,12 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
-        return new JodaTimeScanner(acc, safeMigration);
+        return new JodaTimeScanner(acc, Boolean.TRUE.equals(safeMigration));
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
-        JodaTimeVisitor jodaTimeVisitor = new JodaTimeVisitor(acc, safeMigration, new LinkedList<>());
+        JodaTimeVisitor jodaTimeVisitor = new JodaTimeVisitor(acc, Boolean.TRUE.equals(safeMigration), new LinkedList<>());
         return Preconditions.check(new UsesType<>("org.joda.time.*", true), jodaTimeVisitor);
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -63,7 +63,7 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
-        return new JodaTimeScanner(acc);
+        return new JodaTimeScanner(acc, safeMigration);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeRecipe.java
@@ -38,13 +38,13 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
      * When enabled, the recipe will verify that expressions are safe to migrate before performing the migration.
      * This helps prevent potential issues or bugs that might arise from automatic migration.
      */
-    @Option(displayName = "Enable safe migration",
+    @Option(displayName = "Safe migration only",
       description = "When enabled, performs additional safety checks to verify that expressions are safe to migrate before converting them. " +
                     "Safety checks include analyzing method parameters, return values, and variable usages across class boundaries.",
       required = false
     )
     @Nullable
-    Boolean safeMigration;
+    Boolean safeMigrationOnly;
 
     @Override
     public String getDisplayName() {
@@ -63,12 +63,12 @@ public class JodaTimeRecipe extends ScanningRecipe<JodaTimeRecipe.Accumulator> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
-        return new JodaTimeScanner(acc, Boolean.TRUE.equals(safeMigration));
+        return new JodaTimeScanner(acc, Boolean.TRUE.equals(safeMigrationOnly));
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
-        JodaTimeVisitor jodaTimeVisitor = new JodaTimeVisitor(acc, Boolean.TRUE.equals(safeMigration), new LinkedList<>());
+        JodaTimeVisitor jodaTimeVisitor = new JodaTimeVisitor(acc, Boolean.TRUE.equals(safeMigrationOnly), new LinkedList<>());
         return Preconditions.check(new UsesType<>("org.joda.time.*", true), jodaTimeVisitor);
     }
 

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
@@ -41,7 +41,7 @@ class JodaTimeScanner extends ScopeAwareVisitor {
 
     @Getter
     private final JodaTimeRecipe.Accumulator acc;
-    private final boolean safeMigration;
+    private final boolean safeMigrationOnly;
 
     private final Map<NamedVariable, Set<NamedVariable>> varDependencies = new HashMap<>();
     private final Map<JavaType, Set<String>> unsafeVarsByType = new HashMap<>();
@@ -52,10 +52,10 @@ class JodaTimeScanner extends ScopeAwareVisitor {
         this(acc, true);
     }
 
-    public JodaTimeScanner(JodaTimeRecipe.Accumulator acc, boolean safeMigration) {
+    public JodaTimeScanner(JodaTimeRecipe.Accumulator acc, boolean safeMigrationOnly) {
         super(new LinkedList<>());
         this.acc = acc;
-        this.safeMigration = safeMigration;
+        this.safeMigrationOnly = safeMigrationOnly;
     }
 
     @Override
@@ -73,7 +73,7 @@ class JodaTimeScanner extends ScopeAwareVisitor {
 
     @Override
     public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-        if (!safeMigration) { // skip scan if safe mode is disabled
+        if (!safeMigrationOnly) { // skip scan if safe mode is disabled
             return cu;
         }
         super.visitCompilationUnit(cu, ctx);

--- a/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
+++ b/src/main/java/org/openrewrite/java/migrate/joda/JodaTimeScanner.java
@@ -41,6 +41,7 @@ class JodaTimeScanner extends ScopeAwareVisitor {
 
     @Getter
     private final JodaTimeRecipe.Accumulator acc;
+    private final boolean safeMigration;
 
     private final Map<NamedVariable, Set<NamedVariable>> varDependencies = new HashMap<>();
     private final Map<JavaType, Set<String>> unsafeVarsByType = new HashMap<>();
@@ -48,8 +49,13 @@ class JodaTimeScanner extends ScopeAwareVisitor {
     private final Map<JavaType.Method, Set<UnresolvedVar>> methodUnresolvedReferencedVars = new HashMap<>();
 
     public JodaTimeScanner(JodaTimeRecipe.Accumulator acc) {
+        this(acc, true);
+    }
+
+    public JodaTimeScanner(JodaTimeRecipe.Accumulator acc, boolean safeMigration) {
         super(new LinkedList<>());
         this.acc = acc;
+        this.safeMigration = safeMigration;
     }
 
     @Override
@@ -67,6 +73,9 @@ class JodaTimeScanner extends ScopeAwareVisitor {
 
     @Override
     public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+        if (!safeMigration) { // skip scan if safe mode is disabled
+            return cu;
+        }
         super.visitCompilationUnit(cu, ctx);
         Set<NamedVariable> allReachable = new HashSet<>();
         for (NamedVariable var : acc.getUnsafeVars()) {

--- a/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/BouncyCastleTest.java
@@ -72,7 +72,7 @@ class BouncyCastleTest implements RewriteTest {
                 .afterRecipe(doc -> assertThat(doc.getMarkers().findFirst(MavenResolutionResult.class)
                   .get().getDependencies().get(Scope.Compile))
                   .filteredOn(rd -> rd.getDepth() == 0)
-                  .satisfiesExactly(
+                  .satisfiesExactlyInAnyOrder(
                     rd -> {
                         assertThat(rd.getGroupId()).isEqualTo("org.bouncycastle");
                         assertThat(rd.getArtifactId()).isEqualTo("bcprov-jdk18on");

--- a/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/joda/JodaTimeRecipeTest.java
@@ -30,7 +30,7 @@ class JodaTimeRecipeTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .recipe(new JodaTimeRecipe())
+          .recipe(new JodaTimeRecipe(true))
           .parser(JavaParser.fromJavaVersion().classpath("joda-time"));
     }
 


### PR DESCRIPTION
## What's changed?
The JodaTimeRecipe has been updated to make the safe migration feature optional. Previously, safe migration was mandatory; this change introduces a new safeMigration flag, which defaults to false. Developers can enable safe migration explicitly by setting safeMigration to true.

https://docs.openrewrite.org/recipes/java/migrate/joda/jodatimerecipe

## What's your motivation?
Making safe migration optional helps reduce coverage impact and allows developers to focus on fixing compilation errors incrementally, improving overall adoption flexibility.

