### PR TITLE
Skip Kotlin and Groovy files in ReplaceUnusedVariablesWithUnderscore

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
@@ -28,6 +28,8 @@ import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.staticanalysis.VariableReferences;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -45,7 +47,12 @@ public class ReplaceUnusedVariablesWithUnderscore extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesJavaVersion<>(22), new JavaIsoVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> preconditions = Preconditions.and(
+                new UsesJavaVersion<>(22),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>())
+        );
+        return Preconditions.check(preconditions, new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ForEachLoop visitForEachLoop(J.ForEachLoop forLoop, ExecutionContext ctx) {
                 J.ForEachLoop l = super.visitForEachLoop(forLoop, ctx);


### PR DESCRIPTION
## Summary
- Add `KotlinFileChecker` and `GroovyFileChecker` preconditions to `ReplaceUnusedVariablesWithUnderscore` so the recipe does not modify Kotlin or Groovy source files.
- Follows the same pattern used by other recipes in the `lang` package (e.g., `SwitchCaseEnumGuardToLabel`, `UseTextBlocks`).

## Test plan
- [x] Existing tests pass