### PR TITLE
Document null-probing semantic differences in singleton migrations

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonList.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonList.java
@@ -38,7 +38,9 @@ public class MigrateCollectionsSingletonList extends Recipe {
     final String displayName = "Prefer `List.of(..)`";
 
     @Getter
-    final String description = "Prefer `List.of(..)` instead of using `Collections.singletonList()` in Java 9 or higher.";
+    final String description = "Prefer `List.of(..)` instead of using `Collections.singletonList()` in Java 9 or higher. " +
+            "Note that the resulting `List` is not behaviorally equivalent: `List.of(..)` throws `NullPointerException` when probed with `contains(null)`, `indexOf(null)`, or `lastIndexOf(null)`, " +
+            "whereas `Collections.singletonList(..)` returns `false`/`-1`.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonMap.java
@@ -40,7 +40,9 @@ public class MigrateCollectionsSingletonMap extends Recipe {
     final String displayName = "Prefer `Map.of(..)`";
 
     @Getter
-    final String description = "Prefer `Map.of(..)` instead of using `Collections.singletonMap()` in Java 9 or higher.";
+    final String description = "Prefer `Map.of(..)` instead of using `Collections.singletonMap()` in Java 9 or higher. " +
+            "Note that the resulting `Map` is not behaviorally equivalent: `Map.of(..)` throws `NullPointerException` when probed with `containsKey(null)`, `containsValue(null)`, or `get(null)`, " +
+            "whereas `Collections.singletonMap(..)` returns `false`/`null`.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsSingletonSet.java
@@ -36,7 +36,9 @@ public class MigrateCollectionsSingletonSet extends Recipe {
     final String displayName = "Prefer `Set.of(..)`";
 
     @Getter
-    final String description = "Prefer `Set.Of(..)` instead of using `Collections.singleton()` in Java 9 or higher.";
+    final String description = "Prefer `Set.of(..)` instead of using `Collections.singleton()` in Java 9 or higher. " +
+            "Note that the resulting `Set` is not behaviorally equivalent: `Set.of(..)` throws `NullPointerException` when probed with `contains(null)`, " +
+            "whereas `Collections.singleton(..)` returns `false`.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {


### PR DESCRIPTION
- Resolves #1079.

`List.of(..)`, `Set.of(..)`, and `Map.of(..)` throw `NullPointerException` when probed with `contains(null)` and friends, whereas the `Collections.singleton*` factories return `false`/`-1`/`null`. The semantic difference is undecidable across method boundaries (the reporter's case has the probe happen in downstream code), so rather than make the rewrite conditional, this PR calls out the divergence in each recipe description so users can decide whether the migration is safe for their code.

Also fixes a `Set.Of` → `Set.of` typo in the `MigrateCollectionsSingletonSet` description.