### PR TITLE
Remove parentheses from single unnamed lambda parameters

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
@@ -70,22 +70,31 @@ public class ReplaceUnusedVariablesWithUnderscore extends Recipe {
             @Override
             public J.Lambda visitLambda(J.Lambda lambda, ExecutionContext ctx) {
                 J.Lambda l = super.visitLambda(lambda, ctx);
+                boolean willRename = false;
                 for (J param : l.getParameters().getParameters()) {
                     if (param instanceof J.VariableDeclarations) {
                         for (J.VariableDeclarations.NamedVariable namedVariable : ((J.VariableDeclarations) param).getVariables()) {
-                            renameVariableIfUnusedInContext(namedVariable, l.getBody());
+                            if (renameVariableIfUnusedInContext(namedVariable, l.getBody())) {
+                                willRename = true;
+                            }
                         }
                     }
+                }
+                if (willRename && l.getParameters().isParenthesized() &&
+                        l.getParameters().getParameters().size() == 1) {
+                    l = l.withParameters(l.getParameters().withParenthesized(false));
                 }
                 return l;
             }
 
-            private void renameVariableIfUnusedInContext(J.VariableDeclarations.NamedVariable variable, J context) {
+            private boolean renameVariableIfUnusedInContext(J.VariableDeclarations.NamedVariable variable, J context) {
                 if (!UNDERSCORE.equals(variable.getName().getSimpleName()) &&
                         VariableReferences.findRhsReferences(context, variable.getName()).isEmpty() &&
                         !usedInModifyingUnary(variable.getName(), context)) {
                     doAfterVisit(new RenameVariable<>(variable, UNDERSCORE));
+                    return true;
                 }
+                return false;
             }
 
             private boolean usedInModifyingUnary(J.Identifier identifier, J context) {

--- a/src/test/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscoreTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscoreTest.java
@@ -175,6 +175,37 @@ class ReplaceUnusedVariablesWithUnderscoreTest implements RewriteTest {
     }
 
     @Test
+    void replaceUnusedParenthesizedLambdaParameter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.stream.Stream;
+              import java.util.stream.Collectors;
+
+              class Test {
+                  void example() {
+                      Stream.of("a", "b", "c")
+                          .collect(Collectors.toMap(String::toUpperCase, (item) -> "NODATA"));
+                  }
+              }
+              """,
+            """
+              import java.util.stream.Stream;
+              import java.util.stream.Collectors;
+
+              class Test {
+                  void example() {
+                      Stream.of("a", "b", "c")
+                          .collect(Collectors.toMap(String::toUpperCase, _ -> "NODATA"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotReplaceUsedLambdaParameter() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary
- When `ReplaceUnusedVariablesWithUnderscore` renames a single parenthesized lambda parameter to `_`, it now also strips the parentheses so `(_) -> ...` becomes `_ -> ...`
- `renameVariableIfUnusedInContext` now returns a boolean to signal whether a rename will occur
- Added `replaceUnusedParenthesizedLambdaParameter` test covering this case

## Test plan
- [x] Existing tests pass
- [x] New test verifies `(item) -> "NODATA"` becomes `_ -> "NODATA"`
- [x] Multi-param lambdas like `(_, _) -> ...` retain parentheses