### PR TITLE
Skip `var` when reassignment relies on declared supertype

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -254,20 +254,20 @@ final class DeclarationCheck {
         if (method == null) {
             return false;
         }
-        AtomicBoolean reassigned = new AtomicBoolean(false);
-        new JavaIsoVisitor<AtomicBoolean>() {
+        return new JavaIsoVisitor<AtomicBoolean>() {
             @Override
             public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean found) {
-                if (!found.get() && assignment.getVariable() instanceof J.Identifier) {
-                    JavaType.Variable fieldType = ((J.Identifier) assignment.getVariable()).getFieldType();
-                    if (variableType.equals(fieldType)) {
-                        found.set(true);
-                    }
+                if (found.get()) {
+                    return assignment;
+                }
+                if (assignment.getVariable() instanceof J.Identifier &&
+                        variableType.equals(((J.Identifier) assignment.getVariable()).getFieldType())) {
+                    found.set(true);
+                    return assignment;
                 }
                 return super.visitAssignment(assignment, found);
             }
-        }.visit(method, reassigned);
-        return reassigned.get();
+        }.reduce(method, new AtomicBoolean(false)).get();
     }
 
     public static J.VariableDeclarations transformToVar(J.VariableDeclarations vd) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -19,10 +19,12 @@ import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
@@ -231,6 +233,41 @@ final class DeclarationCheck {
         }
 
         return invocation.getMethodType().hasFlags(Flag.Static);
+    }
+
+    /**
+     * Determine whether the variable declared in {@code vd} is later reassigned within the
+     * enclosing method. Reassignments matter when the declared type differs from the
+     * initializer's concrete type, since switching to {@code var} narrows the inferred type
+     * and may break subsequent assignments of supertype values.
+     *
+     * @param cursor location of the visitor
+     * @param vd     variable definition at hand
+     * @return true iff the variable is reassigned within the enclosing method
+     */
+    public static boolean isReassigned(Cursor cursor, J.VariableDeclarations vd) {
+        JavaType.Variable variableType = vd.getVariables().get(0).getVariableType();
+        if (variableType == null) {
+            return false;
+        }
+        J.MethodDeclaration method = cursor.firstEnclosing(J.MethodDeclaration.class);
+        if (method == null) {
+            return false;
+        }
+        AtomicBoolean reassigned = new AtomicBoolean(false);
+        new JavaIsoVisitor<AtomicBoolean>() {
+            @Override
+            public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean found) {
+                if (!found.get() && assignment.getVariable() instanceof J.Identifier) {
+                    JavaType.Variable fieldType = ((J.Identifier) assignment.getVariable()).getFieldType();
+                    if (variableType.equals(fieldType)) {
+                        found.set(true);
+                    }
+                }
+                return super.visitAssignment(assignment, found);
+            }
+        }.visit(method, reassigned);
+        return reassigned.get();
     }
 
     public static J.VariableDeclarations transformToVar(J.VariableDeclarations vd) {

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -79,6 +79,13 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 return vd;
             }
 
+            // Switching to var narrows the variable type to the initializer's concrete type, which can break later
+            // reassignments that rely on the declared (super)type. Skip when types differ and the variable is reassigned.
+            if (!TypeUtils.isOfType(vd.getType(), invocation.getType()) &&
+                    DeclarationCheck.isReassigned(getCursor(), vd)) {
+                return vd;
+            }
+
             if (vd.getType() instanceof JavaType.FullyQualified) {
                 maybeRemoveImport((JavaType.FullyQualified) vd.getType());
             }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructors.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,6 +76,14 @@ public class UseVarForGenericsConstructors extends Recipe {
             // Therefore, skip variable declarations with generic wildcards.
             boolean genericHasBounds = anyTypeHasBounds(leftTypes);
             if (genericHasBounds) {
+                return vd;
+            }
+
+            // Switching to var narrows the variable type to the initializer's concrete type, which can break later
+            // reassignments that rely on the declared (super)type. Skip when types differ and the variable is reassigned.
+            Expression initializer = variable.getInitializer();
+            if (initializer != null && !TypeUtils.isOfType(vd.getType(), initializer.unwrap().getType()) &&
+                    DeclarationCheck.isReassigned(getCursor(), vd)) {
                 return vd;
             }
 

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JohnzonJavaxtoJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JohnzonJavaxtoJakartaTest.java
@@ -68,7 +68,8 @@ class JohnzonJavaxtoJakartaTest implements RewriteTest {
                   Matcher version = Pattern.compile("<johnzon.version>([0-9]+\\.[0-9]+\\.[0-9]+)</johnzon.version>")
                     .matcher(actual);
 
-                  Matcher jsonApiVersion = Pattern.compile("2.1.\\d+").matcher(actual);
+                  Matcher jsonApiVersion = Pattern.compile("(?s)<artifactId>jakarta\\.json-api</artifactId>\\s*<version>(2\\.1\\.\\d+)</version>")
+                    .matcher(actual);
                   assertThat(jsonApiVersion.find()).describedAs("Expected jakarta.json-api 2.1.x version in %s", actual).isTrue();
 
                   assertThat(version.find()).isTrue();
@@ -94,7 +95,7 @@ class JohnzonJavaxtoJakartaTest implements RewriteTest {
                         </dependency>
                     </dependencies>
                 </project>
-                """.formatted(version.group(1), jsonApiVersion.group(0));
+                """.formatted(version.group(1), jsonApiVersion.group(1));
               })
             ),
             srcMainJava(

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericsConstructorsTest.java
@@ -170,6 +170,33 @@ class UseVarForGenericsConstructorsTest implements RewriteTest {
             );
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1077")
+        @Test
+        void reassignedToSupertype() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import java.util.HashSet;
+                  import java.util.Set;
+
+                  class A {
+                      Set<String> transfer(Set<String> in) {
+                          return in;
+                      }
+
+                      void m() {
+                          Set<String> currentFacts = new HashSet<>();
+                          for (int i = 0; i < 3; i++) {
+                              currentFacts = transfer(currentFacts);
+                          }
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
         @Test
         void javaLowerThan10() {
             //language=java


### PR DESCRIPTION
## Summary
- Detect reassignments to a variable within its enclosing method via a new `DeclarationCheck.isReassigned` helper.
- In `UseVarForGenericsConstructors` and `UseVarForGenericMethodInvocations`, skip the transformation when the declared type differs from the initializer's concrete type and the variable is later reassigned, since `var` would narrow the inferred type and break those reassignments.
- Adds a regression test mirroring the `Set<ConstantFact> currentFacts = new HashSet<>(...)` case from the issue.

- Fixes #1077

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.migrate.lang.var.*"`