### PR TITLE
Add com.sun.istack.NotNull migration to Jakarta validation

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -252,6 +252,9 @@ recipeList:
       oldPackageName: javax.validation
       newPackageName: jakarta.validation
       recursive: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.sun.istack.NotNull
+      newFullyQualifiedTypeName: jakarta.validation.constraints.NotNull
   - org.openrewrite.RenameFile:
       fileMatcher: '**/javax.validation.ConstraintValidator'
       fileName: jakarta.validation.ConstraintValidator

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxValidationMigrationToJakartaValidationTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxValidationMigrationToJakartaValidationTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.jakarta;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class JavaxValidationMigrationToJakartaValidationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(
+          Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite.java.migrate")
+            .build()
+            .activateRecipes("org.openrewrite.java.migrate.jakarta.JavaxValidationMigrationToJakartaValidation")
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1526")
+    @Test
+    void sunIstackNotNullToJakartaValidation() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
+            //language=java
+            """
+              package com.sun.istack;
+              import java.lang.annotation.*;
+              @Documented
+              @Retention(RetentionPolicy.CLASS)
+              @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+              public @interface NotNull {
+              }
+              """,
+            //language=java
+            """
+              package jakarta.validation.constraints;
+              import java.lang.annotation.*;
+              @Documented
+              @Retention(RetentionPolicy.RUNTIME)
+              @Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+              public @interface NotNull {
+                  String message() default "{jakarta.validation.constraints.NotNull.message}";
+                  Class<?>[] groups() default {};
+                  Class<?>[] payload() default {};
+              }
+              """
+          )),
+          //language=java
+          java(
+            """
+              import com.sun.istack.NotNull;
+
+              public class Example {
+                  @NotNull
+                  private String name;
+
+                  public void setName(@NotNull String name) {
+                      this.name = name;
+                  }
+              }
+              """,
+            """
+              import jakarta.validation.constraints.NotNull;
+
+              public class Example {
+                  @NotNull
+                  private String name;
+
+                  public void setName(@NotNull String name) {
+                      this.name = name;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void javaxValidationToJakartaValidation() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
+            //language=java
+            """
+              package javax.validation.constraints;
+              import java.lang.annotation.*;
+              @Documented
+              @Retention(RetentionPolicy.RUNTIME)
+              @Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+              public @interface NotNull {
+                  String message() default "{javax.validation.constraints.NotNull.message}";
+                  Class<?>[] groups() default {};
+                  Class<?>[] payload() default {};
+              }
+              """,
+            //language=java
+            """
+              package jakarta.validation.constraints;
+              import java.lang.annotation.*;
+              @Documented
+              @Retention(RetentionPolicy.RUNTIME)
+              @Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+              public @interface NotNull {
+                  String message() default "{jakarta.validation.constraints.NotNull.message}";
+                  Class<?>[] groups() default {};
+                  Class<?>[] payload() default {};
+              }
+              """
+          )),
+          //language=java
+          java(
+            """
+              import javax.validation.constraints.NotNull;
+
+              public class Example {
+                  @NotNull
+                  private String name;
+              }
+              """,
+            """
+              import jakarta.validation.constraints.NotNull;
+
+              public class Example {
+                  @NotNull
+                  private String name;
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ChangeType` to migrate `com.sun.istack.NotNull` → `jakarta.validation.constraints.NotNull`
- Adds test coverage for the JavaxValidationMigrationToJakartaValidation recipe

## Motivation

- This addresses the third sub-issue in [moderneinc/customer-requests#1526](https://github.com/moderneinc/customer-requests/issues/1526) where Spring Boot upgrade migrations were leaving `com.sun.istack.NotNull` imports unchanged, causing compilation errors.

The `com.sun.istack.NotNull` annotation is an internal Sun JAXB implementation annotation that developers sometimes used inadvertently. When migrating to Jakarta EE, this annotation needs to be replaced with the standard `@jakarta.validation.constraints.NotNull`.

## Test plan

- [x] Added new test class `JavaxValidationMigrationToJakartaValidationTest`
- [x] Tests verify migration of `com.sun.istack.NotNull` → `jakarta.validation.constraints.NotNull`
- [x] Tests verify standard `javax.validation` → `jakarta.validation` migration still works
- [x] All tests pass locally