### PR TITLE
Ignore `java.util.Iterator` in NoGuavaSetsNewHashSet recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSet.java
@@ -75,8 +75,8 @@ public class NoGuavaSetsNewHashSet extends Recipe {
                                     .build()
                                     .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
                         }
-                        // Skip Iterable-only cases to avoid generating broken code
-                        if (TypeUtils.isAssignableTo("java.lang.Iterable", method.getArguments().get(0).getType())) {
+                        // Skip Iterable-only and Iterator-only cases to avoid generating broken code
+                        if (TypeUtils.isAssignableTo("java.lang.Iterable", method.getArguments().get(0).getType()) || TypeUtils.isAssignableTo("java.util.Iterator", method.getArguments().get(0).getType())) {
                             return method;
                         }
                     }

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSetTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSetTest.java
@@ -144,6 +144,28 @@ class NoGuavaSetsNewHashSetTest implements RewriteTest {
     }
 
     @Test
+    void setsNewHashSetWithIteratorsFilter() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Collection;
+              import java.util.Iterator;
+
+              import com.google.common.collect.Iterators;
+              import com.google.common.collect.Sets;
+
+              class Test {
+                  public Collection<String> collectExistingRepresentations(Iterator<Object> iterator) {
+                      return Sets.newHashSet(Iterators.filter(iterator, String.class));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void setsNewHashSetWithCustomIterable() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed?

Before this commit, `java.lang.Iterable` was ignored to avoid generating broken code.
This commit adds `java.util.Iterator` to the ignore list for the same reason.
A corresponding test has also been added.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
