### PR TITLE
Support Lambda for Predicates.and() and Predicates.or()

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaPredicatesAndOr.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaPredicatesAndOr.java
@@ -83,8 +83,8 @@ public class NoGuavaPredicatesAndOr extends Recipe {
                     return method;
                 }
 
-                // If the first argument is a method reference, wrap it with a cast
-                if (result instanceof J.MemberReference && result.getType() != null) {
+                // If the first argument is a method reference or a lambda, wrap it with a cast
+                if ((result instanceof J.MemberReference || result instanceof J.Lambda) && result.getType() != null) {
                     String typeString = result.getType().toString().replace("com.google.common.base.", "");
                     result = JavaTemplate.apply("((" + typeString + ") #{any()})", getCursor(), method.getCoordinates().replace(), result);
                 }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaPredicatesAndOrTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaPredicatesAndOrTest.java
@@ -101,18 +101,38 @@ class NoGuavaPredicatesAndOrTest implements RewriteTest {
               import com.google.common.base.Predicates;
 
               class Test {
-                  Predicate<String> isNotNull = s -> s != null;
-                  Predicate<String> isLong = s -> s.length() > 5;
-                  Predicate<String> combined = Predicates.and(isNotNull, isLong);
+                  Predicate<String> combined = Predicates.and(s -> s != null, s -> s.length() > 5);
               }
               """,
             """
               import com.google.common.base.Predicate;
 
               class Test {
-                  Predicate<String> isNotNull = s -> s != null;
-                  Predicate<String> isLong = s -> s.length() > 5;
-                  Predicate<String> combined = isNotNull.and(isLong);
+                  Predicate<String> combined = ((Predicate<String>) s -> s != null).and(s -> s.length() > 5);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replacePredicatesOrWithLambdas() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import com.google.common.base.Predicate;
+              import com.google.common.base.Predicates;
+
+              class Test {
+                  Predicate<String> combined = Predicates.or(s -> s != null, s -> s.length() > 5);
+              }
+              """,
+            """
+              import com.google.common.base.Predicate;
+
+              class Test {
+                  Predicate<String> combined = ((Predicate<String>) s -> s != null).or(s -> s.length() > 5);
               }
               """
           )


### PR DESCRIPTION
This commit extends NoGuavaPredicatesAndOr recipe to handle Lambda as first parameter for Predicates.and() and Predicates.or() methods.

- Fixes #884

- This PR replaces the second commit of PR #909, just to make things clearer.