### PR TITLE
Skip main migration when referenced as static API

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/MigrateMainMethodToInstanceMain.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/MigrateMainMethodToInstanceMain.java
@@ -15,10 +15,12 @@
  */
 package org.openrewrite.java.migrate.lang;
 
-import lombok.Getter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
+import org.openrewrite.ScanningRecipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
@@ -29,24 +31,57 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.staticanalysis.VariableReferences;
 
+import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
-public class MigrateMainMethodToInstanceMain extends Recipe {
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class MigrateMainMethodToInstanceMain extends ScanningRecipe<Set<JavaType.FullyQualified>> {
 
     private static final MethodMatcher MAIN_METHOD_MATCHER = new MethodMatcher("*..* main(String[])", false);
 
-    @Getter
-    final String displayName = "Migrate `public static void main(String[] args)` to instance `void main()`";
+    String displayName = "Migrate `public static void main(String[] args)` to instance `void main()`";
 
-    @Getter
-    final String description = "Migrate `public static void main(String[] args)` method to instance `void main()` method when the `args` parameter is unused, as supported by JEP 512 in Java 25+.";
+    String description = "Migrate `public static void main(String[] args)` method to instance `void main()` method when the `args` parameter is unused, as supported by JEP 512 in Java 25+.";
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
+    public Set<JavaType.FullyQualified> getInitialValue(ExecutionContext ctx) {
+        return new HashSet<>();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Set<JavaType.FullyQualified> referencedMains) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (MAIN_METHOD_MATCHER.matches(method.getMethodType())) {
+                    recordDeclaringType(method.getMethodType());
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+
+            @Override
+            public J.MemberReference visitMemberReference(J.MemberReference memberRef, ExecutionContext ctx) {
+                if (MAIN_METHOD_MATCHER.matches(memberRef.getMethodType())) {
+                    recordDeclaringType(memberRef.getMethodType());
+                }
+                return super.visitMemberReference(memberRef, ctx);
+            }
+
+            private void recordDeclaringType(JavaType.@Nullable Method methodType) {
+                if (methodType != null && methodType.getDeclaringType() != null) {
+                    referencedMains.add(methodType.getDeclaringType());
+                }
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Set<JavaType.FullyQualified> referencedMains) {
         TreeVisitor<?, ExecutionContext> preconditions = Preconditions.and(
                 new UsesJavaVersion<>(25),
                 new DeclaresMethod<>(MAIN_METHOD_MATCHER)
@@ -78,7 +113,7 @@ public class MigrateMainMethodToInstanceMain extends Recipe {
                 // Do not migrate in any of these cases
                 if (hasSpringBootApplicationAnnotation(enclosingClass) ||
                         !hasNoArgConstructor(enclosingClass) ||
-                        isMainMethodReferenced(md)) {
+                        isMainMethodReferenced(enclosingClass)) {
                     return md;
                 }
 
@@ -115,25 +150,17 @@ public class MigrateMainMethodToInstanceMain extends Recipe {
                                 ctor.hasModifier(J.Modifier.Type.Public));
             }
 
-            private boolean isMainMethodReferenced(J.MethodDeclaration mainMethod) {
-                J.CompilationUnit cu = getCursor().firstEnclosing(J.CompilationUnit.class);
-                if (cu == null) {
+            private boolean isMainMethodReferenced(J.ClassDeclaration classDecl) {
+                JavaType.FullyQualified type = classDecl.getType();
+                if (type == null) {
                     return false;
                 }
-
-                // XXX Only picks up references in the same compilation unit; convert to scanning recipe if needed
-                return new JavaIsoVisitor<AtomicBoolean>() {
-                    @Override
-                    public J.MemberReference visitMemberReference(J.MemberReference memberRef, AtomicBoolean referenced) {
-                        // Check if this is a reference to the main method
-                        if ("main".equals(memberRef.getReference().getSimpleName()) &&
-                                memberRef.getMethodType() != null &&
-                                TypeUtils.isOfType(memberRef.getMethodType(), mainMethod.getMethodType())) {
-                            referenced.set(true);
-                        }
-                        return super.visitMemberReference(memberRef, referenced);
+                for (JavaType.FullyQualified referenced : referencedMains) {
+                    if (TypeUtils.isOfType(referenced, type)) {
+                        return true;
                     }
-                }.reduce(cu, new AtomicBoolean()).get();
+                }
+                return false;
             }
         });
     }

--- a/src/test/java/org/openrewrite/java/migrate/lang/MigrateMainMethodToInstanceMainTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/MigrateMainMethodToInstanceMainTest.java
@@ -321,6 +321,51 @@ class MigrateMainMethodToInstanceMainTest implements RewriteTest {
     }
 
     @Test
+    void doNotMigrateMainInvokedAsStaticFromAnotherFile() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Main {
+                  public static void main(String[] args) {}
+              }
+              """
+          ),
+          java(
+            """
+              class MainTest {
+                  void test() {
+                      Main.main(new String[] {});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateMainInvokedAsStaticFromSameFile() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Application {
+                  public static void main(String[] args) {
+                      System.out.println("Hello!");
+                  }
+              }
+
+              class Runner {
+                  void executeMain() {
+                      Application.main(new String[] {});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotMigrateMainWithNonDefaultConstructor() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## Summary
- Convert `MigrateMainMethodToInstanceMain` to a `ScanningRecipe` so it scans every compilation unit for references to a class's `main(String[])` method, not only the file in which it's declared.
- Detect `Main.main(...)` method invocations in addition to `Main::main` member references, and skip migrating classes whose static main is referenced anywhere.
- Add tests for static `main` invocations from another file and from the same file.

- Fixes #1083

## Test plan
- [x] `./gradlew :test --tests "org.openrewrite.java.migrate.lang.MigrateMainMethodToInstanceMainTest"`