### PR TITLE
Prevent switch expression migrations that produce uncompilable code on Java 17

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpression.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpression.java
@@ -63,8 +63,8 @@ public class SwitchCaseAssignmentsToSwitchExpression extends Recipe {
 
             @Override
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                supportsMultiCaseLabelsWithDefaultCase = SwitchUtils.supportsMultiCaseLabelsWithDefaultCase(cu);
                 return super.visitCompilationUnit(cu, ctx);
-                return super.visitCompilationUnit(cu, executionContext);
             }
 
             @Override

--- a/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpression.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpression.java
@@ -62,8 +62,8 @@ public class SwitchCaseAssignmentsToSwitchExpression extends Recipe {
             boolean supportsMultiCaseLabelsWithDefaultCase = false;
 
             @Override
-            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
-                supportsMultiCaseLabelsWithDefaultCase = SwitchUtils.supportsMultiCaseLabelsWithDefaultCase(cu);
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                return super.visitCompilationUnit(cu, ctx);
                 return super.visitCompilationUnit(cu, executionContext);
             }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpression.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpression.java
@@ -58,8 +58,8 @@ public class SwitchCaseReturnsToSwitchExpression extends Recipe {
             boolean supportsMultiCaseLabelsWithDefaultCase = false;
 
             @Override
-            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
-                supportsMultiCaseLabelsWithDefaultCase = SwitchUtils.supportsMultiCaseLabelsWithDefaultCase(cu);
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                return super.visitCompilationUnit(cu, ctx);
                 return super.visitCompilationUnit(cu, executionContext);
             }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpression.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpression.java
@@ -59,8 +59,8 @@ public class SwitchCaseReturnsToSwitchExpression extends Recipe {
 
             @Override
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                supportsMultiCaseLabelsWithDefaultCase = SwitchUtils.supportsMultiCaseLabelsWithDefaultCase(cu);
                 return super.visitCompilationUnit(cu, ctx);
-                return super.visitCompilationUnit(cu, executionContext);
             }
 
             @Override

--- a/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseAssignmentsToSwitchExpressionTest.java
@@ -622,4 +622,44 @@ class SwitchCaseAssignmentsToSwitchExpressionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void notConvertWhenDefaultAsSecondLabelColonCase() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void doFormat(String str) {
+                      String formatted = "initialValue";
+                      switch (str) {
+                          case "foo": formatted = "Foo"; break;
+                          case "ignored", default: formatted = "unknown";
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notConvertWhenDefaultAsSecondLabelArrowCase() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class B {
+                  void doFormat(String str) {
+                      String formatted = "initialValue";
+                      switch (str) {
+                          case "foo" -> formatted = "Foo";
+                          case "ignored", default -> formatted = "Other";
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/SwitchCaseReturnsToSwitchExpressionTest.java
@@ -76,7 +76,7 @@ class SwitchCaseReturnsToSwitchExpressionTest implements RewriteTest {
                     switch (str) {
                         case "foo": return "Foo";
                         case "bar": return "Bar";
-                        case null, default: return "Other";
+                        default: return "Other";
                     }
                 }
             }
@@ -88,7 +88,7 @@ class SwitchCaseReturnsToSwitchExpressionTest implements RewriteTest {
                     return switch (str) {
                         case "foo" -> "Foo";
                         case "bar" -> "Bar";
-                        case null, default -> "Other";
+                        default -> "Other";
                     };
                 }
             }
@@ -302,7 +302,26 @@ class SwitchCaseReturnsToSwitchExpressionTest implements RewriteTest {
     }
 
     @Test
-    void supportMultiLabelWithNullSwitch() {
+    void doNotConvertMultiLabelWithNWithDefaultCaseWhenItsUnsupported() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  String doFormat(String str) {
+                      switch (str) {
+                          case "foo": return "Foo";
+                          case "ignored", default: return "Other";
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void supportMultiLabelWithNullSwitchIfPossible() {
         rewriteRun(
           version(
             //language=java

--- a/src/test/java/org/openrewrite/java/migrate/lang/SwitchExpressionYieldToArrowTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/SwitchExpressionYieldToArrowTest.java
@@ -199,7 +199,7 @@ class SwitchExpressionYieldToArrowTest implements RewriteTest {
     }
 
     @Test
-    void supportMultiLabelWithNullSwitch() {
+    void supportMultiLabelWithNullSwitchIfPossible() {
         rewriteRun(
           version(
             //language=java


### PR DESCRIPTION
## What's changed?
Switches are not changed to switch expressions when it leads to uncompilable code. 

## What's your motivation?
When running the recipes on a Java 17 codebase, certain transformations could result in uncompilable code.
For example, applying the SwitchCaseAssignmentsToSwitchExpression recipe to:

```java
String formatted = "initialValue";
switch (str) {
    case "foo": formatted = "Foo"; break;
    case "ignored", default: formatted = "unknown";
}
```

would produce:

```java
String formatted = switch (str) {
    case "foo" -> "Foo";
    case "ignored", default -> "unknown";
};
```

While the original statement compiles under Java 17, the transformed switch expression triggers the following error:

```
patterns in switch statements are a preview feature and are disabled by default.
```

This happens because combining a constant label (e.g., "ignored") with `default` in a single case label is only permitted with the pattern matching for switch preview feature in Java 17, which was finalized in Java 21.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
