### PR TITLE
Fixed validation.xml in jakarta-ee-10.yml

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -282,11 +282,11 @@ recipeList:
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xmlns
       elementName: validation-config
-      newValue: https://jakarta.ee/xml/ns/jakartaee
+      newValue: https://jakarta.ee/xml/ns/validation/configuration
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xsi:schemaLocation
       elementName: validation-config
-      newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd
+      newValue: https://jakarta.ee/xml/ns/validation/configuration https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd
   - org.openrewrite.text.FindAndReplace:
       find: "javax."
       replace: "jakarta."


### PR DESCRIPTION
The original URL was broken. Checking the correct URL revealed that the namespace of validation-config has also changed.

I have tested this insofar it fixed my code failing deploy to JBoss with an SAXParseException because validation-config was undefined before applying the two rewritten ChangeTagAttribute after JakartaEE10 in my recipe.

