### PR TITLE
Avoid 9.1 Gradle version, should be 9.1.0

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -200,7 +200,7 @@ recipeList:
   - org.openrewrite.github.SetupJavaUpgradeJavaVersion:
       minimumJavaMajorVersion: 25
   - org.openrewrite.gradle.UpdateGradleWrapper:
-      version: 9.1
+      version: 9.1.0
       addIfMissing: false
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.apache.maven.plugins

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
@@ -17,12 +17,18 @@ package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.marker.BuildTool;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.test.SourceSpecs.other;
+import static org.openrewrite.test.SourceSpecs.text;
 
 class UpgradeToJava25Test implements RewriteTest {
 
@@ -103,6 +109,38 @@ class UpgradeToJava25Test implements RewriteTest {
                 .containsPattern("maven-failsafe-plugin</artifactId>\\s*<version>3\\.1\\.")
                 .actual())
           )
+        );
+    }
+
+    @Test
+    void upgradesGradleWrapperForJava25() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.migrate.UpgradePluginsForJava25")
+            .beforeRecipe(withToolingApi())
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "8.5"))),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://services.gradle.org/distributions/gradle-8.5-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+              .after(actual -> {
+                  assertThat(actual).containsPattern("gradle-9\\.1\\.\\d+-bin\\.zip");
+                  return actual;
+              })
+          ),
+          text("", spec -> spec.path("gradlew").after(a -> {
+              assertThat(a).isNotEmpty();
+              return a + "\n";
+          })),
+          text("", spec -> spec.path("gradlew.bat").after(a -> {
+              assertThat(a).isNotEmpty();
+              return a + "\n";
+          })),
+          other("", spec -> spec.path("gradle/wrapper/gradle-wrapper.jar"))
         );
     }
 


### PR DESCRIPTION
## What's changed?

Changing the Java 25 upgrade recipe to use 9.1.0 as the Gradle version, not 9.1.

## What's your motivation?

- fixes #993 

