### PR TITLE
Fix UseVarForGenericMethodInvocations for nested generics with diamond operators

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -259,5 +259,85 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        void nestedGenericsSimple() {
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                  package com.example.app;
+
+                  import java.util.ArrayList;
+                  import java.util.Collections;
+                  import java.util.List;
+
+                  class A {
+                    private void dostuff() {
+                        List<String> strs = Collections.synchronizedList(new ArrayList<>());
+                    }
+                  }
+                  """, """
+                  package com.example.app;
+
+                  import java.util.ArrayList;
+                  import java.util.Collections;
+                  import java.util.List;
+
+                  class A {
+                    private void dostuff() {
+                        var strs = Collections.synchronizedList(new ArrayList<String>());
+                    }
+                  }
+                  """),
+                10
+              )
+            );
+        }
+
+        @Test
+        void nestedGenericsWithMethodReference() {
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                  package com.example.app;
+
+                  import java.util.ArrayList;
+                  import java.util.Collections;
+                  import java.util.List;
+
+                  class A {
+                    private void dostuff() {
+                        List<String> strs = Collections.synchronizedList(new ArrayList<>());
+                        strs.forEach(this::soString);
+                    }
+
+                    private void soString(String s) {
+                        System.out.println(s);
+                    }
+                  }
+                  """, """
+                  package com.example.app;
+
+                  import java.util.ArrayList;
+                  import java.util.Collections;
+                  import java.util.List;
+
+                  class A {
+                    private void dostuff() {
+                        var strs = Collections.synchronizedList(new ArrayList<String>());
+                        strs.forEach(this::soString);
+                    }
+
+                    private void soString(String s) {
+                        System.out.println(s);
+                    }
+                  }
+                  """),
+                10
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #862 by making nested generic type parameters explicit when converting to `var`.

- Adds test cases replicating the issue with `Collections.synchronizedList(new ArrayList<>())`
- Recipe now replaces diamond operators in nested constructor calls with explicit type parameters
- Prevents compilation errors when using method references with nested generics

## Changes

- Modified `UseVarForGenericMethodInvocations` to detect and fix diamond operators in nested `new` expressions
- Added `makeNestedGenericsExplicit()` method to copy type parameters from variable declaration to nested constructors
- Added test cases: `nestedGenericsSimple()` and `nestedGenericsWithMethodReference()`

## Test plan

- [x] Added unit tests that replicate the issue
- [x] All existing tests pass
- [x] New tests verify the fix works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)