### PR TITLE
Skip `Immutable*.copyOf` rewrite when argument is not a `Collection`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/AbstractNoGuavaImmutableOf.java
@@ -97,6 +97,9 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
                 if (!IMMUTABLE_MATCHER.matches(mi) || !isParentTypeDownCast(mi)) {
                     return mi;
                 }
+                if ("copyOf".equals(methodName) && !isArgumentCompatibleWithJavaCopyOf(mi)) {
+                    return mi;
+                }
                 maybeRemoveImport(guavaType);
                 maybeAddImport(javaType);
 
@@ -230,6 +233,16 @@ abstract class AbstractNoGuavaImmutableOf extends Recipe {
                     isParentTypeDownCast = isParentTypeMatched(arrayType);
                 }
                 return isParentTypeDownCast;
+            }
+
+            private boolean isArgumentCompatibleWithJavaCopyOf(J.MethodInvocation mi) {
+                List<Expression> arguments = mi.getArguments();
+                if (arguments.isEmpty() || arguments.get(0) instanceof J.Empty) {
+                    return true;
+                }
+                JavaType argType = arguments.get(0).getType();
+                String requiredType = "java.util.Map".equals(javaType) ? "java.util.Map" : "java.util.Collection";
+                return TypeUtils.isAssignableTo(requiredType, argType);
             }
 
             private boolean isParentTypeMatched(@Nullable JavaType type) {

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListCopyOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableListCopyOfTest.java
@@ -318,6 +318,51 @@ class NoGuavaImmutableListCopyOfTest implements RewriteTest {
     }
 
     @Test
+    void doNotChangeIterableArgument() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.List;
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    List<String> copy(Iterable<String> values) {
+                        return ImmutableList.copyOf(values);
+                    }
+                }
+                """
+            ),
+            21
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeIteratorArgument() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.Iterator;
+                import java.util.List;
+                import com.google.common.collect.ImmutableList;
+
+                class Test {
+                    List<String> copy(Iterator<String> values) {
+                        return ImmutableList.copyOf(values);
+                    }
+                }
+                """
+            ),
+            21
+          )
+        );
+    }
+
+    @Test
     void doChangeAssignFromImmutableListToList() {
         rewriteRun(
           spec -> spec.recipe(new NoGuavaImmutableListCopyOf(true)),

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapCopyOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableMapCopyOfTest.java
@@ -318,6 +318,28 @@ class NoGuavaImmutableMapCopyOfTest implements RewriteTest {
     }
 
     @Test
+    void doNotChangeIterableEntryArgument() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.Map;
+                import com.google.common.collect.ImmutableMap;
+
+                class Test {
+                    Map<String, String> copy(Iterable<Map.Entry<String, String>> entries) {
+                        return ImmutableMap.copyOf(entries);
+                    }
+                }
+                """
+            ),
+            21
+          )
+        );
+    }
+
+    @Test
     void doChangeAssignFromImmutableMapToMap() {
         rewriteRun(
           spec -> spec.recipe(new NoGuavaImmutableMapCopyOf(true)),

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetCopyOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaImmutableSetCopyOfTest.java
@@ -318,6 +318,28 @@ class NoGuavaImmutableSetCopyOfTest implements RewriteTest {
     }
 
     @Test
+    void doNotChangeIterableArgument() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                import java.util.Set;
+                import com.google.common.collect.ImmutableSet;
+
+                class Test {
+                    Set<String> copy(Iterable<String> values) {
+                        return ImmutableSet.copyOf(values);
+                    }
+                }
+                """
+            ),
+            21
+          )
+        );
+    }
+
+    @Test
     void doChangeAssignFromImmutableSetToSet() {
         rewriteRun(
           spec -> spec.recipe(new NoGuavaImmutableSetCopyOf(true)),


### PR DESCRIPTION
- Fixes #1086.

`NoGuavaImmutable{List,Set,Map}CopyOf` were rewriting `Immutable*.copyOf(Iterable)` (and `Iterator`) calls into `List.copyOf` / `Set.copyOf` / `Map.copyOf`, but the JDK overloads only accept `Collection` (or `Map`), producing code that fails to compile. The shared `AbstractNoGuavaImmutableOf` now skips the rewrite when the argument type is not assignable to the JDK target's parameter type. Added regression tests covering `Iterable`/`Iterator` arguments for all three recipes.