### PR TITLE
Refresh UpdateSdkManTest fixtures after SDKMAN CSV update

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -30,13 +30,13 @@ class UpdateSdkManTest implements RewriteTest {
     @Test
     void updateVersionExact() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateSdkMan("17.0.18", null)),
+          spec -> spec.recipe(new UpdateSdkMan("17.0.19", null)),
           text(
             """
               java=11.1.2-tem
               """,
             """
-              java=17.0.18-tem
+              java=17.0.19-tem
               """,
             spec -> spec.path(".sdkmanrc")
           )
@@ -63,10 +63,10 @@ class UpdateSdkManTest implements RewriteTest {
           spec -> spec.recipe(new UpdateSdkMan(null, "amzn")),
           text(
             """
-              java=11.0.30-tem
+              java=11.0.31-zulu
               """,
             """
-              java=11.0.30-amzn
+              java=11.0.31-amzn
               """,
             spec -> spec.path(".sdkmanrc")
           )
@@ -186,13 +186,13 @@ class UpdateSdkManTest implements RewriteTest {
     @Test
     void upgradeIfNewVersionIsStillSameVersionBasisAndDifferentDistribution() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateSdkMan("23", "amzn")),
+          spec -> spec.recipe(new UpdateSdkMan("21", "tem")),
           text(
             """
-              java=23.0.1-open
+              java=21.0.10-jbr
               """,
             """
-              java=23.0.2-amzn
+              java=21.0.11-tem
               """,
             spec -> spec.path(".sdkmanrc")
           )


### PR DESCRIPTION
## Summary

Today's auto-update of [`sdkman-java.csv`](https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/resources/sdkman-java.csv) (commit 9664adb3, "[Auto] SDKMAN! Java candidates as of 2026-04-27T1141") removed several patch versions that `UpdateSdkManTest` had hard-coded, breaking three tests on `main`:

| Test | Was | Now |
|---|---|---|
| `updateVersionExact` | `17.0.18-tem` | `17.0.19-tem` |
| `updateDistributionOnly` | `11.0.30-tem` → `11.0.30-amzn` | `11.0.31-zulu` → `11.0.31-amzn` |
| `upgradeIfNewVersionIsStillSameVersionBasisAndDifferentDistribution` | `23.0.1-open` → `23.0.2-amzn` | `21.0.10-jbr` → `21.0.11-tem` |

The pairs were chosen to keep demonstrating the same recipe behavior (exact-version pin, distribution-only swap, and major-pinned upgrade across distributions) using versions present in the current CSV.

## Test plan

- [x] `./gradlew test --tests UpdateSdkManTest.updateVersionExact --tests UpdateSdkManTest.updateDistributionOnly --tests UpdateSdkManTest.upgradeIfNewVersionIsStillSameVersionBasisAndDifferentDistribution` passes locally