### PR TITLE
Improve Java 17 and Java 21 switch expression tests

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-21.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-21.yml
@@ -136,7 +136,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.SwitchPatternMatching
 displayName: Adopt switch pattern matching (JEP 441)
-description: ->-
+description: >-
   [JEP 441](https://openjdk.org/jeps/441) describes how some switch statements can be improved with pattern matching.
   This recipe applies some of those improvements where applicable.
 tags:

--- a/src/test/java/org/openrewrite/java/migrate/lang/EnhancedSwitchCaseAssignmentsToSwitchExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/EnhancedSwitchCaseAssignmentsToSwitchExpressionTest.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+@SuppressWarnings({"EnhancedSwitchMigration", "RedundantLabeledSwitchRuleCodeBlock", "UnusedAssignment"})
+class EnhancedSwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new SwitchCaseAssignmentsToSwitchExpression())
+          .allSources(source -> version(source, 21));
+    }
+
+    @Test
+    void convertSimpleArrowCasesAssignment() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case Integer i -> formatted = String.format("int %d", i);
+                          case Long l -> formatted = String.format("long %d", l);
+                          default -> formatted = "unknown";
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = switch (obj) {
+                          case Integer i -> String.format("int %d", i);
+                          case Long l -> String.format("long %d", l);
+                          default -> "unknown";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertSimpleColonCasesAssignment() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case Integer i: formatted = String.format("int %d", i); break;
+                          case Long l: formatted = String.format("long %d", l); break;
+                          default: formatted = "unknown"; break;
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = switch (obj) {
+                          case Integer i -> String.format("int %d", i);
+                          case Long l -> String.format("long %d", l);
+                          default -> "unknown";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notConvertSimpleColonCasesAssignmentWithExtraCodeInBlock() {
+        // Only one statement [+break;] per case is currently supported
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case Integer i: formatted = String.format("int %d", i); break;
+                          case Long l: System.out.println("long"); formatted = String.format("long %d", l); break;
+                          default: formatted = "unknown"; break;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertColonCasesSimpleAssignmentInBlockToSingleYield() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case Integer i: formatted = String.format("int %d", i); break;
+                          case Long l: {
+                              formatted = String.format("long %d", l);
+                              break;
+                          }
+                          default: formatted = "unknown"; break;
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = switch (obj) {
+                          case Integer i -> String.format("int %d", i);
+                          case Long l -> String.format("long %d", l);
+                          default -> "unknown";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertColonCasesSimpleAssignmentInBlockToSingleYieldWithoutFinalCaseBreak() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case Integer i: formatted = String.format("int %d", i); break;
+                          case Long l: {
+                              formatted = String.format("long %d", l);
+                              break;
+                          }
+                          default: formatted = "unknown";
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = switch (obj) {
+                          case Integer i -> String.format("int %d", i);
+                          case Long l -> String.format("long %d", l);
+                          default -> "unknown";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void convertArrowCasesSimpleAssignmentInBlockToSingleValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case Integer i -> formatted = String.format("int %d", i);
+                          case Long l -> {
+                              formatted = String.format("long %d", l);
+                          }
+                          default -> formatted = "unknown";
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = switch (obj) {
+                          case Integer i -> String.format("int %d", i);
+                          case Long l -> String.format("long %d", l);
+                          default -> "unknown";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notConvertCasesWithMissingAssignment() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case String s: formatted = String.format("String %s", s); break;
+                          case Integer i: System.out.println("Integer!"); break;
+                          default: formatted = "unknown"; break;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notConvertCasesWithAssignmentToDifferentVariables() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void doFormat(Object obj) {
+                      String formatted = "initialValue";
+                      String formatted2 = "anotherInitialValue";
+                      switch (obj) {
+                          case String s: formatted = String.format("String %s", s); break;
+                          case Integer i: formatted2 = String.format("Integer %d", i); break;
+                          default: formatted = "unknown"; break;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void defaultAsSecondLabelColonCase() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void doFormat(String str) {
+                      String formatted = "initialValue";
+                      switch (str) {
+                          case "foo": formatted = "Foo"; break;
+                          case "bar": formatted = "Bar"; break;
+                          case null, default: formatted = "unknown";
+                      }
+                  }
+              }
+              """,
+            """
+              class A {
+                  void doFormat(String str) {
+                      String formatted = switch (str) {
+                          case "foo" -> "Foo";
+                          case "bar" -> "Bar";
+                          case null, default -> "unknown";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void defaultAsSecondLabelArrowCase() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class B {
+                  void doFormat(String str) {
+                      String formatted = "initialValue";
+                      switch (str) {
+                          case "foo" -> formatted = "Foo";
+                          case "bar" -> formatted = "Bar";
+                          case null, default -> formatted = "Other";
+                      }
+                  }
+              }
+              """,
+            """
+              class B {
+                  void doFormat(String str) {
+                      String formatted = switch (str) {
+                          case "foo" -> "Foo";
+                          case "bar" -> "Bar";
+                          case null, default -> "Other";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpressionTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
 
-@SuppressWarnings({"EnhancedSwitchMigration", "RedundantLabeledSwitchRuleCodeBlock", "StringOperationCanBeSimplified", "SwitchStatementWithTooFewBranches", "UnnecessaryReturnStatement", "UnusedAssignment"})
+@SuppressWarnings({"EnhancedSwitchMigration", "StringOperationCanBeSimplified", "SwitchStatementWithTooFewBranches", "UnnecessaryReturnStatement", "UnusedAssignment"})
 class SwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
@@ -34,231 +34,35 @@ class SwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void convertSimpleArrowCasesAssignment() {
+    void convertCasesWithAddedDefault() {
         rewriteRun(
           //language=java
           java(
             """
               class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      switch (obj) {
-                          case Integer i -> formatted = String.format("int %d", i);
-                          case Long l -> formatted = String.format("long %d", l);
-                          default -> formatted = "unknown";
+                  enum TrafficLight {
+                      RED, GREEN, YELLOW
+                  }
+                  void doFormat(TrafficLight light) {
+                      String status = "initialValue";
+                      switch (light) {
+                          case RED: status = "stop"; break;
+                          case GREEN: status = "go"; break;
                       }
                   }
               }
               """,
             """
               class Test {
-                  void doFormat(Object obj) {
-                      String formatted = switch (obj) {
-                          case Integer i -> String.format("int %d", i);
-                          case Long l -> String.format("long %d", l);
-                          default -> "unknown";
+                  enum TrafficLight {
+                      RED, GREEN, YELLOW
+                  }
+                  void doFormat(TrafficLight light) {
+                      String status = switch (light) {
+                          case RED -> "stop";
+                          case GREEN -> "go";
+                          default -> "initialValue";
                       };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void convertSimpleColonCasesAssignment() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      switch (obj) {
-                          case Integer i: formatted = String.format("int %d", i); break;
-                          case Long l: formatted = String.format("long %d", l); break;
-                          default: formatted = "unknown"; break;
-                      }
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = switch (obj) {
-                          case Integer i -> String.format("int %d", i);
-                          case Long l -> String.format("long %d", l);
-                          default -> "unknown";
-                      };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void notConvertSimpleColonCasesAssignmentWithExtraCodeInBlock() {
-        // Only one statement [+break;] per case is currently supported
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      switch (obj) {
-                          case Integer i: formatted = String.format("int %d", i); break;
-                          case Long l: System.out.println("long"); formatted = String.format("long %d", l); break;
-                          default: formatted = "unknown"; break;
-                      }
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void convertColonCasesSimpleAssignmentInBlockToSingleYield() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      switch (obj) {
-                          case Integer i: formatted = String.format("int %d", i); break;
-                          case Long l: {
-                              formatted = String.format("long %d", l);
-                              break;
-                          }
-                          default: formatted = "unknown"; break;
-                      }
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = switch (obj) {
-                          case Integer i -> String.format("int %d", i);
-                          case Long l -> String.format("long %d", l);
-                          default -> "unknown";
-                      };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void convertColonCasesSimpleAssignmentInBlockToSingleYieldWithoutFinalCaseBreak() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      switch (obj) {
-                          case Integer i: formatted = String.format("int %d", i); break;
-                          case Long l: {
-                              formatted = String.format("long %d", l);
-                              break;
-                          }
-                          default: formatted = "unknown";
-                      }
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = switch (obj) {
-                          case Integer i -> String.format("int %d", i);
-                          case Long l -> String.format("long %d", l);
-                          default -> "unknown";
-                      };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void convertArrowCasesSimpleAssignmentInBlockToSingleValue() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      switch (obj) {
-                          case Integer i -> formatted = String.format("int %d", i);
-                          case Long l -> {
-                              formatted = String.format("long %d", l);
-                          }
-                          default -> formatted = "unknown";
-                      }
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = switch (obj) {
-                          case Integer i -> String.format("int %d", i);
-                          case Long l -> String.format("long %d", l);
-                          default -> "unknown";
-                      };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void notConvertCasesWithMissingAssignment() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      switch (obj) {
-                          case String s: formatted = String.format("String %s", s); break;
-                          case Integer i: System.out.println("Integer!"); break;
-                          default: formatted = "unknown"; break;
-                      }
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void notConvertCasesWithAssignmentToDifferentVariables() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  void doFormat(Object obj) {
-                      String formatted = "initialValue";
-                      String formatted2 = "anotherInitialValue";
-                      switch (obj) {
-                          case String s: formatted = String.format("String %s", s); break;
-                          case Integer i: formatted2 = String.format("Integer %d", i); break;
-                          default: formatted = "unknown"; break;
-                      }
                   }
               }
               """
@@ -273,10 +77,10 @@ class SwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
           java(
             """
               class Test {
-                  void doFormat(Object obj) {
+                  void doFormat(String s) {
                       String status = "initialValue";
-                      switch (obj) {
-                          case null:
+                      switch (s) {
+                          case "x":
                           default: System.out.println("default"); break;
                       }
                   }
@@ -327,43 +131,6 @@ class SwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
     }
 
     @Test
-    void convertCasesWithAddedDefault() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  enum TrafficLight {
-                      RED, GREEN, YELLOW
-                  }
-                  void doFormat(TrafficLight light) {
-                      String status = "initialValue";
-                      switch (light) {
-                          case RED: status = "stop"; break;
-                          case GREEN: status = "go"; break;
-                      }
-                  }
-              }
-              """,
-            """
-              class Test {
-                  enum TrafficLight {
-                      RED, GREEN, YELLOW
-                  }
-                  void doFormat(TrafficLight light) {
-                      String status = switch (light) {
-                          case RED -> "stop";
-                          case GREEN -> "go";
-                          default -> "initialValue";
-                      };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
     void notConvertColonCasesWithMultipleBlocks() {
         // More than one block statement per case is not yet supported.
         rewriteRun(
@@ -371,10 +138,10 @@ class SwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
           java(
             """
               class Test {
-                  void doFormat(Object obj) {
+                  void doFormat(String s) {
                       String status = "initialValue";
-                      switch (obj) {
-                          case null: {
+                      switch (s) {
+                          case "x": {
                               status = "none";
                           }
                           {
@@ -697,69 +464,6 @@ class SwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
                           default -> "foo";
                       };
                       return;
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void defaultAsSecondLabelColonCase() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class A {
-                  void doFormat(String str) {
-                      String formatted = "initialValue";
-                      switch (str) {
-                          case "foo": formatted = "Foo"; break;
-                          case "bar": formatted = "Bar"; break;
-                          case null, default: formatted = "unknown";
-                      }
-                  }
-              }
-              """,
-            """
-              class A {
-                  void doFormat(String str) {
-                      String formatted = switch (str) {
-                          case "foo" -> "Foo";
-                          case "bar" -> "Bar";
-                          case null, default -> "unknown";
-                      };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void defaultAsSecondLabelArrowCase() {
-        rewriteRun(
-          java(
-            """
-              class B {
-                  void doFormat(String str) {
-                      String formatted = "initialValue";
-                      switch (str) {
-                          case "foo" -> formatted = "Foo";
-                          case "bar" -> formatted = "Bar";
-                          case null, default -> formatted = "Other";
-                      }
-                  }
-              }
-              """,
-            """
-              class B {
-                  void doFormat(String str) {
-                      String formatted = switch (str) {
-                          case "foo" -> "Foo";
-                          case "bar" -> "Bar";
-                          case null, default -> "Other";
-                      };
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpressionTest.java
@@ -21,8 +21,7 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.javaVersion;
+import static org.openrewrite.java.Assertions.*;
 
 class SwitchCaseReturnsToSwitchExpressionTest implements RewriteTest {
 
@@ -43,9 +42,9 @@ class SwitchCaseReturnsToSwitchExpressionTest implements RewriteTest {
                 class Test {
                     String doFormat(String str) {
                         switch (str) {
-                            case "foo": return "Foo";
-                            case "bar": return "Bar";
-                            case null, default: return "Other";
+                            case "foo", "bar": return "FooBar";
+                            case "baz": return "Baz";
+                            default: return "Other";
                         }
                     }
                 }
@@ -54,9 +53,9 @@ class SwitchCaseReturnsToSwitchExpressionTest implements RewriteTest {
                 class Test {
                     String doFormat(String str) {
                         return switch (str) {
-                            case "foo" -> "Foo";
-                            case "bar" -> "Bar";
-                            case null, default -> "Other";
+                            case "foo", "bar" -> "FooBar";
+                            case "baz" -> "Baz";
+                            default -> "Other";
                         };
                     }
                 }
@@ -299,6 +298,37 @@ class SwitchCaseReturnsToSwitchExpressionTest implements RewriteTest {
                 }
                 """
             )
+        );
+    }
+
+    @Test
+    void supportMultiLabelWithNullSwitch() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                class Test {
+                    String doFormat(String str) {
+                        switch (str) {
+                            case "foo", "bar": return "FooBar";
+                            case null, default: return "Other";
+                        }
+                    }
+                }
+                """,
+              """
+                class Test {
+                    String doFormat(String str) {
+                        return switch (str) {
+                            case "foo", "bar" -> "FooBar";
+                            case null, default -> "Other";
+                        };
+                    }
+                }
+                """
+            ),
+            21)
         );
     }
 }


### PR DESCRIPTION
## What's changed?
Nothing. Only the tests are restructured between Java 17 and Java 21.

## What's your motivation?
The recipes target constructs related to the enhanced switch feature introduced in newer Java versions. While the recipes never produce uncompilable code, they can transform code into forms that are only valid starting from Java 21 (for example, a multi-label case that includes null and default).

To ensure tests accurately reflect the language features available in each version, I either split up the test file or used the `version` function to inform the reader this setup is only possible with Java 21.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
