### PR TITLE
Fix ClassCastException in UseVarForGenericMethodInvocations

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -119,7 +119,7 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 if (arg instanceof J.NewClass) {
                     J.NewClass newClass = (J.NewClass) arg;
                     // Check if using diamond operator (rightTypeParams is empty)
-                    if (!hasTypeParams(newClass.getClazz())) {
+                    if (newClass.getClazz() instanceof J.ParameterizedType && !hasTypeParams(newClass.getClazz())) {
                         // Copy type parameters from left side to right side
                         J.ParameterizedType rightType = (J.ParameterizedType) newClass.getClazz();
                         return newClass.withClazz(requireNonNull(rightType).withTypeParameters(leftTypeParams));

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -331,6 +331,70 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
             );
         }
 
+        @Test
+        void nonParameterizedNewClassArgument() {
+            //language=java
+            rewriteRun(
+              version(
+                java(
+                  """
+                    import java.util.Collections;
+                    import java.util.List;
+
+                    class A {
+                      void m() {
+                          List<String> strs = Collections.singletonList(new String("test"));
+                      }
+                    }
+                    """,
+                  """
+                    import java.util.Collections;
+                    import java.util.List;
+
+                    class A {
+                      void m() {
+                          var strs = Collections.singletonList(new String("test"));
+                      }
+                    }
+                    """
+                ),
+                10
+              )
+            );
+        }
+
+        @Test
+        void fieldAccessNewClassArgument() {
+            //language=java
+            rewriteRun(
+              version(
+                java(
+                  """
+                    import java.util.Collections;
+                    import java.util.List;
+
+                    class A {
+                      void m() {
+                          List<java.lang.String> strs = Collections.singletonList(new java.lang.String("test"));
+                      }
+                    }
+                    """,
+                  """
+                    import java.util.Collections;
+                    import java.util.List;
+
+                    class A {
+                      void m() {
+                          var strs = Collections.singletonList(new java.lang.String("test"));
+                      }
+                    }
+                    """
+                ),
+                10
+              )
+            );
+        }
+
         @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/868")
         @Test
         void genericsCollectorsRegression() {


### PR DESCRIPTION
## Motivation

`UseVarForGenericMethodInvocations` throws a `ClassCastException` when a generic method invocation contains a `new` expression with a non-parameterized type (e.g., `new String(...)` or `new java.lang.String(...)`). The `makeNestedGenericsExplicit()` method casts `newClass.getClazz()` to `J.ParameterizedType` without checking, but the clazz can be a `J.Identifier` (237 occurrences) or `J.FieldAccess` (11 occurrences). This was discovered via flagship recipe run alerts on app.moderne.io affecting Netflix/archaius, Netflix/curator, Netflix/eureka, and other repos.

```
java.lang.ClassCastException: class org.openrewrite.java.tree.J$Identifier cannot be cast to class org.openrewrite.java.tree.J$ParameterizedType
  at UseVarForGenericMethodInvocations$UseVarForGenericsVisitor.lambda$makeNestedGenericsExplicit$1(UseVarForGenericMethodInvocations.java:124)
```

## Summary

- Add `instanceof J.ParameterizedType` check before casting in `makeNestedGenericsExplicit()`, so non-parameterized `NewClass` arguments (plain identifiers and field accesses) are left unchanged
- Add two test cases reproducing both the `J.Identifier` and `J.FieldAccess` variants of the `ClassCastException`

## Test plan

- [x] New test `nonParameterizedNewClassArgument` reproduces `J$Identifier` cast failure (was `ClassCastException` before fix)
- [x] New test `fieldAccessNewClassArgument` reproduces `J$FieldAccess` cast failure (was `ClassCastException` before fix)
- [x] All 13 tests in `UseVarForGenericMethodInvocationsTest` pass