### PR TITLE
Fix `MigrateCollections*` template errors on complex expression contexts

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyList.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyList.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 public class MigrateCollectionsEmptyList extends Recipe {
     private static final MethodMatcher EMPTY_LIST = new MethodMatcher("java.util.Collections emptyList()");
@@ -39,7 +41,9 @@ public class MigrateCollectionsEmptyList extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(EMPTY_LIST));
+                new UsesMethod<>(EMPTY_LIST),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>()));
         return Preconditions.check(check, new JavaIsoVisitor<ExecutionContext>() {
 
             @Override
@@ -50,7 +54,6 @@ public class MigrateCollectionsEmptyList extends Recipe {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.List");
                     return JavaTemplate.builder("List.of()")
-                            .contextSensitive()
                             .imports("java.util.List")
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace());

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMap.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 public class MigrateCollectionsEmptyMap extends Recipe {
     private static final MethodMatcher EMPTY_MAP = new MethodMatcher("java.util.Collections emptyMap()");
@@ -39,7 +41,9 @@ public class MigrateCollectionsEmptyMap extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(EMPTY_MAP));
+                new UsesMethod<>(EMPTY_MAP),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>()));
         return Preconditions.check(check, new JavaIsoVisitor<ExecutionContext>() {
 
             @Override
@@ -50,7 +54,6 @@ public class MigrateCollectionsEmptyMap extends Recipe {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.Map");
                     return JavaTemplate.builder("Map.of()")
-                            .contextSensitive()
                             .imports("java.util.Map")
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace());

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptySet.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptySet.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 public class MigrateCollectionsEmptySet extends Recipe {
     private static final MethodMatcher EMPTY_SET = new MethodMatcher("java.util.Collections emptySet()");
@@ -39,7 +41,9 @@ public class MigrateCollectionsEmptySet extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(EMPTY_SET));
+                new UsesMethod<>(EMPTY_SET),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>()));
         return Preconditions.check(check, new JavaIsoVisitor<ExecutionContext>() {
 
             @Override
@@ -50,7 +54,6 @@ public class MigrateCollectionsEmptySet extends Recipe {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.Set");
                     return JavaTemplate.builder("Set.of()")
-                            .contextSensitive()
                             .imports("java.util.Set")
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace());

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonList.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonList.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.JavaType.ShallowClass;
 import org.openrewrite.java.tree.Space;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import static java.util.Collections.emptyList;
 
@@ -41,7 +43,9 @@ public class MigrateCollectionsSingletonList extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(SINGLETON_LIST), new NoMissingTypes());
+                new UsesMethod<>(SINGLETON_LIST), new NoMissingTypes(),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>()));
         return Preconditions.check(check, new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
@@ -27,6 +27,8 @@ import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.util.List;
 import java.util.StringJoiner;
@@ -42,7 +44,11 @@ public class MigrateCollectionsSingletonMap extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.and(new UsesJavaVersion<>(9), new UsesMethod<>(SINGLETON_MAP)), new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(Preconditions.and(
+                new UsesJavaVersion<>(9),
+                new UsesMethod<>(SINGLETON_MAP),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>())), new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
@@ -54,7 +60,6 @@ public class MigrateCollectionsSingletonMap extends Recipe {
                     args.forEach(o -> mapOf.add("#{any()}"));
 
                     return JavaTemplate.builder(mapOf.toString())
-                            .contextSensitive()
                             .imports("java.util.Map")
                             .build()
                             .apply(

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonSet.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 public class MigrateCollectionsSingletonSet extends Recipe {
     private static final MethodMatcher SINGLETON_SET = new MethodMatcher("java.util.Collections singleton(..)", true);
@@ -39,7 +41,9 @@ public class MigrateCollectionsSingletonSet extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(SINGLETON_SET));
+                new UsesMethod<>(SINGLETON_SET),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>()));
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
@@ -49,7 +53,6 @@ public class MigrateCollectionsSingletonSet extends Recipe {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.Set");
                     return JavaTemplate.builder("Set.of(#{any()})")
-                            .contextSensitive()
                             .imports("java.util.Set")
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace(), m.getArguments().get(0));

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsUnmodifiableList.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsUnmodifiableList.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 public class MigrateCollectionsUnmodifiableList extends Recipe {
     private static final MethodMatcher UNMODIFIABLE_LIST = new MethodMatcher("java.util.Collections unmodifiableList(java.util.List)", true);
@@ -40,7 +42,9 @@ public class MigrateCollectionsUnmodifiableList extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(UNMODIFIABLE_LIST));
+                new UsesMethod<>(UNMODIFIABLE_LIST),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>()));
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsUnmodifiableSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsUnmodifiableSet.java
@@ -27,6 +27,8 @@ import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.util.List;
 import java.util.StringJoiner;
@@ -44,7 +46,9 @@ public class MigrateCollectionsUnmodifiableSet extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> check = Preconditions.and(new UsesJavaVersion<>(9),
-                new UsesMethod<>(UNMODIFIABLE_SET));
+                new UsesMethod<>(UNMODIFIABLE_SET),
+                Preconditions.not(new KotlinFileChecker<>()),
+                Preconditions.not(new GroovyFileChecker<>()));
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
@@ -62,7 +66,6 @@ public class MigrateCollectionsUnmodifiableSet extends Recipe {
                                 args.forEach(o -> setOf.add("#{any()}"));
 
                                 return JavaTemplate.builder(setOf.toString())
-                                        .contextSensitive()
                                         .imports("java.util.Set")
                                         .build()
                                         .apply(updateCursor(m), m.getCoordinates().replace(), args.toArray());

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyListTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyListTest.java
@@ -81,4 +81,93 @@ class MigrateCollectionsEmptyListTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyListAsMethodArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Test {
+                  void use(List<String> l) {}
+                  void call() {
+                      use(Collections.emptyList());
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  void use(List<String> l) {}
+                  void call() {
+                      use(List.of());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyListInTernary() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Test {
+                  List<String> get(boolean flag, List<String> other) {
+                      return flag ? Collections.emptyList() : other;
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  List<String> get(boolean flag, List<String> other) {
+                      return flag ? List.of() : other;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyListInSwitchExpression() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Test {
+                  List<String> get(int i) {
+                      return switch (i) {
+                          case 0 -> Collections.emptyList();
+                          default -> null;
+                      };
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  List<String> get(int i) {
+                      return switch (i) {
+                          case 0 -> List.of();
+                          default -> null;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMapTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMapTest.java
@@ -81,4 +81,66 @@ class MigrateCollectionsEmptyMapTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyMapAsArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Test {
+                  void use(Map<String, String> m) {}
+                  void call() {
+                      use(Collections.emptyMap());
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class Test {
+                  void use(Map<String, String> m) {}
+                  void call() {
+                      use(Map.of());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyMapInSwitchExpression() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Test {
+                  Map<String, String> get(int i) {
+                      return switch (i) {
+                          case 0 -> Collections.emptyMap();
+                          default -> null;
+                      };
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class Test {
+                  Map<String, String> get(int i) {
+                      return switch (i) {
+                          case 0 -> Map.of();
+                          default -> null;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptySetTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptySetTest.java
@@ -81,4 +81,64 @@ class MigrateCollectionsEmptySetTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptySetInTernaryInParentheses() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Test {
+                  Set<String> get(Set<String> input) {
+                      return (input != null ? input : Collections.emptySet());
+                  }
+              }
+              """,
+            """
+              import java.util.Set;
+
+              class Test {
+                  Set<String> get(Set<String> input) {
+                      return (input != null ? input : Set.of());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptySetInSwitchExpression() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Test {
+                  Set<String> get(int i) {
+                      return switch (i) {
+                          case 0 -> Collections.emptySet();
+                          default -> null;
+                      };
+                  }
+              }
+              """,
+            """
+              import java.util.Set;
+
+              class Test {
+                  Set<String> get(int i) {
+                      return switch (i) {
+                          case 0 -> Set.of();
+                          default -> null;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMapTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMapTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class MigrateCollectionsSingletonMapTest implements RewriteTest {
 
@@ -99,6 +100,135 @@ class MigrateCollectionsSingletonMapTest implements RewriteTest {
                 class Test {
                     Map<String, String> mapWithNullKey = Collections.singletonMap(null, "foo");
                     Map<String, String> mapWithNullValue = Collections.singletonMap("bar", null);
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Test
+    void singletonMapAsArgument() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.*;
+
+                class Test {
+                    void take(Map<String, Object> m) {}
+                    void call(String key, Object value) {
+                        take(Collections.singletonMap(key, value));
+                    }
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    void take(Map<String, Object> m) {}
+                    void call(String key, Object value) {
+                        take(Map.of(key, value));
+                    }
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Test
+    void singletonMapInSwitchExpression() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.*;
+
+                class Test {
+                    Map<String, Object> get(int i) {
+                        return switch (i) {
+                            case 0 -> Collections.singletonMap("a", "b");
+                            default -> null;
+                        };
+                    }
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Test {
+                    Map<String, Object> get(int i) {
+                        return switch (i) {
+                            case 0 -> Map.of("a", "b");
+                            default -> null;
+                        };
+                    }
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Test
+    void doesNotModifyKotlinSources() {
+        rewriteRun(
+          version(
+            //language=kotlin
+            kotlin(
+              """
+                import java.util.Collections
+
+                class Test {
+                    fun make(key: Int, value: Int): Map<Int, Int> = Collections.singletonMap(key, value)
+                }
+                """
+            ),
+            9
+          )
+        );
+    }
+
+    @Test
+    void singletonMapInTernaryWithMethodCallValue() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.util.*;
+
+                class Converter { String convert(String o) { return "x"; } }
+
+                class Test {
+                    private final Converter converter = new Converter();
+
+                    public Object beforeBodyWrite(Object body) {
+                        return body instanceof String
+                                ? Collections.singletonMap("alps", converter.convert((String) body))
+                                : body;
+                    }
+                }
+                """,
+              """
+                import java.util.Map;
+
+                class Converter { String convert(String o) { return "x"; } }
+
+                class Test {
+                    private final Converter converter = new Converter();
+
+                    public Object beforeBodyWrite(Object body) {
+                        return body instanceof String
+                                ? Map.of("alps", converter.convert((String) body))
+                                : body;
+                    }
                 }
                 """
             ),


### PR DESCRIPTION
## Motivation

The `MigrateCollections{Empty,Singleton,Unmodifiable}*` recipes threw
`IllegalArgumentException: Expected a template that would generate exactly one statement to replace one statement, but generated {0,2}` whenever the `Collections.xxx()` call sat in an expression context that the block-statement stub generator doesn't handle. Observed in the wild on Spring, Spring Data, and Conductor codebases — for example:

```java
// AbstractSockJsSession.java — switch expression arm
return switch (type) {
    case 0 -> Collections.emptyList();
    ...
};

// StaticListableBeanFactory.java — parenthesized ternary branch
return (beanType != null ? ... : Collections.emptySet());

// SQSObservableQueue.java — method argument
return Observable.from(Collections.emptyList());

// AlpsJsonHttpMessageConverter.java — ternary branch with nested method invocation
return body instanceof RootResourceInformation
        ? Collections.singletonMap("alps", converter.convert((RootResourceInformation) body))
        : body;
```

The recipes also blew up on Kotlin `.kt` sources (three `MigrateCollectionsSingletonMap` failures in Spring Security), because `JavaTemplate`'s stub generator produces a Java-shaped stub that doesn't line up with a K-tree.

## Summary

- Drop `.contextSensitive()` from all `JavaTemplate.builder(...)` calls in the `MigrateCollections*` family. The templates (`List.of()`, `Map.of()`, `Set.of()`, `Set.of(#{any()})`, `Map.of(#{any()}, #{any()})`) reference only static factories and their arguments — no local scope — so the context-sensitive block-statement stub generator was doing nothing useful and just exposing gaps (no handling for `J.SwitchExpression`, substitution quirks for method-invocation values). With context-free templating, the stub is always `class Template {{ Object o = List.of(); }}` and parses to exactly one statement regardless of the surrounding syntax.
- Add `KotlinFileChecker` / `GroovyFileChecker` preconditions to every `MigrateCollections*` recipe, matching the pattern already used by `ReplaceUnusedVariablesWithUnderscore` and `IfElseIfConstructToSwitch`. Idiomatic Kotlin already has `emptyList()`/`mapOf()`/`setOf()` and Groovy has `[]`/`[:]`; if those languages ever warrant migration, they belong in separate language-specific recipes.

## Test plan

- [x] New regression tests for switch expressions, ternaries, method arguments, and parenthesized expressions in `MigrateCollectionsEmptyListTest`, `MigrateCollectionsEmptyMapTest`, `MigrateCollectionsEmptySetTest`, and `MigrateCollectionsSingletonMapTest`.
- [x] New Kotlin no-op test in `MigrateCollectionsSingletonMapTest` to lock in the precondition.
- [x] Existing tests for all eight recipes still pass.
- [x] Full `./gradlew test` passes locally.