### PR TITLE
Fix UpgradeToJava21 recipe ordering for switch expressions

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-21.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-21.yml
@@ -41,12 +41,12 @@ recipeList:
   - org.openrewrite.java.migrate.UpgradePluginsForJava21
   - org.openrewrite.java.migrate.DeleteDeprecatedFinalize
   - org.openrewrite.java.migrate.RemovedSubjectMethods
+  - org.openrewrite.java.migrate.lang.IfElseIfConstructToSwitch
+  - org.openrewrite.java.migrate.lang.NullCheckAsSwitchCase
   - org.openrewrite.java.migrate.lang.SwitchCaseAssignmentsToSwitchExpression
   - org.openrewrite.java.migrate.lang.SwitchCaseReturnsToSwitchExpression
   - org.openrewrite.java.migrate.lang.SwitchExpressionYieldToArrow
-  - org.openrewrite.java.migrate.lang.IfElseIfConstructToSwitch
   - org.openrewrite.java.migrate.SwitchPatternMatching
-  - org.openrewrite.java.migrate.lang.NullCheckAsSwitchCase
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava21Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava21Test.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+class UpgradeToJava21Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.migrate.UpgradeToJava21");
+    }
+
+    @DocumentExample
+    @Test
+    void ifElseIfAssignmentToSwitchExpressionInOnePass() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                class Test {
+                    private static double convertToDouble(Object value) {
+                        double dValue;
+                        if (value instanceof String string) {
+                            dValue = Double.parseDouble(string);
+                        } else if (value instanceof Integer integer) {
+                            dValue = integer.doubleValue();
+                        } else if (value instanceof Long long1) {
+                            dValue = long1.doubleValue();
+                        } else {
+                            dValue = (double) value;
+                        }
+                        return dValue;
+                    }
+                }
+                """,
+              """
+                class Test {
+                    private static double convertToDouble(Object value) {
+                        return switch (value) {
+                            case String string -> Double.parseDouble(string);
+                            case Integer integer -> integer.doubleValue();
+                            case Long long1 -> long1.doubleValue();
+                            default -> (double) value;
+                        };
+                    }
+                }
+                """
+            ), 21)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Reorders recipes in `UpgradeToJava21` so that `IfElseIfConstructToSwitch` runs before the switch expression conversion recipes. This ensures if-else-if instanceof chains are fully converted to switch expressions in a single pass.
- fixes #1011

Previously, `SwitchCaseAssignmentsToSwitchExpression` ran before `IfElseIfConstructToSwitch`, so newly created switch statements weren't converted to expressions until a second run.

## Changes

- Reorder recipes in `java-version-21.yml`: Move `IfElseIfConstructToSwitch` and `NullCheckAsSwitchCase` before the expression converters
- Add integration test `UpgradeToJava21Test` demonstrating the fix

## Verification

All existing switch-related tests pass; new test verifies single-pass conversion of the issue's example code.