### PR TITLE
Keep parentheses when renaming typed lambda parameter to underscore

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
@@ -78,16 +78,21 @@ public class ReplaceUnusedVariablesWithUnderscore extends Recipe {
             public J.Lambda visitLambda(J.Lambda lambda, ExecutionContext ctx) {
                 J.Lambda l = super.visitLambda(lambda, ctx);
                 boolean willRename = false;
+                boolean hasTypedParameter = false;
                 for (J param : l.getParameters().getParameters()) {
                     if (param instanceof J.VariableDeclarations) {
-                        for (J.VariableDeclarations.NamedVariable namedVariable : ((J.VariableDeclarations) param).getVariables()) {
+                        J.VariableDeclarations vd = (J.VariableDeclarations) param;
+                        if (vd.getTypeExpression() != null) {
+                            hasTypedParameter = true;
+                        }
+                        for (J.VariableDeclarations.NamedVariable namedVariable : vd.getVariables()) {
                             if (renameVariableIfUnusedInContext(namedVariable, l.getBody())) {
                                 willRename = true;
                             }
                         }
                     }
                 }
-                if (willRename && l.getParameters().isParenthesized() &&
+                if (willRename && !hasTypedParameter && l.getParameters().isParenthesized() &&
                         l.getParameters().getParameters().size() == 1) {
                     l = l.withParameters(l.getParameters().withParenthesized(false));
                 }

--- a/src/test/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscoreTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscoreTest.java
@@ -206,6 +206,49 @@ class ReplaceUnusedVariablesWithUnderscoreTest implements RewriteTest {
     }
 
     @Test
+    void replaceUnusedTypedLambdaParameterKeepsParentheses() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.helloworld;
+
+              public class Main {
+                  interface Handler {
+                      String handle(RequestContext context);
+                  }
+
+                  static class RequestContext {}
+
+                  Handler route() {
+                      return (RequestContext rc) -> {
+                          return "result";
+                      };
+                  }
+              }
+              """,
+            """
+              package com.helloworld;
+
+              public class Main {
+                  interface Handler {
+                      String handle(RequestContext context);
+                  }
+
+                  static class RequestContext {}
+
+                  Handler route() {
+                      return (RequestContext _) -> {
+                          return "result";
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotReplaceUsedLambdaParameter() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary
- Fix `ReplaceUnusedVariablesWithUnderscore` producing invalid Java for explicitly typed single-parameter lambdas: `(RequestContext rc) -> ...` was being unparenthesized to `RequestContext _ -> ...`
- Only drop the parentheses when the single parameter has no explicit type expression
- Add regression test mirroring the issue's reproducer

- Fixes #1080

## Test plan
- [x] `./gradlew test --tests ReplaceUnusedVariablesWithUnderscoreTest` passes