### PR TITLE
Add URLEqualsHashCodeRecipes to Java best practices

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-best-practices.yml
+++ b/src/main/resources/META-INF/rewrite/java-best-practices.yml
@@ -56,6 +56,7 @@ recipeList:
   - org.openrewrite.staticanalysis.UseObjectNotifyAll
   - org.openrewrite.staticanalysis.RemoveCallsToSystemGc
   - org.openrewrite.staticanalysis.RemoveCallsToObjectFinalize
+  - org.openrewrite.staticanalysis.URLEqualsHashCodeRecipes
   # Static analysis: modernization and cleanup
   - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
   - org.openrewrite.staticanalysis.UseDiamondOperator


### PR DESCRIPTION
## Summary
- Add `URLEqualsHashCodeRecipes` to the bug prevention section of `JavaBestPractices`

`java.net.URL.equals()` and `hashCode()` perform DNS resolution, making them blocking, slow, and non-deterministic. This recipe replaces those calls with `URI`-based alternatives.

## Test plan
- [x] `JavaBestPracticesTest` passes