### PR TITLE
Fix Jetty EE9 dependencies

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -1298,7 +1298,8 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.eclipse.jetty.websocket
       oldArtifactId: websocket-api
-      newArtifactId: jetty-websocket-jetty-api
+      newGroupId: org.eclipse.jetty.ee9.websocket
+      newArtifactId: jetty-ee9-websocket-jetty-api
       newVersion: 12.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.eclipse.jetty.websocket
@@ -1315,12 +1316,14 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.eclipse.jetty.websocket
       oldArtifactId: javax-websocket-server-impl
-      newArtifactId: websocket-javax-server
+      newGroupId: org.eclipse.jetty.ee9.websocket
+      newArtifactId: jetty-ee9-websocket-jakarta-server
       newVersion: 12.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.eclipse.jetty.websocket
       oldArtifactId: javax-websocket-client-impl
-      newArtifactId: websocket-javax-client
+      newGroupId: org.eclipse.jetty.ee9.websocket
+      newArtifactId: jetty-ee9-websocket-jakarta-client
       newVersion: 12.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.eclipse.jetty


### PR DESCRIPTION
## What's changed?
- Fixes #1015
Some Jetty group:artifact:versions did not exist. 

## What's your motivation?
After a migration, ran into:
`Could not find artifact org.eclipse.jetty.websocket:websocket-javax-server:jar:12.0.x in central (https://repo.maven.apache.org/maven2)`

## Any additional context
- Since the original PR #826, it seems Jetty has released 12.1.x. (as seen in https://mvnrepository.com/artifact/org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jakarta-client and other artifacts)

Should this EE9 recipe point to **12.1.x** or **12.x** instead?

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases - no existing tests yet
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
