### PR TITLE
Inline JavaTemplate fields at their usage sites

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaAtomicsNewReference.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaAtomicsNewReference.java
@@ -45,16 +45,15 @@ public class NoGuavaAtomicsNewReference extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesMethod<>(NEW_ATOMIC_REFERENCE), new JavaVisitor<ExecutionContext>() {
-            private final JavaTemplate newAtomicReference = JavaTemplate.builder("new AtomicReference<>()")
-                    .imports("java.util.concurrent.atomic.AtomicReference")
-                    .build();
-
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 if (NEW_ATOMIC_REFERENCE.matches(method)) {
                     maybeRemoveImport("com.google.common.util.concurrent.Atomics");
                     maybeAddImport("java.util.concurrent.atomic.AtomicReference");
-                    return ((J.NewClass) newAtomicReference.apply(getCursor(), method.getCoordinates().replace()))
+                    return ((J.NewClass) JavaTemplate.builder("new AtomicReference<>()")
+                            .imports("java.util.concurrent.atomic.AtomicReference")
+                            .build()
+                            .apply(getCursor(), method.getCoordinates().replace()))
                             .withArguments(method.getArguments());
                 }
                 return super.visitMethodInvocation(method, ctx);

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewArrayList.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewArrayList.java
@@ -51,40 +51,37 @@ public class NoGuavaListsNewArrayList extends Recipe {
                 new UsesMethod<>(NEW_ARRAY_LIST),
                 new UsesMethod<>(NEW_ARRAY_LIST_ITERABLE),
                 new UsesMethod<>(NEW_ARRAY_LIST_CAPACITY)), new JavaVisitor<ExecutionContext>() {
-            private final JavaTemplate newArrayList = JavaTemplate.builder("new ArrayList<>()")
-                    .contextSensitive()
-                    .imports("java.util.ArrayList")
-                    .build();
-
-            private final JavaTemplate newArrayListCollection = JavaTemplate.builder("new ArrayList<>(#{any(java.util.Collection)})")
-                    .contextSensitive()
-                    .imports("java.util.ArrayList")
-                    .build();
-
-            private final JavaTemplate newArrayListCapacity = JavaTemplate.builder("new ArrayList<>(#{any(int)})")
-                    .contextSensitive()
-                    .imports("java.util.ArrayList")
-                    .build();
-
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 if (NEW_ARRAY_LIST.matches(method)) {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.ArrayList");
-                    return newArrayList.apply(getCursor(), method.getCoordinates().replace());
+                    return JavaTemplate.builder("new ArrayList<>()")
+                            .contextSensitive()
+                            .imports("java.util.ArrayList")
+                            .build()
+                            .apply(getCursor(), method.getCoordinates().replace());
                 }
                 if (NEW_ARRAY_LIST_ITERABLE.matches(method) && method.getArguments().size() == 1 &&
                         TypeUtils.isAssignableTo("java.util.Collection", method.getArguments().get(0).getType())) {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.ArrayList");
-                    return newArrayListCollection.apply(getCursor(), method.getCoordinates().replace(),
-                            method.getArguments().get(0));
+                    return JavaTemplate.builder("new ArrayList<>(#{any(java.util.Collection)})")
+                            .contextSensitive()
+                            .imports("java.util.ArrayList")
+                            .build()
+                            .apply(getCursor(), method.getCoordinates().replace(),
+                                    method.getArguments().get(0));
                 }
                 if (NEW_ARRAY_LIST_CAPACITY.matches(method)) {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.ArrayList");
-                    return newArrayListCapacity.apply(getCursor(), method.getCoordinates().replace(),
-                            method.getArguments().get(0));
+                    return JavaTemplate.builder("new ArrayList<>(#{any(int)})")
+                            .contextSensitive()
+                            .imports("java.util.ArrayList")
+                            .build()
+                            .apply(getCursor(), method.getCoordinates().replace(),
+                                    method.getArguments().get(0));
                 }
                 return super.visitMethodInvocation(method, ctx);
             }

--- a/src/main/java/org/openrewrite/java/migrate/javax/AnnotateTypesVisitor.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/AnnotateTypesVisitor.java
@@ -27,20 +27,10 @@ import java.util.Set;
 public class AnnotateTypesVisitor extends JavaIsoVisitor<Set<String>> {
     private final String annotationToBeAdded;
     private final AnnotationMatcher annotationMatcher;
-    private final JavaTemplate template;
 
     public AnnotateTypesVisitor(String annotationToBeAdded) {
         this.annotationToBeAdded = annotationToBeAdded;
-        String[] split = this.annotationToBeAdded.split("\\.");
-        String className = split[split.length - 1];
-        String packageName = this.annotationToBeAdded.substring(0, this.annotationToBeAdded.lastIndexOf("."));
         this.annotationMatcher = new AnnotationMatcher("@" + this.annotationToBeAdded);
-        String interfaceAsString = String.format("package %s\npublic @interface %s {}", packageName, className);
-        //noinspection LanguageMismatch
-        this.template = JavaTemplate.builder("@" + className)
-                .imports(this.annotationToBeAdded)
-                .javaParser(JavaParser.fromJavaVersion().dependsOn(interfaceAsString))
-                .build();
     }
 
     @Override
@@ -49,7 +39,16 @@ public class AnnotateTypesVisitor extends JavaIsoVisitor<Set<String>> {
         if (cd.getType() != null && injectedTypes.contains(cd.getType().getFullyQualifiedName()) &&
             cd.getLeadingAnnotations().stream().noneMatch(annotationMatcher::matches)) {
             maybeAddImport(annotationToBeAdded);
-            cd = template.apply(getCursor(), cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+            String[] split = annotationToBeAdded.split("\\.");
+            String className = split[split.length - 1];
+            String packageName = annotationToBeAdded.substring(0, annotationToBeAdded.lastIndexOf("."));
+            String interfaceAsString = String.format("package %s\npublic @interface %s {}", packageName, className);
+            //noinspection LanguageMismatch
+            cd = JavaTemplate.builder("@" + className)
+                    .imports(annotationToBeAdded)
+                    .javaParser(JavaParser.fromJavaVersion().dependsOn(interfaceAsString))
+                    .build()
+                    .apply(getCursor(), cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
             cd = maybeAutoFormat(classDecl, cd, cd.getName(), injectedTypes, getCursor());
         }
         return cd;

--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValueToRecord.java
@@ -214,11 +214,6 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
 
     @RequiredArgsConstructor
     private static class LombokValueToRecordVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private static final JavaTemplate TO_STRING_TEMPLATE = JavaTemplate
-                .builder("@Override public String toString() { return \"#{}(\" +\n#{}\n\")\"; }")
-                .contextSensitive()
-                .build();
-
         private static final String TO_STRING_MEMBER_LINE_PATTERN = "\"%s=\" + %s +";
         private static final String TO_STRING_MEMBER_DELIMITER = "\", \" +\n";
         private static final String STANDARD_GETTER_PREFIX = "get";
@@ -319,7 +314,10 @@ public class LombokValueToRecord extends ScanningRecipe<Map<String, Set<String>>
 
         private J.ClassDeclaration addExactToStringMethod(J.ClassDeclaration classDeclaration,
                                                           List<J.VariableDeclarations> memberVariables) {
-            return classDeclaration.withBody(TO_STRING_TEMPLATE
+            return classDeclaration.withBody(JavaTemplate
+                    .builder("@Override public String toString() { return \"#{}(\" +\n#{}\n\")\"; }")
+                    .contextSensitive()
+                    .build()
                     .apply(new Cursor(getCursor(), classDeclaration.getBody()),
                             classDeclaration.getBody().getCoordinates().lastStatement(),
                             classDeclaration.getSimpleName(),


### PR DESCRIPTION
## Summary
- Removes stored `JavaTemplate` fields in favor of inline `JavaTemplate.builder(...).build().apply(...)` chains, matching the recommended pattern used throughout the rest of the codebase.
- Affects `NoGuavaListsNewArrayList`, `NoGuavaAtomicsNewReference`, `AnnotateTypesVisitor`, and `LombokValueToRecord`.
- Net reduction of 7 lines; no behavioral changes.