### PR TITLE
Java25  Migrate to Process::waitFor(Duration)

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDuration.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDuration.java
@@ -16,18 +16,13 @@
 package org.openrewrite.java.migrate.lang;
 
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-
-import java.util.Collections;
-import java.util.List;
 
 public class MigrateProcessWaitForDuration extends Recipe {
 
@@ -44,121 +39,75 @@ public class MigrateProcessWaitForDuration extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
-                    private final MethodMatcher waitForMatcher = new MethodMatcher("java.lang.Process waitFor(long, java.util.concurrent.TimeUnit)");
+            private final MethodMatcher waitForMatcher = new MethodMatcher("java.lang.Process waitFor(long, java.util.concurrent.TimeUnit)");
 
-                    @Override
-                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                        J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
-                        if (waitForMatcher.matches(mi)) {
-                            List<Expression> arguments = mi.getArguments();
-                            if (arguments.size() == 2) {
-                                Expression timeoutArg = arguments.get(0);
-                                Expression timeUnitArg = arguments.get(1);
+                if (waitForMatcher.matches(mi)) {
+                    Expression valueArg = mi.getArguments().get(0);
+                    Expression unitArg = mi.getArguments().get(1);
+                    String timeUnitName = getTimeUnitName(unitArg);
+                    String durationMethod = getDurationMethod(timeUnitName);
 
-                                maybeAddImport("java.time.Duration");
+                    boolean isSimpleValue = valueArg instanceof J.Literal || valueArg instanceof J.Identifier;
 
-                                // Check if we can determine the TimeUnit value
-                                String timeUnitName = getTimeUnitName(timeUnitArg);
-                                boolean isSimpleTimeout = isSimpleValue(timeoutArg);
-
-                                Expression durationArg;
-                                if (timeUnitName != null && isSimpleTimeout) {
-                                    // Try to use expressive Duration methods
-                                    String durationMethod = null;
-                                    boolean needsChronoUnit = false;
-
-                                    switch (timeUnitName) {
-                                        case "NANOSECONDS":
-                                            durationMethod = "ofNanos";
-                                            break;
-                                        case "MICROSECONDS":
-                                            // Special case: Duration doesn't have ofMicros
-                                            needsChronoUnit = true;
-                                            break;
-                                        case "MILLISECONDS":
-                                            durationMethod = "ofMillis";
-                                            break;
-                                        case "SECONDS":
-                                            durationMethod = "ofSeconds";
-                                            break;
-                                        case "MINUTES":
-                                            durationMethod = "ofMinutes";
-                                            break;
-                                        case "HOURS":
-                                            durationMethod = "ofHours";
-                                            break;
-                                        case "DAYS":
-                                            durationMethod = "ofDays";
-                                            break;
-                                    }
-
-                                    if (needsChronoUnit) {
-                                        // Use Duration.of with ChronoUnit for MICROSECONDS
-                                        maybeAddImport("java.time.temporal.ChronoUnit");
-                                        maybeRemoveImport("java.util.concurrent.TimeUnit");
-                                        JavaTemplate template = JavaTemplate.builder("Duration.of(#{any(long)}, ChronoUnit.MICROS)")
-                                                .imports("java.time.Duration", "java.time.temporal.ChronoUnit")
-                                                .build();
-                                        mi = template.apply(getCursor(), method.getCoordinates().replaceArguments(), timeoutArg);
-                                    } else if (durationMethod != null) {
-                                        // Use expressive Duration method
-                                        maybeRemoveImport("java.util.concurrent.TimeUnit");
-                                        // Also remove static imports if present
-                                        maybeRemoveImport("java.util.concurrent.TimeUnit." + timeUnitName);
-                                        JavaTemplate template = JavaTemplate.builder("Duration." + durationMethod + "(#{any(long)})")
-                                                .imports("java.time.Duration")
-                                                .build();
-                                        mi = template.apply(getCursor(), method.getCoordinates().replaceArguments(), timeoutArg);
-                                    } else {
-                                        // Shouldn't happen, but fallback to generic conversion
-                                        JavaTemplate template = JavaTemplate.builder("Duration.of(#{any(long)}, #{any(java.util.concurrent.TimeUnit)}.toChronoUnit())")
-                                                .imports("java.time.Duration")
-                                                .build();
-                                        mi = template.apply(getCursor(), method.getCoordinates().replaceArguments(), timeoutArg, timeUnitArg);
-                                    }
-                                } else {
-                                    // Complex case: use Duration.of with toChronoUnit
-                                    JavaTemplate template = JavaTemplate.builder("Duration.of(#{any(long)}, #{any(java.util.concurrent.TimeUnit)}.toChronoUnit())")
-                                            .imports("java.time.Duration")
-                                            .build();
-                                    mi = template.apply(getCursor(), method.getCoordinates().replaceArguments(), timeoutArg, timeUnitArg);
-                                }
-                            }
-                        }
-                        return mi;
+                    if (isSimpleValue && "MICROSECONDS".equals(timeUnitName)) {
+                        JavaTemplate template = JavaTemplate.builder("Duration.of(#{any(long)}, ChronoUnit.MICROS)")
+                                .imports("java.time.Duration", "java.time.temporal.ChronoUnit")
+                                .build();
+                        mi = template.apply(getCursor(), mi.getCoordinates().replaceArguments(), valueArg);
+                    } else if (isSimpleValue && durationMethod != null) {
+                        JavaTemplate template = JavaTemplate.builder("Duration." + durationMethod + "(#{any(long)})")
+                                .imports("java.time.Duration")
+                                .build();
+                        mi = template.apply(getCursor(), mi.getCoordinates().replaceArguments(), valueArg);
+                    } else {
+                        JavaTemplate template = JavaTemplate.builder("Duration.of(#{any(long)}, #{any(java.util.concurrent.TimeUnit)}.toChronoUnit())")
+                                .imports("java.time.Duration")
+                                .build();
+                        mi = template.apply(getCursor(), mi.getCoordinates().replaceArguments(), valueArg, unitArg);
                     }
 
-                    private String getTimeUnitName(Expression timeUnitArg) {
-                        if (timeUnitArg instanceof J.FieldAccess) {
-                            J.FieldAccess fa = (J.FieldAccess) timeUnitArg;
-                            return fa.getSimpleName();
-                        } else if (timeUnitArg instanceof J.Identifier) {
-                            // Handle static imports
-                            J.Identifier id = (J.Identifier) timeUnitArg;
-                            String name = id.getSimpleName();
-                            // Check if it's a known TimeUnit constant
-                            if (isTimeUnitConstant(name)) {
-                                return name;
-                            }
-                        }
+                    // Handle all imports at the end
+                    maybeAddImport("java.time.Duration");
+                    maybeAddImport("java.time.temporal.ChronoUnit");
+                    maybeRemoveImport("java.util.concurrent.TimeUnit");
+                    maybeRemoveImport("java.util.concurrent.TimeUnit." + timeUnitName);
+                }
+                return mi;
+            }
+
+            private String getTimeUnitName(Expression timeUnitArg) {
+                if (timeUnitArg instanceof J.FieldAccess) {
+                    J.FieldAccess fa = (J.FieldAccess) timeUnitArg;
+                    return fa.getSimpleName();
+                } else if (timeUnitArg instanceof J.Identifier) {
+                    J.Identifier id = (J.Identifier) timeUnitArg;
+                    return id.getSimpleName();
+                }
+                return null;
+            }
+
+            private String getDurationMethod(String timeUnitName) {
+                switch (timeUnitName) {
+                    case "NANOSECONDS":
+                        return "ofNanos";
+                    case "MILLISECONDS":
+                        return "ofMillis";
+                    case "SECONDS":
+                        return "ofSeconds";
+                    case "MINUTES":
+                        return "ofMinutes";
+                    case "HOURS":
+                        return "ofHours";
+                    case "DAYS":
+                        return "ofDays";
+                    default:
                         return null;
-                    }
-
-                    private boolean isTimeUnitConstant(String name) {
-                        return "NANOSECONDS".equals(name) ||
-                               "MICROSECONDS".equals(name) ||
-                               "MILLISECONDS".equals(name) ||
-                               "SECONDS".equals(name) ||
-                               "MINUTES".equals(name) ||
-                               "HOURS".equals(name) ||
-                               "DAYS".equals(name);
-                    }
-
-                    private boolean isSimpleValue(Expression expr) {
-                        // Check if the expression is a literal or a simple identifier (not a method call or complex expression)
-                        return expr instanceof J.Literal || expr instanceof J.Identifier;
-                    }
-                };
+                }
+            }
+        };
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDuration.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDuration.java
@@ -16,11 +16,13 @@
 package org.openrewrite.java.migrate.lang;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
@@ -38,7 +40,7 @@ public class MigrateProcessWaitForDuration extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesJavaVersion(25), new JavaVisitor<ExecutionContext>() {
             private final MethodMatcher waitForMatcher = new MethodMatcher("java.lang.Process waitFor(long, java.util.concurrent.TimeUnit)");
 
             @Override
@@ -70,7 +72,6 @@ public class MigrateProcessWaitForDuration extends Recipe {
                         mi = template.apply(getCursor(), mi.getCoordinates().replaceArguments(), valueArg, unitArg);
                     }
 
-                    // Handle all imports at the end
                     maybeAddImport("java.time.Duration");
                     maybeAddImport("java.time.temporal.ChronoUnit");
                     maybeRemoveImport("java.util.concurrent.TimeUnit");
@@ -108,6 +109,6 @@ public class MigrateProcessWaitForDuration extends Recipe {
                         return null;
                 }
             }
-        };
+        });
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDuration.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDuration.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MigrateProcessWaitForDuration extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Use `Process#waitFor(Duration)`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Use `Process#waitFor(Duration)` instead of `Process#waitFor(long, TimeUnit)` in Java 25 or higher.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesJavaVersion<>(25),
+                new JavaVisitor<ExecutionContext>() {
+                    private final MethodMatcher waitForMatcher = new MethodMatcher("java.lang.Process waitFor(long, java.util.concurrent.TimeUnit)");
+
+                    @Override
+                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+
+                        if (waitForMatcher.matches(mi)) {
+                            List<Expression> arguments = mi.getArguments();
+                            if (arguments.size() == 2) {
+                                Expression timeoutArg = arguments.get(0);
+                                Expression timeUnitArg = arguments.get(1);
+
+                                maybeAddImport("java.time.Duration");
+                                
+                                // Check if the TimeUnit is a constant we can map to a specific Duration method
+                                String durationMethod = null;
+                                if (timeUnitArg instanceof J.FieldAccess) {
+                                    J.FieldAccess fa = (J.FieldAccess) timeUnitArg;
+                                    if (fa.getSimpleName().equals("NANOSECONDS")) {
+                                        durationMethod = "ofNanos";
+                                    } else if (fa.getSimpleName().equals("MICROSECONDS")) {
+                                        durationMethod = "ofNanos"; // will multiply by 1000
+                                        timeoutArg = JavaTemplate.builder("#{any(long)} * 1000")
+                                                .build()
+                                                .apply(getCursor(), timeoutArg.getCoordinates().replace(), timeoutArg);
+                                    } else if (fa.getSimpleName().equals("MILLISECONDS")) {
+                                        durationMethod = "ofMillis";
+                                    } else if (fa.getSimpleName().equals("SECONDS")) {
+                                        durationMethod = "ofSeconds";
+                                    } else if (fa.getSimpleName().equals("MINUTES")) {
+                                        durationMethod = "ofMinutes";
+                                    } else if (fa.getSimpleName().equals("HOURS")) {
+                                        durationMethod = "ofHours";
+                                    } else if (fa.getSimpleName().equals("DAYS")) {
+                                        durationMethod = "ofDays";
+                                    }
+                                }
+
+                                Expression durationArg;
+                                if (durationMethod != null && !durationMethod.equals("ofNanos") && 
+                                    (timeoutArg instanceof J.Literal || timeoutArg instanceof J.Identifier)) {
+                                    // Use the more expressive Duration method for simple timeout values
+                                    maybeRemoveImport("java.util.concurrent.TimeUnit");
+                                    JavaTemplate template = JavaTemplate.builder("Duration." + durationMethod + "(#{any(long)})")
+                                            .imports("java.time.Duration")
+                                            .build();
+                                    durationArg = template.apply(getCursor(), mi.getCoordinates().replaceArguments(), timeoutArg);
+                                } else {
+                                    // Fall back to Duration.of with toChronoUnit conversion
+                                    JavaTemplate template = JavaTemplate.builder("Duration.of(#{any(long)}, #{any(java.util.concurrent.TimeUnit)}.toChronoUnit())")
+                                            .imports("java.time.Duration")
+                                            .build();
+                                    durationArg = template.apply(getCursor(), mi.getCoordinates().replaceArguments(), timeoutArg, timeUnitArg);
+                                }
+
+                                return mi.withArguments(Collections.singletonList(durationArg));
+                            }
+                        }
+                        return mi;
+                    }
+                }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/java-lang-apis.yml
+++ b/src/main/resources/META-INF/rewrite/java-lang-apis.yml
@@ -29,6 +29,7 @@ recipeList:
   - org.openrewrite.java.migrate.lang.MigrateSecurityManagerMulticast
   - org.openrewrite.java.migrate.lang.MigrateClassLoaderDefineClass
   - org.openrewrite.java.migrate.lang.MigrateClassNewInstanceToGetDeclaredConstructorNewInstance
+  - org.openrewrite.java.migrate.lang.MigrateProcessWaitForDuration
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -27,6 +27,7 @@ tags:
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava21
   - org.openrewrite.java.migrate.UpgradeBuildToJava25
+  - org.openrewrite.java.migrate.lang.MigrateProcessWaitForDuration
   - org.openrewrite.java.migrate.AccessController
   - org.openrewrite.java.migrate.RemoveSecurityPolicy
   - org.openrewrite.java.migrate.RemoveSecurityManager

--- a/src/test/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDurationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDurationTest.java
@@ -142,7 +142,7 @@ class MigrateProcessWaitForDurationTest implements RewriteTest {
                   private long getTimeout() {
                       return 10;
                   }
-                  
+
                   void test(Process process) throws Exception {
                       process.waitFor(getTimeout(), TimeUnit.SECONDS);
                   }
@@ -156,7 +156,7 @@ class MigrateProcessWaitForDurationTest implements RewriteTest {
                   private long getTimeout() {
                       return 10;
                   }
-                  
+
                   void test(Process process) throws Exception {
                       process.waitFor(Duration.of(getTimeout(), TimeUnit.SECONDS.toChronoUnit()));
                   }
@@ -281,24 +281,6 @@ class MigrateProcessWaitForDurationTest implements RewriteTest {
               class Test {
                   void test() throws Exception {
                       new ProcessBuilder("echo", "hello").start().waitFor(Duration.ofSeconds(3));
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void noChangeWhenAlreadyUsingDuration() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import java.time.Duration;
-
-              class Test {
-                  void test(Process process) throws Exception {
-                      process.waitFor(Duration.ofSeconds(5));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDurationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDurationTest.java
@@ -208,8 +208,6 @@ class MigrateProcessWaitForDurationTest implements RewriteTest {
                   void test(Process process) throws Exception {
                       if (process.waitFor(5, TimeUnit.SECONDS)) {
                           System.out.println("Process completed within timeout");
-                      } else {
-                          System.out.println("Process did not complete within timeout");
                       }
                   }
               }
@@ -221,8 +219,6 @@ class MigrateProcessWaitForDurationTest implements RewriteTest {
                   void test(Process process) throws Exception {
                       if (process.waitFor(Duration.ofSeconds(5))) {
                           System.out.println("Process completed within timeout");
-                      } else {
-                          System.out.println("Process did not complete within timeout");
                       }
                   }
               }

--- a/src/test/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDurationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/MigrateProcessWaitForDurationTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.lang;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateProcessWaitForDurationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new MigrateProcessWaitForDuration())
+          .parser(JavaParser.fromJavaVersion());
+    }
+
+    @DocumentExample
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+        SECONDS, 5, ofSeconds
+        MINUTES, 2, ofMinutes
+        HOURS, 24, ofHours
+        DAYS, 7, ofDays
+        MILLISECONDS, 1000, ofMillis
+        NANOSECONDS, 1000000, ofNanos
+        """)
+    void migrateProcessWaitForWithExpressiveMethods(String timeUnit, String value, String durationMethod) {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor(%s, TimeUnit.%s);
+                  }
+              }
+              """.formatted(value, timeUnit),
+            """
+              import java.time.Duration;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor(Duration.%s(%s));
+                  }
+              }
+              """.formatted(durationMethod, value)
+          )
+        );
+    }
+
+    @Test
+    void migrateProcessWaitForWithMicroseconds() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor(1000, TimeUnit.MICROSECONDS);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.temporal.ChronoUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor(Duration.of(1000, ChronoUnit.MICROS));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateProcessWaitForWithVariables() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      long timeout = 5;
+                      TimeUnit unit = TimeUnit.SECONDS;
+                      process.waitFor(timeout, unit);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      long timeout = 5;
+                      TimeUnit unit = TimeUnit.SECONDS;
+                      process.waitFor(Duration.of(timeout, unit.toChronoUnit()));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateProcessWaitForWithMethodCall() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  private long getTimeout() {
+                      return 10;
+                  }
+                  
+                  void test(Process process) throws Exception {
+                      process.waitFor(getTimeout(), TimeUnit.SECONDS);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  private long getTimeout() {
+                      return 10;
+                  }
+                  
+                  void test(Process process) throws Exception {
+                      process.waitFor(Duration.of(getTimeout(), TimeUnit.SECONDS.toChronoUnit()));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateProcessWaitForWithExpression() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      long timeout = 5;
+                      process.waitFor(timeout * 2, TimeUnit.MINUTES);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      long timeout = 5;
+                      process.waitFor(Duration.of(timeout * 2, TimeUnit.MINUTES.toChronoUnit()));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateProcessWaitForWithReturnValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      if (process.waitFor(5, TimeUnit.SECONDS)) {
+                          System.out.println("Process completed within timeout");
+                      } else {
+                          System.out.println("Process did not complete within timeout");
+                      }
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      if (process.waitFor(Duration.ofSeconds(5))) {
+                          System.out.println("Process completed within timeout");
+                      } else {
+                          System.out.println("Process did not complete within timeout");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateProcessWaitForWithStaticImport() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static java.util.concurrent.TimeUnit.SECONDS;
+              import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor(5, SECONDS);
+                      process.waitFor(100, MILLISECONDS);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor(Duration.ofSeconds(5));
+                      process.waitFor(Duration.ofMillis(100));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateProcessWaitForWithChainedCalls() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+
+              class Test {
+                  void test() throws Exception {
+                      new ProcessBuilder("echo", "hello").start().waitFor(3, TimeUnit.SECONDS);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+
+              class Test {
+                  void test() throws Exception {
+                      new ProcessBuilder("echo", "hello").start().waitFor(Duration.ofSeconds(3));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWhenAlreadyUsingDuration() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.time.Duration;
+
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor(Duration.ofSeconds(5));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeForParameterlessWaitFor() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void test(Process process) throws Exception {
+                      process.waitFor();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
`Process::waitFor(Long, TimeUnit)` can be migrated to `Process::waitFor(Durarion)` in java 25.

## What's your motivation?
As requested in 
- https://github.com/openrewrite/rewrite-migrate-java/issues/839

