### PR TITLE
Enable Lombok annotation processor during Java 17 upgrades

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -74,6 +74,7 @@ recipeList:
       artifactId: mapstruct*
       newVersion: 1.6.x
   - org.openrewrite.java.migrate.AddLombokMapstructBinding
+  - org.openrewrite.java.migrate.EnableLombokAnnotationProcessor
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -42,7 +42,6 @@ recipeList:
   - org.openrewrite.java.migrate.RemoveSecurityManager
   - org.openrewrite.java.migrate.SystemGetSecurityManagerToNull
   - org.openrewrite.java.migrate.MigrateZipErrorToZipException
-  - org.openrewrite.java.migrate.EnableLombokAnnotationProcessor
   - org.openrewrite.java.migrate.MigrateGraalVMResourceConfig
 
 ---

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava17Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava17Test.java
@@ -428,43 +428,32 @@ class UpgradeToJava17Test implements RewriteTest {
     @Test
     void lombokBumpedGoingTo17() {
         rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <dependencies>
-                  <dependency>
-                    <groupId>org.projectlombok</groupId>
-                    <artifactId>lombok</artifactId>
-                    <version>1.16.22</version>
-                  </dependency>
-                </dependencies>
-              </project>
-              """,
-            spec -> spec.after(actual ->
+          spec -> spec.cycles(2).expectedCyclesThatMakeChanges(2),
+          mavenProject("project",
+            //language=xml
+            pomXml(
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-                  <properties>
-                    <maven.compiler.release>17</maven.compiler.release>
-                  </properties>
                   <dependencies>
                     <dependency>
                       <groupId>org.projectlombok</groupId>
                       <artifactId>lombok</artifactId>
-                      <version>%s</version>
+                      <version>1.16.22</version>
                     </dependency>
                   </dependencies>
                 </project>
-                """.formatted(Pattern.compile("<version>(1\\.18.*)</version>")
-                .matcher(actual).results().findFirst().orElseThrow().group(1))
+                """,
+              spec -> spec.after(actual ->
+                assertThat(actual)
+                  .contains("<maven.compiler.release>17</maven.compiler.release>")
+                  .containsPattern("<annotationProcessorPaths>(.|\\n)*<path>(.|\\n)*<groupId>org.projectlombok")
+                  .containsPattern("<annotationProcessorPaths>(.|\\n)*<path>(.|\\n)*<artifactId>lombok")
+                  .actual()
+              )
             )
           )
         );


### PR DESCRIPTION
## Summary
- Move `EnableLombokAnnotationProcessor` from `UpgradeToJava25` to `UpgradeToJava17`, where the `maven-compiler-plugin` bump to 3.x actually breaks implicit annotation processor discovery (JEP 477)
- Java 21 and 25 inherit this automatically via recipe chaining
- The recipe is a no-op when Lombok isn't on the classpath (guarded by `RepositoryHasDependency` precondition)

- Closes moderneinc/customer-requests#1949

## Test plan
- [x] `UpgradeToJava17Test.lombokBumpedGoingTo17` updated and passing — now asserts `annotationProcessorPaths` with Lombok
- [x] `UpgradeToJava25Test.addsLombokAnnotationProcessor` still passes (inherits via Java 17 chain)