### PR TITLE
Fix order for ManagedProperty migration in Faces 4.0

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-4.yml
@@ -242,13 +242,13 @@ recipeList:
       oldFullyQualifiedTypeName: javax.faces.bean.ManagedProperty
       newFullyQualifiedTypeName: jakarta.faces.annotation.ManagedProperty
       ignoreDefinition: true
-  - org.openrewrite.java.RemoveAnnotationAttribute:
-      annotationType: jakarta.faces.annotation.ManagedProperty
-      attributeName: name
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: jakarta.faces.bean.ManagedProperty
       newFullyQualifiedTypeName: jakarta.faces.annotation.ManagedProperty
       ignoreDefinition: true
+  - org.openrewrite.java.RemoveAnnotationAttribute:
+      annotationType: jakarta.faces.annotation.ManagedProperty
+      attributeName: name
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.faces.bean.NoneScoped
       newFullyQualifiedTypeName: jakarta.enterprise.context.Dependent


### PR DESCRIPTION
- Followup to #1025

Fix order of recipes to ensure `name` attribute removal for migrated `@ManagedProperty`