### PR TITLE
Fix `IfElseIfConstructToSwitch` dropping pattern variables for unresolvable types

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -235,13 +235,11 @@ public class IfElseIfConstructToSwitch extends Recipe {
             // Cases are ordered: [null case (optional)], [pattern cases...], [default case]
             int nullCaseOffset = nullCheckedParameter != null ? 1 : 0;
             int patternCaseCount = patternMatchers.size();
-            int[] index = {0};
             return switch_.withCases(switch_.getCases().withStatements(
-                    ListUtils.map(switch_.getCases().getStatements(), stmt -> {
+                    ListUtils.map(switch_.getCases().getStatements(), (currentIndex, stmt) -> {
                         if (!(stmt instanceof J.Case)) {
                             return stmt;
                         }
-                        int currentIndex = index[0]++;
                         int patternIndex = currentIndex - nullCaseOffset;
                         if (patternIndex < 0 || patternIndex >= patternCaseCount || !instanceOfs.hasNext()) {
                             return stmt; // null case or default case


### PR DESCRIPTION
## Summary
- When `IfElseIfConstructToSwitch` converts if-else-if chains with `instanceof` checks on non-JDK types, JavaTemplate's raw string substitution (`#{}`) can fail to produce `J.VariableDeclarations` AST nodes, causing pattern variable declarations to be dropped (e.g., `case Dog d ->` becomes `case Dog ->`)
- Uses positional case identification (null case offset + pattern case count) instead of type-checking labels, ensuring the `instanceOfs` iterator always advances correctly for pattern match cases
- Adds a `buildVariableDeclarations()` fallback that reconstructs a proper `J.VariableDeclarations` from the original `J.InstanceOf` when JavaTemplate fails to produce one

## Test plan
- [x] All 14 existing `IfElseIfConstructToSwitchTest` tests pass (including `nullCheckWithNonJdkTypes` and `threeNonJdkTypes`)
- [x] No regressions in other tests

- Fixes #1004