### PR TITLE
Fix indentation calculation

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -372,15 +372,21 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
             classDeclaration = new RemoveAnnotationVisitor(LOMBOK_VALUE_MATCHER).visitClassDeclaration(classDeclaration, ctx);
             maybeRemoveImport("lombok.Value");
 
+            List<J.Modifier> mappedModifiers = ListUtils.map(classDeclaration.getModifiers(), modifier -> {
+                J.Modifier.Type type = modifier.getType();
+                if (type == J.Modifier.Type.Static || type == J.Modifier.Type.Final) {
+                    return null;
+                }
+                return modifier;
+            });
+            J.ClassDeclaration.Kind kind = classDeclaration.withKind(J.ClassDeclaration.Kind.Type.Record).getPadding().getKind();
+            if (mappedModifiers.isEmpty()) {
+                kind = kind.withPrefix(kind.getPrefix().withWhitespace(""));
+            }
+
             classDeclaration = classDeclaration
-                    .withKind(J.ClassDeclaration.Kind.Type.Record)
-                    .withModifiers(ListUtils.map(classDeclaration.getModifiers(), modifier -> {
-                        J.Modifier.Type type = modifier.getType();
-                        if (type == J.Modifier.Type.Static || type == J.Modifier.Type.Final) {
-                            return null;
-                        }
-                        return modifier;
-                    }))
+                    .getPadding().withKind(kind)
+                    .withModifiers(mappedModifiers)
                     .withType(buildRecordType(classDeclaration))
                     .withBody(classDeclaration.getBody()
                             .withStatements(bodyStatements)

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValueToRecordTest.java
@@ -62,7 +62,7 @@ class LombokValueToRecordTest implements RewriteTest {
               package example;
 
               public record A(
-                  String test) {
+                      String test) {
               }
               """
           ),
@@ -121,9 +121,9 @@ class LombokValueToRecordTest implements RewriteTest {
               """,
             """
               public record Test(
-                  String field1,
+                      String field1,
 
-                  String field2) {
+                      String field2) {
                   @Override
                   public String toString() {
                       return "Test(" +
@@ -166,7 +166,7 @@ class LombokValueToRecordTest implements RewriteTest {
               import lombok.Value;
 
               public record A(
-                  String test) {
+                      String test) {
               }
 
               @Value
@@ -201,14 +201,12 @@ class LombokValueToRecordTest implements RewriteTest {
 
               public class A {
                   record B(
-                      String test) {
+                          String test) {
                   }
               }
               """
           )
         );
-
-
     }
 
     @Test
@@ -233,7 +231,7 @@ class LombokValueToRecordTest implements RewriteTest {
               import java.io.Serializable;
 
               public record A(
-                  String test) implements Serializable {
+                      String test) implements Serializable {
               }
               """
           )
@@ -266,7 +264,7 @@ class LombokValueToRecordTest implements RewriteTest {
 
               @Builder
               public record A(
-                  String test) implements Serializable {
+                      String test) implements Serializable {
               }
               """
           )
@@ -289,7 +287,7 @@ class LombokValueToRecordTest implements RewriteTest {
               """,
             """
               public record Foo(
-                  boolean bar) {
+                      boolean bar) {
               }"""
           ),
           java(
@@ -329,9 +327,9 @@ class LombokValueToRecordTest implements RewriteTest {
               """,
             """
               public record Config(
-                  boolean enabled,
-                  Boolean active,
-                  String name) {
+                      boolean enabled,
+                      Boolean active,
+                      String name) {
               }
               """
           ),
@@ -384,7 +382,7 @@ class LombokValueToRecordTest implements RewriteTest {
               import java.util.function.Supplier;
 
               record A(
-                  String test) {
+                      String test) {
               }
 
               class Using {


### PR DESCRIPTION
For the `innerRecordsNotStatic` I had to add some logic to remove the prefix in the Kind. 
when removing `static`, the space between `static` and `class` was preserved, causing indentation of variable to be calculated at position 13 instead of 12. 

Now we trim the prefix of Kind when no modifiers are remaining. 