### PR TITLE
Fix UpdateSdkManTest to use current SDKMAN Java versions

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -30,13 +30,13 @@ class UpdateSdkManTest implements RewriteTest {
     @Test
     void updateVersionExact() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateSdkMan("17.0.17", null)),
+          spec -> spec.recipe(new UpdateSdkMan("17.0.18", null)),
           text(
             """
               java=11.1.2-tem
               """,
             """
-              java=17.0.17-tem
+              java=17.0.18-tem
               """,
             spec -> spec.path(".sdkmanrc")
           )
@@ -63,10 +63,10 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan(null, "amzn")),
           text(
             """
-              java=11.0.29-tem
+              java=11.0.30-tem
               """,
             """
-              java=11.0.29-amzn
+              java=11.0.30-amzn
               """,
             spec -> spec.path(".sdkmanrc")
           )


### PR DESCRIPTION
## Summary

Fixes CI failures caused by the automated SDKMAN Java candidates update (commit 7c8b223e) which removed Java versions that two tests were expecting.

The tests `updateVersionExact()` and `updateDistributionOnly()` were failing because they referenced `17.0.17-tem` and `11.0.29-amzn` respectively, which no longer exist in the CSV. Updated test fixtures to use `17.0.18-tem` and `11.0.30-amzn` which are available in the current CSV.

## Test plan

- [x] Run `./gradlew test --tests "org.openrewrite.java.migrate.UpdateSdkManTest"` - all tests pass