### PR TITLE
Cleanup Jetty EE10 recipes. Reorder…

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -615,6 +615,12 @@ preconditions:
 recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.eclipse.jetty.ee9.websocket
+      oldArtifactId: jetty-ee9-websocket-jetty-api
+      newGroupId: org.eclipse.jetty.ee10.websocket
+      newArtifactId: jetty-ee10-websocket-jetty-api
+      newVersion: 12.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.eclipse.jetty.ee9.websocket
       oldArtifactId: jetty-ee9-websocket-jetty-server
       newGroupId: org.eclipse.jetty.ee10.websocket
       newArtifactId: jetty-ee10-websocket-jetty-server
@@ -625,6 +631,18 @@ recipeList:
       newGroupId: org.eclipse.jetty.ee10.websocket
       newArtifactId: jetty-ee10-websocket-jetty-client
       newVersion: 12.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.eclipse.jetty.ee9.websocket
+      oldArtifactId: jetty-ee9-websocket-jakarta-server
+      newGroupId: org.eclipse.jetty.ee10.websocket
+      newArtifactId: jetty-ee10-websocket-jakarta-server
+      newVersion: 12.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.eclipse.jetty.ee9.websocket
+      oldArtifactId: jetty-ee9-websocket-jakarta-client
+      newGroupId: org.eclipse.jetty.ee10.websocket
+      newArtifactId: jetty-ee10-websocket-jakarta-client
+      newVersion: 12.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.eclipse.jetty.ee9
       oldArtifactId: jetty-ee9-apache-jsp
@@ -667,12 +685,6 @@ recipeList:
       newGroupId: org.eclipse.jetty.ee10
       newArtifactId: jetty-ee10-annotations
       newVersion: 12.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.eclipse.jetty.ee9.websocket
-      oldArtifactId: jetty-ee9-websocket-jetty-server
-      newGroupId: org.eclipse.jetty.ee10.websocket
-      newArtifactId: jetty-ee10-websocket-jakarta-server
-      newVersion: 12.x
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.eclipse.jetty.util.resource.ResourceCollection
       newFullyQualifiedTypeName: org.eclipse.jetty.util.resource.Resource


### PR DESCRIPTION
## What's changed?
General cleanup and fixes for Jetty EE10
- Fix duplicate ChangeDependency > oldArtifactId `jetty-ee9-websocket-jetty-server` in recipe list 
- Bring recipe list in line with Jetty EE9 list
  - Add `jetty-ee10-websocket-jetty-api` and `jetty-ee10-websocket-jakarta-client` dependency.
  - Reorder to match Jetty EE9 list

## What's your motivation?
Was hard to compare Jetty EE9 upgrade to EE10 upgrade recipes