### PR TITLE
Java 25: Migrate new Stringreader(..) to Reader.of(CharSequence)

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateStringReaderToReaderOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateStringReaderToReaderOf.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.util;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.ArrayList;
+
+/**
+ * Migrates StringReader to Reader.of(CharSequence) for Java 25+.
+ * This recipe only transforms:
+ * 1. Assignments to variables of type Reader (not StringReader)
+ * 2. Return statements from methods that return Reader (not StringReader)
+ */
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class MigrateStringReaderToReaderOf extends Recipe {
+    private static final MethodMatcher STRING_READER_CONSTRUCTOR = new MethodMatcher("java.io.StringReader <constructor>(java.lang.String)");
+
+    @Override
+    public String getDisplayName() {
+        return "Use `Reader.of(CharSequence)` for non-synchronized readers";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate `new StringReader(String)` to `Reader.of(CharSequence)` in Java 25+. " +
+               "This only applies when assigning to `Reader` variables or returning from methods that return `Reader`. " +
+               "The new method creates non-synchronized readers which are more efficient when thread-safety is not required.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                Preconditions.and(
+                        new UsesJavaVersion<>(25),
+                        new UsesType<>("java.io.StringReader", false)
+                ),
+                new JavaVisitor<ExecutionContext>() {
+
+                    @Override
+                    public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
+                        // Only process if the variable type is Reader (not StringReader)
+                        if (isReaderType(multiVariable.getTypeAsFullyQualified())) {
+                            // Check each variable in the declaration
+                            return multiVariable.withVariables(ListUtils.map(multiVariable.getVariables(), v -> {
+                                Expression initializer = v.getInitializer();
+                                if (initializer instanceof J.NewClass) {
+                                    J.NewClass nc = (J.NewClass) initializer;
+                                    if (STRING_READER_CONSTRUCTOR.matches(nc)) {
+                                        maybeRemoveImport("java.io.StringReader");
+                                        return (J.VariableDeclarations.NamedVariable) new TransformVisitor().visit(v, executionContext, getCursor().getParent());
+                                    }
+                                }
+                                return v;
+                            }));
+                        }
+                        return super.visitVariableDeclarations(multiVariable, executionContext);
+                    }
+
+                    @Override
+                    public J visitAssignment(J.Assignment assignment, ExecutionContext executionContext) {
+                        // Check if assigning new StringReader to a Reader variable
+                        if (assignment.getAssignment() instanceof J.NewClass) {
+                            J.NewClass nc = (J.NewClass) assignment.getAssignment();
+                            if (STRING_READER_CONSTRUCTOR.matches(nc)) {
+                                // Check if the variable being assigned to is of type Reader
+                                if (assignment.getVariable() instanceof J.Identifier) {
+                                    J.Identifier variable = (J.Identifier) assignment.getVariable();
+                                    if (isReaderType(variable.getType())) {
+                                        maybeRemoveImport("java.io.StringReader");
+                                        return new TransformVisitor().visit(assignment, executionContext, getCursor().getParent());
+                                    }
+                                }
+                            }
+                        }
+                        return super.visitAssignment(assignment, executionContext);
+                    }
+
+                    @Override
+                    public J visitReturn(J.Return return_, ExecutionContext executionContext) {
+                        // Check if returning new StringReader from a method that returns Reader
+                        if (return_.getExpression() instanceof J.NewClass) {
+                            J.NewClass nc = (J.NewClass) return_.getExpression();
+                            if (STRING_READER_CONSTRUCTOR.matches(nc)) {
+                                // Check if the method returns Reader (not StringReader)
+                                J.MethodDeclaration method = getCursor().firstEnclosing(J.MethodDeclaration.class);
+                                if (method != null && method.getReturnTypeExpression() != null) {
+                                    JavaType returnType = method.getReturnTypeExpression().getType();
+                                    if (isReaderType(returnType)) {
+                                        maybeRemoveImport("java.io.StringReader");
+                                        return new TransformVisitor().visit(return_, executionContext, getCursor().getParent());
+                                    }
+                                }
+                            }
+                        }
+                        return super.visitReturn(return_, executionContext);
+                    }
+
+                    private boolean isReaderType(JavaType type) {
+                        if (type instanceof JavaType.FullyQualified) {
+                            return "java.io.Reader".equals(((JavaType.FullyQualified) type).getFullyQualifiedName());
+                        }
+                        return false;
+                    }
+
+                    private class TransformVisitor extends JavaVisitor<ExecutionContext> {
+                        @Override
+                        public J visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
+                            if (STRING_READER_CONSTRUCTOR.matches(newClass)) {
+                                Expression argument = newClass.getArguments().get(0);
+
+                                // Optimize CharSequence.toString() calls
+                                argument = optimizeCharSequenceToString(argument);
+
+                                JavaTemplate template = JavaTemplate.builder("Reader.of(#{any(java.lang.CharSequence)})")
+                                        .imports("java.io.Reader")
+                                        .contextSensitive()
+                                        .build();
+
+                                maybeAddImport("java.io.Reader");
+                                return template.apply(getCursor(), newClass.getCoordinates().replace(), argument);
+                            }
+                            return super.visitNewClass(newClass, executionContext);
+                        }
+
+                        private Expression optimizeCharSequenceToString(Expression expr) {
+                            if (expr instanceof J.MethodInvocation) {
+                                J.MethodInvocation mi = (J.MethodInvocation) expr;
+                                if ("toString".equals(mi.getSimpleName()) &&
+                                        (mi.getArguments().isEmpty() || (mi.getArguments().size() == 1 && mi.getArguments().get(0) instanceof J.Empty)) &&
+                                    mi.getSelect() != null &&
+                                    isCharSequenceType(mi.getSelect().getType())) {
+                                    return mi.getSelect();
+                                }
+                            }
+                            return expr;
+                        }
+
+                        private boolean isCharSequenceType(JavaType type) {
+                            if (type instanceof JavaType.Class) {
+                                JavaType.Class classType = (JavaType.Class) type;
+                                String fqn = classType.getFullyQualifiedName();
+                                return "java.lang.CharSequence".equals(fqn) ||
+                                       "java.lang.String".equals(fqn) ||
+                                       "java.lang.StringBuilder".equals(fqn) ||
+                                       "java.lang.StringBuffer".equals(fqn) ||
+                                       "java.nio.CharBuffer".equals(fqn) ||
+                                       implementsCharSequence(classType);
+                            }
+                            return false;
+                        }
+
+                        private boolean implementsCharSequence(JavaType.Class classType) {
+                            for (JavaType.FullyQualified iface : classType.getInterfaces()) {
+                                if ("java.lang.CharSequence".equals(iface.getFullyQualifiedName())) {
+                                    return true;
+                                }
+                            }
+                            JavaType.FullyQualified supertype = classType.getSupertype();
+                            if (supertype instanceof JavaType.Class) {
+                                return implementsCharSequence((JavaType.Class) supertype);
+                            }
+                            return false;
+                        }
+                    }
+                }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -29,6 +29,7 @@ recipeList:
   - org.openrewrite.java.migrate.UpgradeBuildToJava25
   - org.openrewrite.java.migrate.lang.MigrateProcessWaitForDuration
   - org.openrewrite.java.migrate.util.MigrateInflaterDeflaterToClose
+  - org.openrewrite.java.migrate.util.MigrateStringReaderToReaderOf
   - org.openrewrite.java.migrate.AccessController
   - org.openrewrite.java.migrate.RemoveSecurityPolicy
   - org.openrewrite.java.migrate.RemoveSecurityManager

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateStringReaderToReaderOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateStringReaderToReaderOfTest.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.util;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+class MigrateStringReaderToReaderOfTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MigrateStringReaderToReaderOf())
+            .parser(JavaParser.fromJavaVersion())
+            .allSources(s -> s.markers(javaVersion(25)));
+    }
+
+    @DocumentExample
+    @Test
+    void migrateReaderVariableWithString() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(String content) {
+                      Reader reader = new StringReader(content);
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  void test(String content) {
+                      Reader reader = Reader.of(content);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateStringReaderVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.StringReader;
+
+              class Test {
+                  void test(String content) {
+                      StringReader reader = new StringReader(content);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateMethodReturningReader() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  Reader createReader(String content) {
+                      return new StringReader(content);
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  Reader createReader(String content) {
+                      return Reader.of(content);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateMethodReturningStringReader() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.StringReader;
+
+              class Test {
+                  StringReader createReader(String content) {
+                      return new StringReader(content);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateWithStringBuilder() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(StringBuilder sb) {
+                      Reader reader = new StringReader(sb.toString());
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  void test(StringBuilder sb) {
+                      Reader reader = Reader.of(sb);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateWithStringBuffer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(StringBuffer sb) {
+                      Reader reader = new StringReader(sb.toString());
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  void test(StringBuffer sb) {
+                      Reader reader = Reader.of(sb);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateWithCharBuffer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+              import java.nio.CharBuffer;
+
+              class Test {
+                  void test(CharBuffer cb) {
+                      Reader reader = new StringReader(cb.toString());
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+              import java.nio.CharBuffer;
+
+              class Test {
+                  void test(CharBuffer cb) {
+                      Reader reader = Reader.of(cb);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateWithCharSequence() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(CharSequence cs) {
+                      Reader reader = new StringReader(cs.toString());
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  void test(CharSequence cs) {
+                      Reader reader = Reader.of(cs);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateMultipleReaderVariables() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(String s1, String s2) {
+                      Reader reader1 = new StringReader(s1);
+                      Reader reader2 = new StringReader(s2);
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  void test(String s1, String s2) {
+                      Reader reader1 = Reader.of(s1);
+                      Reader reader2 = Reader.of(s2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateAsMethodArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.BufferedReader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(String content) {
+                      BufferedReader br = new BufferedReader(new StringReader(content));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateInTryWithResources() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(String content) throws Exception {
+                      try (Reader reader = new StringReader(content)) {
+                          // use reader
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  void test(String content) throws Exception {
+                      try (Reader reader = Reader.of(content)) {
+                          // use reader
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateWithLiteral() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test() {
+                      Reader reader = new StringReader("Hello World");
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  void test() {
+                      Reader reader = Reader.of("Hello World");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateReaderFieldAssignment() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  private Reader reader;
+
+                  void test(String content) {
+                      reader = new StringReader(content);
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  private Reader reader;
+
+                  void test(String content) {
+                      reader = Reader.of(content);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateBeforeJava25() {
+        rewriteRun(
+          spec -> spec.allSources(s -> s.markers(javaVersion(24))),
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  void test(String content) {
+                      Reader reader = new StringReader(content);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateComplexReturn() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+
+              class Test {
+                  Reader getReader(boolean flag, String s1, String s2) {
+                      if (flag) {
+                          return new StringReader(s1);
+                      } else {
+                          return new StringReader(s2);
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.Reader;
+
+              class Test {
+                  Reader getReader(boolean flag, String s1, String s2) {
+                      if (flag) {
+                          return Reader.of(s1);
+                      } else {
+                          return Reader.of(s2);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateLambdaReturn() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+              import java.util.function.Function;
+
+              class Test {
+                  Function<String, Reader> factory = s -> new StringReader(s);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateMethodReference() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Reader;
+              import java.io.StringReader;
+              import java.util.function.Function;
+
+              class Test {
+                  Function<String, Reader> factory = StringReader::new;
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Java 25: Migrate new Stringreader(..) to Reader.of(CharSequence)

## What's your motivation?
As requested in 
- https://github.com/openrewrite/rewrite-migrate-java/issues/839
