### PR TITLE
Keep block body when refined switch arm contains an if statement

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/RefineSwitchCases.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/RefineSwitchCases.java
@@ -131,7 +131,10 @@ public class RefineSwitchCases extends Recipe {
                 List<J.Case> cases = new ArrayList<>();
                 Statement caseBody = if_.getThenPart();
                 if (caseBody instanceof J.Block && ((J.Block) caseBody).getStatements().size() == 1) {
-                    caseBody = ((J.Block) caseBody).getStatements().get(0);
+                    Statement single = ((J.Block) caseBody).getStatements().get(0);
+                    if (single instanceof Expression || single instanceof J.Throw) {
+                        caseBody = single;
+                    }
                 }
                 cases.add(case_.withId(Tree.randomId()).withGuard(if_.getIfCondition().getTree().withPrefix(Space.SINGLE_SPACE)).withBody(caseBody));
                 if (if_.getElsePart() == null) {

--- a/src/test/java/org/openrewrite/java/migrate/lang/RefineSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/RefineSwitchCasesTest.java
@@ -221,6 +221,51 @@ class RefineSwitchCasesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void keepBlockWhenInnerStatementIsIf() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void handle(Object value) {
+                      switch (value) {
+                          case String s -> {
+                              if (s.isEmpty()) {
+                                  if (s.hashCode() > 0) {
+                                      use(s);
+                                  }
+                              }
+                          }
+                          default -> {
+                          }
+                      }
+                  }
+
+                  void use(Object value) {}
+              }
+              """,
+            """
+              class Test {
+                  void handle(Object value) {
+                      switch (value) {
+                          case String s when s.isEmpty() -> {
+                              if (s.hashCode() > 0) {
+                                  use(s);
+                              }
+                          }
+                          case String s -> {}
+                          default -> {}
+                      }
+                  }
+
+                  void use(Object value) {}
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class NoChange{
         @Test


### PR DESCRIPTION
- Fixes #1085.

`RefineSwitchCases` was unconditionally unwrapping a single-statement block into the bare statement when refining an `if` into a guarded `case`, producing invalid Java when that statement was itself an `if` (or any non-arm-body statement). Per JLS 14.11.1, a switch rule arm must be an expression statement, a block, or a throw statement, so the block is now only unwrapped when the inner statement is an `Expression` or `J.Throw`.