### PR TITLE
Fix duplicate @Getter annotations on multiple variable declarations

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokGetterTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/UseLombokGetterTest.java
@@ -638,4 +638,36 @@ class UseLombokGetterTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/876")
+    @Test
+    void multipleVariableDeclarations() {
+        rewriteRun(// language=java
+          java(
+            """
+              class A {
+
+                  int foo, bar = 9;
+
+                  public int getFoo() {
+                      return foo;
+                  }
+
+                  public int getBar() {
+                      return bar;
+                  }
+              }
+              """,
+            """
+              import lombok.Getter;
+
+              class A {
+
+                  @Getter
+                  int foo, bar = 9;
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed issue where `@Getter` annotation was being added twice to field declarations containing multiple variables
- Added test case `multipleVariableDeclarations` to verify the fix

## Problem
When a class had multiple variables declared on one line (e.g., `int foo, bar = 9;`) with corresponding getter methods for each variable, the `UseLombokGetter` recipe was incorrectly adding the `@Getter` annotation twice to the same field declaration.

This happened because:
1. Each getter method (`getFoo()` and `getBar()`) triggered a separate `FieldAnnotator` visitor
2. Both visitors encountered the same `VariableDeclarations` node (since both variables share the same declaration)
3. Each visitor attempted to add the annotation without checking if it already existed

## Solution
Updated `FieldAnnotator.visitVariableDeclarations()` to check if the annotation already exists before applying it. The fix:
- Checks if the annotation simple name already exists in the variable declaration's leading annotations
- Only applies the annotation if it doesn't already exist
- Returns the multiVariable node appropriately in both cases

## Test plan
- [x] Test `multipleVariableDeclarations` passes
- [x] All tests in `UseLombokGetterTest` pass
- [x] All tests in `UseLombokSetterTest` pass  
- [x] All Lombok-related tests pass

- Fixes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)