### PR TITLE
Fix JavaxWebXmlToJakartaWebXml regex to match multiline schemaLocation

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
@@ -180,7 +180,7 @@ recipeList:
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xsi:schemaLocation
       elementName: web-app
-      oldValue: .*xml/ns/javaee.*
+      oldValue: (?s).*xml/ns/javaee.*
       newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd
       regex: true
   - org.openrewrite.text.FindAndReplace:

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxWebXmlToJakartaWebXmlTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxWebXmlToJakartaWebXmlTest.java
@@ -144,6 +144,41 @@ class JavaxWebXmlToJakartaWebXmlTest implements RewriteTest {
         );
     }
 
+    @Test
+    void migrateMultilineSchemaLocation() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+                       version="4.0">
+                  <context-param>
+                      <param-name>javax.faces.PROJECT_STAGE</param-name>
+                      <param-value>Production</param-value>
+                  </context-param>
+              </web-fragment>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+                       version="5.0">
+                  <context-param>
+                      <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+                      <param-value>Production</param-value>
+                  </context-param>
+              </web-fragment>
+              """,
+            sourceSpecs -> sourceSpecs.path("web.xml")
+          )
+        );
+    }
+
     @Nested
     class NoChanges {
         @Test


### PR DESCRIPTION
## Summary
- Fixed the regex pattern in `JavaxWebXmlToJakartaWebXml` recipe to handle `xsi:schemaLocation` attributes with embedded line breaks
- Added `(?s)` flag (dotall mode) to the regex `.*xml/ns/javaee.*` so that `.` matches newline characters
- Added test case to verify the fix works with multi-line schemaLocation values

- Fixes #970

## Test plan
- [x] Added `migrateMultilineSchemaLocation` test case that verifies the recipe handles attributes with line breaks
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)