### PR TITLE
Ensure `case` always has a space before the label in `IfElseIfConstructToSwitch`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
@@ -264,13 +265,29 @@ public class IfElseIfConstructToSwitch extends Recipe {
                                         var0.withType( originalPattern.getType() )
                                                 .withName( var0.getName().withType( originalPattern.getType() ) ) ) );
                             }
-                            return case_.withCaseLabels( singletonList( varDecl.withPrefix( label.getPrefix() ) ) );
+                            return case_.withCaseLabels( singletonList( varDecl.withPrefix( ensureLeadingSpace( label.getPrefix(), varDecl.getTypeExpression() ) ) ) );
                         }
                         // JavaTemplate couldn't resolve the type, so no VariableDeclarations was produced.
                         // Reconstruct one from the original instanceof pattern.
                         return case_.withCaseLabels( singletonList(
-                                buildVariableDeclarations( instanceOf, label.getPrefix() ) ) );
+                                buildVariableDeclarations( instanceOf, ensureLeadingSpace( label.getPrefix(), null ) ) ) );
                     })));
+        }
+
+        /**
+         * The label prefix carries the space after {@code case}. If it is empty and the
+         * type expression also has no leading space, the printed output would collapse
+         * {@code case} into the type name (e.g. {@code caseType name}). Guarantee a
+         * single space so the emitted switch case is always well-formed.
+         */
+        private Space ensureLeadingSpace(Space labelPrefix, @Nullable TypeTree typeExpression) {
+            if (!labelPrefix.getWhitespace().isEmpty()) {
+                return labelPrefix;
+            }
+            if (typeExpression != null && !typeExpression.getPrefix().getWhitespace().isEmpty()) {
+                return labelPrefix;
+            }
+            return Space.SINGLE_SPACE;
         }
 
         @SuppressWarnings("deprecation")

--- a/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.staticanalysis.InstanceOfPatternMatch;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
@@ -933,6 +934,51 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
               )
             );
         }
+    }
+
+    @Test
+    void unresolvableTypesKeepCaseSpacing() {
+        // https://github.com/openrewrite/rewrite/issues/7458
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              package com.example;
+              import com.example.missing.Http2Frame;
+              import com.example.missing.Http2ResetFrame;
+              import com.example.missing.Http2GoAwayFrame;
+              class Test {
+                  protected void incrementCounter(Http2Frame frame) {
+                      long errorCode;
+                      if (frame instanceof Http2ResetFrame resetFrame) {
+                          errorCode = resetFrame.errorCode();
+                      } else if (frame instanceof Http2GoAwayFrame goAwayFrame) {
+                          errorCode = goAwayFrame.errorCode();
+                      } else {
+                          errorCode = -1;
+                      }
+                  }
+              }
+              """,
+            """
+              package com.example;
+              import com.example.missing.Http2Frame;
+              import com.example.missing.Http2ResetFrame;
+              import com.example.missing.Http2GoAwayFrame;
+              class Test {
+                  protected void incrementCounter(Http2Frame frame) {
+                      long errorCode;
+                      switch (frame) {
+                          case Http2ResetFrame resetFrame -> errorCode = resetFrame.errorCode();
+                          case Http2GoAwayFrame goAwayFrame -> errorCode = goAwayFrame.errorCode();
+                          case null, default -> errorCode = -1;
+                      }
+                  }
+              }
+              """
+          )
+        );
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Guarantee a single space between `case` and the pattern label so the emitted switch is always well-formed (`case Type name` rather than `caseType name`).
- Adds a regression test (`unresolvableTypesKeepCaseSpacing`) that exercises the recipe on code with unresolvable types, mirroring the failure reported on Netflix/zuul.

- Reported in openrewrite/rewrite#7458, where the recipe's output against `Http2MetricsChannelHandlers.java` collapsed `case Http2ResetFrame resetFrame` into `caseHttp2ResetFrame resetFrame`. This defensive fix wraps both branches that build the case label (JavaTemplate-resolved and manually reconstructed) with `ensureLeadingSpace`, so the label always has leading whitespace regardless of the incoming prefix state of the type expression.

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.migrate.lang.IfElseIfConstructToSwitchTest"`
- [x] `./gradlew test`