### PR TITLE
Remove dependency version upgrade for commons-fileupload

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -335,10 +335,6 @@ recipeList:
       oldGroupId: org.apache.commons
       oldArtifactId: commons-fileupload2-jakarta
       newArtifactId: commons-fileupload2-jakarta-servlet5
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: org.apache.commons
-      artifactId: '*'
-      newVersion: 2.0.0-M4
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.commons.fileload.disk
       newPackageName: org.apache.commons.fileload2.core


### PR DESCRIPTION
This pull request makes a targeted adjustment to the dependency management and package migration recipes in the Jakarta EE 9 migration configuration. The main change is the removal of the automatic dependency upgrade step for all `org.apache.commons` artifacts.

- Fix for https://github.com/openrewrite/rewrite-migrate-java/issues/942