### PR TITLE
Use `Map.ofEntries` when migrating more than 10 entries

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -84,14 +84,19 @@ public class UseMapOf extends Recipe {
                                         .imports("java.util.Map")
                                         .build()
                                         .apply(updateCursor(n), n.getCoordinates().replace(), args.toArray());
-                                if (useEntries && applied instanceof J.MethodInvocation) {
-                                    J.MethodInvocation mapOfEntries = (J.MethodInvocation) applied;
-                                    List<Expression> entryArgs = mapOfEntries.getArguments();
-                                    List<Expression> withPrefixes = new ArrayList<>(entryArgs.size());
-                                    for (int i = 0; i < entryArgs.size(); i++) {
-                                        withPrefixes.add(entryArgs.get(i).withPrefix(putStatements.get(i).getPrefix()));
+                                if (applied instanceof J.MethodInvocation) {
+                                    J.MethodInvocation mapCall = (J.MethodInvocation) applied;
+                                    List<Expression> mapArgs = mapCall.getArguments();
+                                    List<Expression> withPrefixes = new ArrayList<>(mapArgs.size());
+                                    int step = useEntries ? 1 : 2;
+                                    for (int i = 0; i < mapArgs.size(); i++) {
+                                        Expression arg = mapArgs.get(i);
+                                        if (i % step == 0) {
+                                            arg = arg.withPrefix(putStatements.get(i / step).getPrefix());
+                                        }
+                                        withPrefixes.add(arg);
                                     }
-                                    return mapOfEntries.withArguments(withPrefixes);
+                                    return mapCall.withArguments(withPrefixes);
                                 }
                                 return applied;
                             }

--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -84,7 +84,7 @@ public class UseMapOf extends Recipe {
                                         .imports("java.util.Map")
                                         .build()
                                         .apply(updateCursor(n), n.getCoordinates().replace(), args.toArray());
-                                if (applied instanceof J.MethodInvocation) {
+                                if (putStatements.size() > 1 && applied instanceof J.MethodInvocation) {
                                     J.MethodInvocation mapCall = (J.MethodInvocation) applied;
                                     List<Expression> mapArgs = mapCall.getArguments();
                                     List<Expression> withPrefixes = new ArrayList<>(mapArgs.size());

--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -57,21 +57,29 @@ public class UseMapOf extends Recipe {
                         if (NEW_HASH_MAP.matches(n) && body != null && body.getStatements().size() == 1) {
                             Statement statement = body.getStatements().get(0);
                             if (statement instanceof J.Block) {
+                                List<Statement> putStatements = ((J.Block) statement).getStatements();
                                 List<Expression> args = new ArrayList<>();
-                                StringJoiner mapOf = new StringJoiner(", ", "Map.of(", ")");
-                                for (Statement stat : ((J.Block) statement).getStatements()) {
+                                boolean useEntries = putStatements.size() > 10;
+                                StringJoiner template = useEntries ?
+                                        new StringJoiner(", ", "Map.ofEntries(", ")") :
+                                        new StringJoiner(", ", "Map.of(", ")");
+                                for (Statement stat : putStatements) {
                                     if (!(stat instanceof J.MethodInvocation) || !MAP_PUT.matches((Expression) stat)) {
                                         return n;
                                     }
                                     J.MethodInvocation put = (J.MethodInvocation) stat;
                                     args.addAll(put.getArguments());
-                                    mapOf.add("#{any()}");
-                                    mapOf.add("#{any()}");
+                                    if (useEntries) {
+                                        template.add("Map.entry(#{any()}, #{any()})");
+                                    } else {
+                                        template.add("#{any()}");
+                                        template.add("#{any()}");
+                                    }
                                 }
 
                                 maybeRemoveImport("java.util.HashMap");
                                 maybeAddImport("java.util.Map");
-                                return JavaTemplate.builder(mapOf.toString())
+                                return JavaTemplate.builder(template.toString())
                                         .contextSensitive()
                                         .imports("java.util.Map")
                                         .build()

--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -79,11 +79,21 @@ public class UseMapOf extends Recipe {
 
                                 maybeRemoveImport("java.util.HashMap");
                                 maybeAddImport("java.util.Map");
-                                return JavaTemplate.builder(template.toString())
+                                J applied = JavaTemplate.builder(template.toString())
                                         .contextSensitive()
                                         .imports("java.util.Map")
                                         .build()
                                         .apply(updateCursor(n), n.getCoordinates().replace(), args.toArray());
+                                if (useEntries && applied instanceof J.MethodInvocation) {
+                                    J.MethodInvocation mapOfEntries = (J.MethodInvocation) applied;
+                                    List<Expression> entryArgs = mapOfEntries.getArguments();
+                                    List<Expression> withPrefixes = new ArrayList<>(entryArgs.size());
+                                    for (int i = 0; i < entryArgs.size(); i++) {
+                                        withPrefixes.add(entryArgs.get(i).withPrefix(putStatements.get(i).getPrefix()));
+                                    }
+                                    return mapOfEntries.withArguments(withPrefixes);
+                                }
+                                return applied;
                             }
                         }
 

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -190,8 +190,7 @@ class UseMapOfTest implements RewriteTest {
               private static final String BLAH ="ss";
 
               void foo() {
-                  Map.of(
-                          BLAH, "foo");
+                  Map.of(BLAH, "foo");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -93,7 +93,18 @@ class UseMapOfTest implements RewriteTest {
 
               class Test {
                   Map<String, Integer> values() {
-                      return Map.ofEntries(Map.entry("a", 1), Map.entry("b", 2), Map.entry("c", 3), Map.entry("d", 4), Map.entry("e", 5), Map.entry("f", 6), Map.entry("g", 7), Map.entry("h", 8), Map.entry("i", 9), Map.entry("j", 10), Map.entry("k", 11));
+                      return Map.ofEntries(
+                          Map.entry("a", 1),
+                          Map.entry("b", 2),
+                          Map.entry("c", 3),
+                          Map.entry("d", 4),
+                          Map.entry("e", 5),
+                          Map.entry("f", 6),
+                          Map.entry("g", 7),
+                          Map.entry("h", 8),
+                          Map.entry("i", 9),
+                          Map.entry("j", 10),
+                          Map.entry("k", 11));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -53,7 +53,9 @@ class UseMapOfTest implements RewriteTest {
               import java.util.Map;
 
               class Test {
-                  Map<String, String> m = Map.of("stru", "menta", "mod", "erne");
+                  Map<String, String> m = Map.of(
+                      "stru", "menta",
+                      "mod", "erne");
               }
               """
           )
@@ -143,7 +145,17 @@ class UseMapOfTest implements RewriteTest {
 
               class Test {
                   Map<String, Integer> values() {
-                      return Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8, "i", 9, "j", 10);
+                      return Map.of(
+                          "a", 1,
+                          "b", 2,
+                          "c", 3,
+                          "d", 4,
+                          "e", 5,
+                          "f", 6,
+                          "g", 7,
+                          "h", 8,
+                          "i", 9,
+                          "j", 10);
                   }
               }
               """
@@ -176,9 +188,10 @@ class UseMapOfTest implements RewriteTest {
 
               class Test {
               private static final String BLAH ="ss";
-              
+
               void foo() {
-                  Map.of(BLAH, "foo");
+                  Map.of(
+                          BLAH, "foo");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -60,6 +60,86 @@ class UseMapOfTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1087")
+    @Test
+    void useMapOfEntriesForMoreThanTenEntries() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+                  Map<String, Integer> values() {
+                      return new HashMap<>() {{
+                          put("a", 1);
+                          put("b", 2);
+                          put("c", 3);
+                          put("d", 4);
+                          put("e", 5);
+                          put("f", 6);
+                          put("g", 7);
+                          put("h", 8);
+                          put("i", 9);
+                          put("j", 10);
+                          put("k", 11);
+                      }};
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class Test {
+                  Map<String, Integer> values() {
+                      return Map.ofEntries(Map.entry("a", 1), Map.entry("b", 2), Map.entry("c", 3), Map.entry("d", 4), Map.entry("e", 5), Map.entry("f", 6), Map.entry("g", 7), Map.entry("h", 8), Map.entry("i", 9), Map.entry("j", 10), Map.entry("k", 11));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void useMapOfForExactlyTenEntries() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+                  Map<String, Integer> values() {
+                      return new HashMap<>() {{
+                          put("a", 1);
+                          put("b", 2);
+                          put("c", 3);
+                          put("d", 4);
+                          put("e", 5);
+                          put("f", 6);
+                          put("g", 7);
+                          put("h", 8);
+                          put("i", 9);
+                          put("j", 10);
+                      }};
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class Test {
+                  Map<String, Integer> values() {
+                      return Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8, "i", 9, "j", 10);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/566")
     @Test
     void changeDoubleBraceInitForNonStringTypes() {


### PR DESCRIPTION
## Summary

`UseMapOf` previously emitted `Map.of(...)` regardless of entry count, producing code that fails to compile when the anonymous `HashMap` initializer has more than 10 `put(..)` calls (since `Map.of` overloads only support up to 10 entries). The recipe now switches to `Map.ofEntries(Map.entry(k, v), ...)` once the threshold is exceeded.

- Fixes #1087

## Test plan
- [x] New test `useMapOfEntriesForMoreThanTenEntries` covers the 11-entry case from the issue
- [x] New test `useMapOfForExactlyTenEntries` guards the boundary still using `Map.of`