### PR TITLE
Add UseTryWithResources to Java 11 migration recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-11.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-11.yml
@@ -45,6 +45,7 @@ recipeList:
   # Remediate deprecations
   - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
   - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
+  - org.openrewrite.staticanalysis.UseTryWithResources
   - org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs
   - org.openrewrite.java.migrate.lang.JavaLangAPIs
   - org.openrewrite.java.RemoveMethodInvocations:


### PR DESCRIPTION
## Summary
- Adds the `UseTryWithResources` recipe from rewrite-static-analysis to the `Java8toJava11` migration recipe list, alongside the existing static analysis recipes in the deprecation remediation section.
- Try-with-resources is a Java 7+ language feature, so encouraging its adoption fits naturally in the Java 11 modernization path.