### PR TITLE
Use Groovy 4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ recipeDependencies {
 val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
-    compileOnly("org.codehaus.groovy:groovy:latest.release")
+    compileOnly("org.apache.groovy:groovy:4.+")
 
     annotationProcessor("org.projectlombok:lombok:latest.release")
     testImplementation("org.projectlombok:lombok:latest.release")
@@ -91,7 +91,7 @@ dependencies {
     testRuntimeOnly("commons-logging:commons-logging:1.3.2")
     testRuntimeOnly("org.apache.logging.log4j:log4j-api:2.23.1")
     testRuntimeOnly("org.apache.johnzon:johnzon-core:1.2.18")
-    testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
+    testRuntimeOnly("org.apache.groovy:groovy:4.+")
     testRuntimeOnly("org.jboss.logging:jboss-logging:3.6.0.Final")
     testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
     testRuntimeOnly("org.springframework:spring-core:6.1.13")


### PR DESCRIPTION
## What's changed?

Switching over from Groovy 3 to 4.

## What's your motivation?

- Fix broken CI after https://github.com/openrewrite/rewrite/pull/6228:
```
Caused by: org.gradle.internal.component.resolution.failure.exception.ComponentSelectionException: Module 'org.codehaus.groovy:groovy' has been rejected:
   Cannot select module with conflict on capability 'org.codehaus.groovy:groovy:3.0.25' also provided by ['org.apache.groovy:groovy:4.0.30' (groovyRuntimeElements)]
```