### PR TITLE
Fix `ClassCastException` on parenthesized initializers in `var` recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForConstructors.java
@@ -21,6 +21,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.*;
@@ -57,11 +58,11 @@ public class UseVarForConstructors extends Recipe {
                     return vd;
                 }
 
-                Expression initializer = vd.getVariables().get(0).getInitializer();
-                if (initializer == null) {
+                Expression originalInitializer = vd.getVariables().get(0).getInitializer();
+                if (originalInitializer == null) {
                     return vd;
                 }
-                initializer = initializer.unwrap();
+                Expression initializer = originalInitializer.unwrap();
 
                 // Only transform constructor calls
                 if (!(initializer instanceof J.NewClass)) {
@@ -77,7 +78,13 @@ public class UseVarForConstructors extends Recipe {
                     maybeRemoveImport((JavaType.FullyQualified) vd.getType());
                 }
 
-                return DeclarationCheck.transformToVar(vd, (J.NewClass nc) -> maybeTransferTypeArguments(vd, nc));
+                if (initializer != originalInitializer) {
+                    Expression unwrapped = initializer.withPrefix(originalInitializer.getPrefix());
+                    vd = vd.withVariables(ListUtils.mapFirst(vd.getVariables(), nv -> nv.withInitializer(unwrapped)));
+                }
+
+                J.VariableDeclarations finalVd = vd;
+                return DeclarationCheck.transformToVar(vd, (J.NewClass nc) -> maybeTransferTypeArguments(finalVd, nc));
             }
 
             private J.NewClass maybeTransferTypeArguments(J.VariableDeclarations vd, J.NewClass initializer) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -66,21 +66,26 @@ public class UseVarForGenericMethodInvocations extends Recipe {
             }
 
             // Now we deal with generics, check for method invocations
-            Expression initializer = vd.getVariables().get(0).getInitializer();
-            boolean isMethodInvocation = initializer != null && initializer.unwrap() instanceof J.MethodInvocation;
-            if (!isMethodInvocation) {
+            Expression originalInitializer = vd.getVariables().get(0).getInitializer();
+            if (originalInitializer == null || !(originalInitializer.unwrap() instanceof J.MethodInvocation)) {
                 return vd;
             }
+            J.MethodInvocation invocation = (J.MethodInvocation) originalInitializer.unwrap();
 
             // If no type parameters and no arguments are present, we assume the type is too hard to determine
-            boolean hasNoTypeParams = ((J.MethodInvocation) initializer).getTypeParameters() == null;
-            boolean argumentsEmpty = allArgumentsEmpty((J.MethodInvocation) initializer);
+            boolean hasNoTypeParams = invocation.getTypeParameters() == null;
+            boolean argumentsEmpty = allArgumentsEmpty(invocation);
             if (hasNoTypeParams && argumentsEmpty) {
                 return vd;
             }
 
             if (vd.getType() instanceof JavaType.FullyQualified) {
                 maybeRemoveImport((JavaType.FullyQualified) vd.getType());
+            }
+
+            if (invocation != originalInitializer) {
+                J.MethodInvocation unwrapped = invocation.withPrefix(originalInitializer.getPrefix());
+                vd = vd.withVariables(ListUtils.mapFirst(vd.getVariables(), nv -> nv.withInitializer(unwrapped)));
             }
 
             // Make nested generic types explicit before converting to var

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForConstructorsTest.java
@@ -185,6 +185,33 @@ class UseVarForConstructorsTest implements RewriteTest {
     }
 
     @Test
+    void parenthesizedConstructorInitializer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.ArrayList;
+
+              class A {
+                  void m() {
+                      ArrayList<String> list = (new ArrayList<String>());
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayList;
+
+              class A {
+                  void m() {
+                      var list = new ArrayList<String>();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotReplaceInvalidPatterns() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -395,6 +395,36 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
             );
         }
 
+        @Test
+        void parenthesizedMethodInvocationInitializer() {
+            //language=java
+            rewriteRun(
+              version(
+                java(
+                  """
+                    import java.util.List;
+
+                    class A {
+                      void m() {
+                          List<String> strs = (List.of("one", "two"));
+                      }
+                    }
+                    """,
+                  """
+                    import java.util.List;
+
+                    class A {
+                      void m() {
+                          var strs = List.of("one", "two");
+                      }
+                    }
+                    """
+                ),
+                10
+              )
+            );
+        }
+
         @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/868")
         @Test
         void genericsCollectorsRegression() {


### PR DESCRIPTION
## Motivation

`UseVarForConstructors` crashes with `ClassCastException: J$Parentheses cannot be cast to J$NewClass` when the variable initializer is a parenthesized `new` expression:

```
java.lang.ClassCastException: class org.openrewrite.java.tree.J$Parentheses cannot be cast to class org.openrewrite.java.tree.J$NewClass
  org.openrewrite.java.migrate.lang.var.DeclarationCheck.transformToVar(DeclarationCheck.java:246)
  org.openrewrite.java.migrate.lang.var.UseVarForConstructors$1.visitVariableDeclarations(UseVarForConstructors.java:80)
```

The recipe unwraps the initializer locally for the `instanceof J.NewClass` check, but then hands the original `VariableDeclarations` (still wrapping `J.Parentheses`) to `DeclarationCheck.transformToVar`, which re-fetches the raw initializer and casts it to `J.NewClass`.

`UseVarForGenericMethodInvocations` has the same latent bug — it unwraps for the `instanceof J.MethodInvocation` check but then casts the *raw* initializer to `J.MethodInvocation` for further inspection.

The other sibling recipes that call `DeclarationCheck.transformToVar` (`UseVarForObject`, `UseVarForGenericsConstructors`, `UseVarForPrimitive`, `UseVarForTypeCast`) are not affected — they either don't unwrap, bail out early on parentheses, or use a lambda parameter type of `Expression`.

## Example

Before — crashes:

```java
ArrayList<String> list = (new ArrayList<String>());
```

After:

```java
var list = new ArrayList<String>();
```

(Surplus parentheses are dropped as part of the transformation.)

## Summary

- Rewrite `vd` to use the unwrapped initializer (preserving the original prefix) before calling `DeclarationCheck.transformToVar` in `UseVarForConstructors` and `UseVarForGenericMethodInvocations`.
- Preserve the existing behavior for non-parenthesized initializers (the rewrite only happens when unwrap actually peeled parens).
- The fix is applied at each call site rather than inside `transformToVar`, because the transformer lambda's signature commits the caller to a specific expression type — silently unwrapping in `transformToVar` would drop parens from outputs whose callers didn't request that.

## Test plan

- [x] Added `UseVarForConstructorsTest#parenthesizedConstructorInitializer` reproducing the original `ClassCastException`; confirmed it failed on `main` with the same stack and passes after the fix.
- [x] Added `UseVarForGenericMethodInvocationsTest#parenthesizedMethodInvocationInitializer` reproducing the analogous crash for that recipe; confirmed it failed on `main` and passes after the fix.
- [x] Full `./gradlew test` is green.