### PR TITLE
Add maven-compiler-plugin version when missing during Java migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -110,6 +110,7 @@ recipeList:
       groupId: org.apache.maven.plugins
       artifactId: maven-compiler-plugin
       newVersion: 3.6.2
+      addVersionIfMissing: true
   - org.openrewrite.github.SetupJavaUpgradeJavaVersion:
       minimumJavaMajorVersion: 11
   - org.openrewrite.maven.UpgradePluginVersion:

--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -110,6 +110,7 @@ recipeList:
       groupId: org.apache.maven.plugins
       artifactId: maven-compiler-plugin
       newVersion: 3.x
+      addVersionIfMissing: true
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.apache.maven.plugins
       artifactId: maven-war-plugin

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -207,6 +207,7 @@ recipeList:
       groupId: org.apache.maven.plugins
       artifactId: maven-compiler-plugin
       newVersion: 3.15.x
+      addVersionIfMissing: true
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.apache.maven.plugins
       artifactId: maven-surefire-plugin


### PR DESCRIPTION
## Summary
- When `maven-compiler-plugin` is declared without a `<version>` tag and uses `<source>`/`<target>` configuration, the Java migration recipes convert to `<release>` but don't add a plugin version. Maven 3.x defaults to plugin version 3.1 which doesn't support `<release>` (introduced in 3.6), causing build failures.
- Added `addVersionIfMissing: true` to the `UpgradePluginVersion` calls for `maven-compiler-plugin` in the Java 11, 17, and 25 migration recipes.

## Test plan
- [x] Added `compilerPluginVersionAddedWhenMissing` test verifying `UpgradePluginsForJava11` adds a version to a versionless plugin
- [x] Added `compilerPluginVersionAddedAndReleaseSetForFullMigration` integration test verifying the full `Java8toJava11` recipe sets both `<release>11</release>` and a plugin version