### PR TITLE
Set build tools to use Java 8 when running Java 8 upgrade

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -58,9 +58,9 @@ recipeList:
   - org.openrewrite.java.migrate.javax.JavaxXmlStreamAPIs
   - org.openrewrite.java.migrate.cobertura.RemoveCoberturaMavenPlugin
   - org.openrewrite.java.migrate.UpgradeBuildToJava11
-  # Disabled due to null safety issues in the current implementation
-  # https://github.com/openrewrite/rewrite-migrate-java/issues/250
-  #  - org.openrewrite.java.migrate.util.JavaUtilAPIs
+# Disabled due to null safety issues in the current implementation
+# https://github.com/openrewrite/rewrite-migrate-java/issues/250
+#  - org.openrewrite.java.migrate.util.JavaUtilAPIs
   - org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty
   - org.openrewrite.java.migrate.util.OptionalNotEmptyToIsPresent
   - org.openrewrite.java.migrate.util.OptionalStreamRecipe


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
added Java `org.openrewrite.java.migrate.UpgradeJavaVersion` to java updates predating java 17. 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Enable iterative updates 7 -> 8 -> 11 -> 17

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
without you need to manual fix.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
