### PR TITLE
Add jakarta.annotation-api dependency when using javax.annotation

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -124,6 +124,12 @@ recipeList:
       groupId: jakarta.annotation
       artifactId: jakarta.annotation-api
       newVersion: 2.0.x
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api
+      version: 2.0.x
+      onlyIfUsing: javax.annotation..*
+      acceptTransitive: true
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.annotation
       newPackageName: jakarta.annotation

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxToJakartaTest.java
@@ -962,4 +962,75 @@ class JavaxToJakartaTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1563")
+    @Test
+    void addJakartaAnnotationApiWhenUsingJavaxAnnotationPriority() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            .dependsOn(
+              """
+                package javax.annotation;
+                public @interface Priority {
+                    int value();
+                }
+                """,
+              """
+                package jakarta.annotation;
+                public @interface Priority {
+                    int value();
+                }
+                """
+            )
+          ),
+          mavenProject(
+            "Sample",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """,
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>jakarta.annotation</groupId>
+                      <artifactId>jakarta.annotation-api</artifactId>
+                      <version>2.0.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
+            ),
+            srcMainJava(
+              //language=java
+              java(
+                """
+                  import javax.annotation.Priority;
+
+                  @Priority(1)
+                  public class MyFilter {
+                  }
+                  """,
+                """
+                  import jakarta.annotation.Priority;
+
+                  @Priority(1)
+                  public class MyFilter {
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Added `AddDependency` recipe to `JavaxAnnotationMigrationToJakartaAnnotation` to add `jakarta.annotation:jakarta.annotation-api` when `javax.annotation.*` classes are in use
- Added test case covering the transitive dependency scenario

## Problem

When migrating from `javax.annotation` to `jakarta.annotation`, the recipe was only changing/upgrading the dependency if it already existed explicitly. If the `javax.annotation` classes (like `@Priority`) were available transitively, the migration would change the import statements but not add the `jakarta.annotation-api` dependency, causing compilation failures.

This is inconsistent with how other migration recipes (like `JavaxMailToJakartaMail`, `JavaxServletToJakartaServlet`, `JavaxWsToJakartaWs`) handle this scenario - they all include an `AddDependency` recipe with `onlyIfUsing` to ensure the dependency is present.

## Solution

Added `AddDependency` recipe to `JavaxAnnotationMigrationToJakartaAnnotation`:
```yaml
- org.openrewrite.java.dependencies.AddDependency:
    groupId: jakarta.annotation
    artifactId: jakarta.annotation-api
    version: 2.0.x
    onlyIfUsing: javax.annotation..*
    acceptTransitive: true
```

## Test plan

- [x] Existing tests pass
- [x] New test added for the transitive dependency scenario

- Fixes moderneinc/customer-requests#1563