### PR TITLE
Update jakarta-faces-4.yml to remove PrimeFaces entries

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
@@ -118,14 +118,6 @@ recipeList:
       find: "http://xmlns.jcp.org/jsf"
       replace: "jakarta.faces"
       filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://primefaces.org/ui/extensions"
-      replace: "primefaces.extensions"
-      filePattern: '**/*.xhtml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "http://primefaces.org/ui"
-      replace: "primefaces"
-      filePattern: '**/*.xhtml'
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JakartaFacesConfigXml4


### PR DESCRIPTION
Removed obsolete FindAndReplace entries for PrimeFaces URLs.

- Fix for https://github.com/openrewrite/rewrite-migrate-java/issues/940
