### PR TITLE
Upgrade Mockito to 5.17.x in Java 25 migration recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -217,6 +217,10 @@ recipeList:
       groupId: net.bytebuddy
       artifactId: byte-buddy*
       newVersion: 1.17.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.mockito
+      artifactId: mockito-*
+      newVersion: 5.17.x
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
## Summary

- Adds Mockito `5.17.x` upgrade to `UpgradePluginsForJava25` recipe alongside the existing Byte Buddy upgrade

## Problem

Mockito's inline mock maker relies on Byte Buddy for bytecode manipulation. Byte Buddy versions bundled with Mockito before 5.17.0 only understand classfile version 66 (Java 22), but Java 25 emits classfile version 69. This causes Byte Buddy to abort instrumentation, resulting in `Mockito cannot mock this class` failures for any test that mocks classes under Java 25.

While the recipe already upgrades `byte-buddy*` to `1.17.x`, Mockito bundles its own Byte Buddy and older Mockito versions can pull in an incompatible version through dependency resolution.

## Solution

Add `UpgradeDependencyVersion` for `org.mockito:mockito-*` to `5.17.x` — the minimum minor version that bundles Byte Buddy 1.17.6+ with full Java 25 support.

## Test plan

- [x] Existing tests pass
- [x] Recipe CSV validation passes