### PR TITLE
Fix IBMSemeruTest for updated ChangeType wildcard import handling

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/IBMSemeruTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/IBMSemeruTest.java
@@ -45,7 +45,7 @@ class IBMSemeruTest implements RewriteTest {
           //language=java
           java(
             """
-              import com.sun.net.ssl.internal.www.protocol.https.*;  //do NOT flag this
+              import com.sun.net.ssl.internal.www.protocol.https.*;
 
               class Foo{
                 void bar() {
@@ -70,7 +70,6 @@ class IBMSemeruTest implements RewriteTest {
               """,
             """
               import com.ibm.net.ssl.www2.protocol.https.Handler;
-              import com.sun.net.ssl.internal.www.protocol.https.*;  //do NOT flag this
 
               class Foo{
                 void bar() {
@@ -142,7 +141,7 @@ class IBMSemeruTest implements RewriteTest {
           //language=java
           java(
             """
-              import com.sun.net.ssl.internal.ssl.*;  // do NOT flag, handled by other rule
+              import com.sun.net.ssl.internal.ssl.*;
 
               class TestClass_2{
                 void bar() {
@@ -154,7 +153,6 @@ class IBMSemeruTest implements RewriteTest {
               """,
             """
               import com.ibm.jsse2.IBMJSSEProvider2;
-              import com.sun.net.ssl.internal.ssl.*;  // do NOT flag, handled by other rule
 
               class TestClass_2{
                 void bar() {


### PR DESCRIPTION
## Summary
- Updated two `IBMSemeruTest` tests (`doNotUseSunNetSslInternalSslProvider` and `doNotUseSunNetSslInternalWwwProtocolHttpsHandler`) to match new `ChangeType` behavior in rewrite-java core
- The core now removes unused wildcard imports when all referenced types from that package have been changed, rather than leaving them behind
- Removed now-unnecessary "do NOT flag" comments from the test text blocks since the wildcard imports they annotated are no longer retained in the expected output

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.migrate.IBMSemeruTest"` passes (all 9 tests)