### PR TITLE
Enable the switch recipes as part of the Java 21 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-21.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-21.yml
@@ -42,7 +42,7 @@ recipeList:
   - org.openrewrite.java.migrate.lang.SwitchCaseAssignmentsToSwitchExpression
   - org.openrewrite.java.migrate.lang.SwitchCaseReturnsToSwitchExpression
   - org.openrewrite.java.migrate.lang.SwitchExpressionYieldToArrow
-  - org.openrewrite.java.migrate.lang.IfElseIfConstructToSwitch
+  #- org.openrewrite.java.migrate.lang.IfElseIfConstructToSwitch # FIXME `casecase` seen near non JDK types
   - org.openrewrite.java.migrate.SwitchPatternMatching
   - org.openrewrite.java.migrate.lang.NullCheckAsSwitchCase
 


### PR DESCRIPTION
@Jenson3210 These were held back at the time
- https://github.com/openrewrite/rewrite-migrate-java/commit/db99c93a8fc8971e10a56bc39c6722a109d7494f
- https://github.com/openrewrite/rewrite-migrate-java/pull/769

Any concerns with enabling these now?