### PR TITLE
Add `java.io.IO` import in `ReplaceSystemOutWithIOPrint`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrint.java
+++ b/src/main/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrint.java
@@ -54,6 +54,7 @@ public class ReplaceSystemOutWithIOPrint extends Recipe {
                         if (!isSystemOutMethod(m)) {
                             return m;
                         }
+                        maybeAddImport("java.io.IO", false);
                         String methodName = m.getName().getSimpleName();
                         return m.getArguments().isEmpty() ?
                                 JavaTemplate.apply( "IO.#{}()", getCursor(), m.getCoordinates().replace(), methodName ) :

--- a/src/test/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrintTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrintTest.java
@@ -53,6 +53,8 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
+              import java.io.IO;
+
               class Example {
                   void test() {
                       IO.print("Hello");
@@ -75,6 +77,8 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
+              import java.io.IO;
+
               class Example {
                   void test() {
                       IO.println("Hello");
@@ -99,6 +103,8 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
+              import java.io.IO;
+
               class Example {
                   void test() {
                       IO.println("Hello");
@@ -122,6 +128,8 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
+              import java.io.IO;
+
               class Example {
                   void test() {
                       String message = "Hello World";
@@ -145,6 +153,8 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
+              import java.io.IO;
+
               class Example {
                   void test() {
                       IO.println();
@@ -170,6 +180,8 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
+              import java.io.IO;
+
               class Example {
                   void test() {
                       IO.print("Hello");
@@ -198,6 +210,8 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
+              import java.io.IO;
+
               class Example {
                   void test() {
                       String name = "John";
@@ -239,6 +253,34 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
                       PrintStream ps = new PrintStream(System.out);
                       ps.print("Should not change");
                       ps.println("Should not change");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsImportForRegularClassWithPackage() {
+        rewriteRun(
+          java(
+            """
+              package com.helloworld;
+
+              public class Main {
+                  public void greet() {
+                      System.out.println("hello");
+                  }
+              }
+              """,
+            """
+              package com.helloworld;
+
+              import java.io.IO;
+
+              public class Main {
+                  public void greet() {
+                      IO.println("hello");
                   }
               }
               """


### PR DESCRIPTION
## Summary
- Fixes #1091: the recipe rewrote `System.out.println(...)` to `IO.println(...)` but never added `import java.io.IO`, so regular classes (with a package declaration) failed to compile.
- Call `maybeAddImport("java.io.IO", false)` whenever a `System.out.print(ln)` call is replaced; the explicit import is harmless inside JEP 512 compact source files where `IO` is implicitly available.
- Updated existing tests to expect the new import and added a reproducer mirroring the issue's example.

## Test plan
- [x] `./gradlew test --tests ReplaceSystemOutWithIOPrintTest`