### PR TITLE
Add javax/jakarta.enterprise.concurrent-api migration for EE9

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -387,6 +387,15 @@ preconditions:
   - org.openrewrite.Singleton
 recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: javax.enterprise.concurrent
+      oldArtifactId: javax.enterprise.concurrent-api
+      newGroupId: jakarta.enterprise.concurrent
+      newArtifactId: jakarta.enterprise.concurrent-api
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.enterprise.concurrent
+      artifactId: jakarta.enterprise.concurrent-api
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: javax.enterprise
       oldArtifactId: cdi-api
       newGroupId: jakarta.enterprise


### PR DESCRIPTION
Migrate `javax.enterprise.concurrent-api` to jakarta

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
