### PR TITLE
Explain why Spring annotations are migrated to JSpecify

### DIFF
--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -35,7 +35,9 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateToJSpecify
 displayName: Migrate to JSpecify
 description: >-
-  This recipe will migrate to JSpecify annotations from various other nullability annotation standards.
+  This recipe will migrate to JSpecify nullability annotations from various other annotation standards
+  including javax, Jakarta, JetBrains, Micrometer, and Micronaut. JSpecify is an industry-wide effort
+  to provide a single set of nullability annotations for Java.
 tags:
   - java
 preconditions:
@@ -155,7 +157,11 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations
 displayName: Migrate from Spring Framework annotations to JSpecify
-description: Migrate from Spring Framework annotations to JSpecify.
+description: >-
+  Spring Framework 7 has adopted JSpecify as its nullability annotation standard, deprecating Spring's own
+  `org.springframework.lang.@Nullable` and `org.springframework.lang.@NonNull` annotations. This recipe migrates
+  these annotations to their JSpecify equivalents (`org.jspecify.annotations.@Nullable` and
+  `org.jspecify.annotations.@NonNull`) and adds the JSpecify dependency.
 preconditions:
   - org.openrewrite.Singleton
 recipeList:


### PR DESCRIPTION
## Summary
- Improved `MigrateFromSpringFrameworkAnnotations` description to explain that Spring Framework 7 adopted JSpecify as its nullability annotation standard
- Improved `MigrateToJSpecify` description to mention JSpecify as an industry-wide effort

Customers running Spring Boot 4 migrations were confused about why `org.springframework.lang.@Nullable` and `@NonNull` were being changed to `org.jspecify.annotations` equivalents. The recipe descriptions now explain the "why".

- Closes moderneinc/customer-requests#1869