### PR TITLE
Modernize README to reflect current project capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,8 @@ Beyond Java and Jakarta EE version migrations, this module also includes recipes
 
 - **Guava** — Replace Guava utilities with Java standard library equivalents
 - **Lombok** — Best practices and modernization
-- **Logging** — Migrate between logging frameworks
 - **JSpecify** — Adopt JSpecify nullability annotations
 - **DataNucleus** — Upgrade DataNucleus versions
-- **Scala** — Java/Scala interop migrations
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Fix outdated claims (e.g., "only Maven-based build files are supported" — Gradle is fully supported)
- Add Java 25 to LTS list and migration recipe table
- Broaden Jakarta EE coverage from just JAXB/JAX-WS to the full breadth of EE 9/10/11 migrations
- Replace prose-heavy sections with scannable tables for migration recipes
- Remove obsolete content: Illegal Reflective Access deep-dive, stale IBM WAMT link
- Add "Other recipes" section covering Guava, Lombok, logging, JSpecify, DataNucleus, Scala

## Test plan
- [ ] Verify rendered markdown formatting on GitHub
- [ ] Confirm all links resolve correctly
- [ ] Cross-check recipe names against YAML files in `src/main/resources/META-INF/rewrite/`