### PR TITLE
Fix Jackson 2.21+ compatibility for JREThrowableFinalMethods

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
+++ b/src/main/java/org/openrewrite/java/migrate/JREThrowableFinalMethods.java
@@ -16,10 +16,9 @@
 package org.openrewrite.java.migrate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -33,16 +32,19 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 @EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class JREThrowableFinalMethods extends Recipe {
 
     private final String methodPatternAddSuppressed;
     private final String methodPatternGetSuppressed;
 
     @JsonCreator
-    public JREThrowableFinalMethods() {
-        this.methodPatternAddSuppressed = "*..* addSuppressed(Throwable)";
-        this.methodPatternGetSuppressed = "*..* getSuppressed()";
+    public JREThrowableFinalMethods(
+            @Nullable String methodPatternAddSuppressed,
+            @Nullable String methodPatternGetSuppressed) {
+        this.methodPatternAddSuppressed = methodPatternAddSuppressed == null ?
+                "*..* addSuppressed(Throwable)" : methodPatternAddSuppressed;
+        this.methodPatternGetSuppressed = methodPatternGetSuppressed == null ?
+                "*..* getSuppressed()" : methodPatternGetSuppressed;
     }
 
     @Getter

--- a/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JREThrowableFinalMethodsTest.java
@@ -91,7 +91,7 @@ class JREThrowableFinalMethodsTest implements RewriteTest {
     void shouldRenameOnJava6() {
         //language=java
         rewriteRun(
-          spec -> spec.recipe(new JREThrowableFinalMethods()),
+          spec -> spec.recipe(new JREThrowableFinalMethods(null, null)),
           java(
             """
               class ClassUsingThrowable {
@@ -118,7 +118,7 @@ class JREThrowableFinalMethodsTest implements RewriteTest {
     void shouldNotRenameOnJava7() {
         //language=java
         rewriteRun(
-          spec -> spec.recipe(new JREThrowableFinalMethods()),
+          spec -> spec.recipe(new JREThrowableFinalMethods(null, null)),
           java(
             """
               class ClassUsingThrowable {


### PR DESCRIPTION
## Summary

- Fixes the `InvalidDefinitionException: Conflicting property-based creators` error reported in issue #1003. The "Lombok Best Practices" commit introduced `@RequiredArgsConstructor(access = AccessLevel.PACKAGE)`, which generates a constructor with `@ConstructorProperties`, conflicting with the existing no-arg `@JsonCreator`.

## Changes

- Removed `@RequiredArgsConstructor` from `JREThrowableFinalMethods`
- Converted `@JsonCreator` to accept nullable parameters with defaults, matching the pattern used in #1007
- Updated test calls accordingly

This approach is consistent with how `ReplaceAWTGetPeerMethod` was fixed for Jackson 2.21+ compatibility.