### PR TITLE
Skip `UseMapOf` when `put()` argument is a null literal

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -68,6 +68,11 @@ public class UseMapOf extends Recipe {
                                         return n;
                                     }
                                     J.MethodInvocation put = (J.MethodInvocation) stat;
+                                    for (Expression arg : put.getArguments()) {
+                                        if (J.Literal.isLiteralValue(arg, null)) {
+                                            return n;
+                                        }
+                                    }
                                     args.addAll(put.getArguments());
                                     if (useEntries) {
                                         template.add("Map.entry(#{any()}, #{any()})");

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -163,6 +163,48 @@ class UseMapOfTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1092")
+    @Test
+    void doNotChangeWhenNullValue() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+                  Map<String, String> m = new HashMap<>() {{
+                      put("key", "value");
+                      put("nullable", null);
+                  }};
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1092")
+    @Test
+    void doNotChangeWhenNullKey() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+                  Map<String, String> m = new HashMap<>() {{
+                      put(null, "value");
+                      put("key", "other");
+                  }};
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/566")
     @Test
     void changeDoubleBraceInitForNonStringTypes() {


### PR DESCRIPTION
- `Map.of(..)` throws `NullPointerException` on null keys or values, so converting a `HashMap` containing null arguments is not behavior-preserving. Added a null-literal guard mirroring the one in `MigrateCollectionsSingletonMap` (PR #772) plus tests for null key and null value cases.

- Fixes #1092