### PR TITLE
Prepare formatting refactor

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
@@ -110,7 +110,10 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
                         .apply(getCursor(), mi.getCoordinates().replace(), templateArguments);
                 m = m.getPadding().withArguments(mi.getPadding().getArguments());
                 JavaType.Method newType = (JavaType.Method) visitType(mi.getMethodType(), ctx);
-                m = m.withMethodType(newType).withName(m.getName().withType(newType));
+                m = m.withMethodType(newType)
+                        .withName(m.getName().withType(newType))
+                        .withPrefix(mi.getPrefix());
+
                 return super.visitMethodInvocation(m, ctx);
             }
 


### PR DESCRIPTION
The test here was expecting that a prefix of 2 spaces before the replaced element is kept. With new formatting we're cleaning up these spaces. So keep the prefix of the original object (also preserving potential comments before the method that gets replaced)