### PR TITLE
Fix empty diff test failure from upstream JavaSourceSet marker updates

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/javax/AddCommonAnnotationsDependenciesTest.java
@@ -49,6 +49,13 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
                   @Generated("Hello")
                   class A {
                   }
+                  """,
+                """
+                  import javax.annotation.Generated;
+
+                  @Generated("Hello")
+                  class A {
+                  }
                   """
               )
             ),
@@ -91,6 +98,13 @@ class AddCommonAnnotationsDependenciesTest implements RewriteTest {
             //language=java
             srcMainJava(
               java(
+                """
+                  import javax.annotation.Generated;
+
+                  @Generated("Hello")
+                  class A {
+                  }
+                  """,
                 """
                   import javax.annotation.Generated;
 


### PR DESCRIPTION
## Summary
- Fixes `AddCommonAnnotationsDependenciesTest.changeAndUpgradeDependencyIfAnnotationJsr250Present()` failing with "An empty diff was generated"
- Caused by openrewrite/rewrite#7202 which added `JavaSourceSet` marker updates to `ChangeDependencyGroupIdAndArtifactId`
- Adds explicit `after` text for the Java source spec to accept marker-only changes

## Context
- Failing CI run: https://github.com/openrewrite/rewrite-migrate-java/actions/runs/24287908619
- Upstream issue: openrewrite/rewrite#7349

## Test plan
- [x] `AddCommonAnnotationsDependenciesTest.changeAndUpgradeDependencyIfAnnotationJsr250Present` passes locally