### PR TITLE
Add NoJodaTime to Java best practices

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("org.openrewrite.recipe:rewrite-github-actions:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
+    implementation("org.openrewrite.recipe:rewrite-joda:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-jenkins:$rewriteVersion")
     implementation("org.openrewrite:rewrite-templating:$rewriteVersion")
     implementation("org.openrewrite.meta:rewrite-analysis:$rewriteVersion")

--- a/src/main/resources/META-INF/rewrite/java-best-practices.yml
+++ b/src/main/resources/META-INF/rewrite/java-best-practices.yml
@@ -36,6 +36,8 @@ recipeList:
       convertStringsWithoutNewlines: true
   # Prefer Java standard library over Guava where possible
   - org.openrewrite.java.migrate.guava.NoGuava
+  # Prefer Java standard library over Joda-Time where possible
+  - org.openrewrite.java.joda.time.NoJodaTime
   # JSpecify nullability annotations best practices
   - org.openrewrite.java.jspecify.JSpecifyBestPractices
   # Local variable type inference — targeted, non-controversial uses


### PR DESCRIPTION
## Summary
- Add `org.openrewrite.java.joda.time.NoJodaTime` to the `JavaBestPractices` recipe, migrating Joda-Time usage to `java.time` (JSR-310)
- Add `rewrite-joda` as a dependency to make the recipe available

## Test plan
- [ ] Verify the recipe resolves and the build passes