### PR TITLE
Prevent UseTextBlocks from dropping comments in concatenations

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -100,6 +100,10 @@ public class UseTextBlocks extends Recipe {
                     return binary; // Not super.visitBinary(binary, ctx) because we don't want to visit the children
                 }
 
+                if (containsComments(binary)) {
+                    return binary;
+                }
+
                 boolean flattenable = flatAdditiveStringLiterals(binary, stringLiterals, contentSb, concatenationSb);
                 if (!flattenable) {
                     return super.visitBinary(binary, ctx);
@@ -193,6 +197,18 @@ public class UseTextBlocks extends Recipe {
                        content.endsWith(";");
             }
         });
+    }
+
+    private static boolean containsComments(Expression expression) {
+        if (expression instanceof J.Binary) {
+            J.Binary b = (J.Binary) expression;
+            if (!b.getPrefix().getComments().isEmpty() ||
+                !b.getPadding().getOperator().getBefore().getComments().isEmpty()) {
+                return true;
+            }
+            return containsComments(b.getLeft()) || containsComments(b.getRight());
+        }
+        return expression instanceof J.Literal && !expression.getPrefix().getComments().isEmpty();
     }
 
     private static boolean allLiterals(Expression exp) {

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -257,6 +257,37 @@ class UseTextBlocksTest implements RewriteTest {
     }
 
     @Test
+    void doNotDropLineComments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String query = "SELECT * FROM\\n" + // table query
+                          "my_table\\n" +
+                          "WHERE something = 1;";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotDropBlockComments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String query = "SELECT * FROM\\n" + /* table name */ "my_table\\n" +
+                          "WHERE something = 1;";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void preferNoChangeIfCarriageReturnInContent() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary

Skip text block conversion when comments exist in string concatenations. The recipe was silently dropping line and block comments because text block literals have nowhere to preserve inline comments from the middle of the original binary tree.

## Changes

- Add `containsComments(Expression)` method to detect comments in binary expressions
- Add guard in `visitBinary` to skip transformation when comments are found
- Add test coverage for line and block comment preservation

## Test Plan

- Run existing tests: all 28 UseTextBlocksTest pass
- Added 2 new no-change tests verifying concatenations with comments are not transformed