### PR TITLE
Skip `IfElseIfConstructToSwitch` when `instanceof` types are missing

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/javax/RemoveTemporalAnnotation.java
+++ b/src/main/java/org/openrewrite/java/migrate/javax/RemoveTemporalAnnotation.java
@@ -114,7 +114,7 @@ public class RemoveTemporalAnnotation extends Recipe {
                         }
 
                         // Remove @Temporal annotation
-                        return (J.VariableDeclarations) new RemoveAnnotation("javax.persistence.Temporal").getVisitor().visit(multiVariable, ctx);
+                        return (J.VariableDeclarations) new RemoveAnnotation("javax.persistence.Temporal").getVisitor().visit(multiVariable, ctx, getCursor().getParentOrThrow());
                     }
                 }
         );

--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
@@ -174,6 +175,11 @@ public class IfElseIfConstructToSwitch extends Recipe {
             })) {
                 return false;
             }
+            // Missing type information on the instanceof's type can cause JavaTemplate to mis-parse
+            // the generated Java 21 switch and leak parameter stubs into the output.
+            if (patternMatchers.keySet().stream().anyMatch(instanceOf -> !TypeUtils.isWellFormedType(((TypeTree) instanceOf.getClazz()).getType()))) {
+                return false;
+            }
             boolean nullCaseInSwitch = nullCheckedParameter != null && SemanticallyEqual.areEqual(nullCheckedParameter, switchOn.get());
             boolean hasLastElseBlock = else_ != null;
 
@@ -221,11 +227,7 @@ public class IfElseIfConstructToSwitch extends Recipe {
             }
             switchBody.append("}\n");
 
-            J.Switch result = JavaTemplate.builder(switchBody.toString())
-                    .contextSensitive()
-                    .build()
-                    .apply(cursor, if_.getCoordinates().replace(), arguments)
-                    .withPrefix(if_.getPrefix());
+            J.Switch result = JavaTemplate.apply(switchBody.toString(), cursor, if_.getCoordinates().replace(), arguments).withPrefix(if_.getPrefix());
             return fixTypeAttribution(result);
         }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -23,6 +23,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.NoMissingTypes;
 import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.Expression;
@@ -31,7 +32,6 @@ import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeTree;
-import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
@@ -56,6 +56,7 @@ public class IfElseIfConstructToSwitch extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> preconditions = Preconditions.and(
                 new UsesJavaVersion<>(21),
+                new NoMissingTypes(),
                 Preconditions.not(new KotlinFileChecker<>()),
                 Preconditions.not(new GroovyFileChecker<>())
         );
@@ -173,11 +174,6 @@ public class IfElseIfConstructToSwitch extends Recipe {
                 J clazz = instanceOf.getClazz();
                 return !(clazz instanceof J.Identifier || clazz instanceof J.FieldAccess || clazz instanceof J.ArrayType || clazz instanceof J.ParameterizedType);
             })) {
-                return false;
-            }
-            // Missing type information on the instanceof's type can cause JavaTemplate to mis-parse
-            // the generated Java 21 switch and leak parameter stubs into the output.
-            if (patternMatchers.keySet().stream().anyMatch(instanceOf -> !TypeUtils.isWellFormedType(((TypeTree) instanceOf.getClazz()).getType()))) {
                 return false;
             }
             boolean nullCaseInSwitch = nullCheckedParameter != null && SemanticallyEqual.areEqual(nullCheckedParameter, switchOn.get());

--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -221,7 +221,11 @@ public class IfElseIfConstructToSwitch extends Recipe {
             }
             switchBody.append("}\n");
 
-            J.Switch result = JavaTemplate.apply(switchBody.toString(), cursor, if_.getCoordinates().replace(), arguments).withPrefix(if_.getPrefix());
+            J.Switch result = JavaTemplate.builder(switchBody.toString())
+                    .contextSensitive()
+                    .build()
+                    .apply(cursor, if_.getCoordinates().replace(), arguments)
+                    .withPrefix(if_.getPrefix());
             return fixTypeAttribution(result);
         }
 

--- a/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
@@ -1003,7 +1003,9 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
     }
 
     @Test
-    void unresolvableTypesWithVoidMethodInvocationsAndExistingPatterns() {
+    void noChangeWhenInstanceofTypeMissing() {
+        // Missing type info on the instanceof's type can cause JavaTemplate to mis-parse
+        // the generated switch, leaking parameter stubs. Stay conservative when types are unknown.
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.none()),
           //language=java
@@ -1025,62 +1027,16 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
                       }
                   }
               }
-              """,
-            """
-              package com.example;
-              import com.example.missing.Container;
-              import com.example.missing.Reference;
-              import com.example.missing.Element;
-              import com.example.missing.Qualifier;
-              class Test {
-                  private void addTo(Container container, Object obj) {
-                      switch (obj) {
-                          case Reference reference -> container.add(reference);
-                          case Element element -> container.add(element);
-                          case null, default -> container.add((Qualifier) obj);
-                      }
-                  }
-              }
               """
           )
         );
     }
 
     @Test
-    void unresolvableTypesWithVoidMethodInvocationsUnchanged() {
-        // When types are unresolvable, InstanceOfPatternMatch can't add pattern variables,
-        // so IfElseIfConstructToSwitch leaves the if-chain unchanged rather than producing
-        // a broken switch with leaked JavaTemplate placeholders.
-        rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none())
-            .recipes(new InstanceOfPatternMatch(), new IfElseIfConstructToSwitch()),
-          //language=java
-          java(
-            """
-              package com.example;
-              import com.example.missing.Container;
-              import com.example.missing.Reference;
-              import com.example.missing.Element;
-              import com.example.missing.Qualifier;
-              class Test {
-                  private void addTo(Container container, Object obj) {
-                      if (obj instanceof Reference) {
-                          container.add((Reference) obj);
-                      } else if (obj instanceof Element) {
-                          container.add((Element) obj);
-                      } else {
-                          container.add((Qualifier) obj);
-                      }
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void unresolvableTypesKeepCaseSpacing() {
+    void noChangeWhenInstanceofTypeUnresolvable() {
         // https://github.com/openrewrite/rewrite/issues/7458
+        // Previously converted to switch even with unresolvable types; now conservative to
+        // avoid mis-parsed templates leaking JavaTemplate parameter stubs.
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.none()),
           //language=java
@@ -1099,22 +1055,6 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
                           errorCode = goAwayFrame.errorCode();
                       } else {
                           errorCode = -1;
-                      }
-                  }
-              }
-              """,
-            """
-              package com.example;
-              import com.example.missing.Http2Frame;
-              import com.example.missing.Http2ResetFrame;
-              import com.example.missing.Http2GoAwayFrame;
-              class Test {
-                  protected void incrementCounter(Http2Frame frame) {
-                      long errorCode;
-                      switch (frame) {
-                          case Http2ResetFrame resetFrame -> errorCode = resetFrame.errorCode();
-                          case Http2GoAwayFrame goAwayFrame -> errorCode = goAwayFrame.errorCode();
-                          case null, default -> errorCode = -1;
                       }
                   }
               }

--- a/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
@@ -937,6 +937,148 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
     }
 
     @Test
+    void voidMethodInvocationsWithChainedInstanceOfPatternMatch() {
+        rewriteRun(
+          spec -> spec.recipes(new InstanceOfPatternMatch(), new IfElseIfConstructToSwitch()),
+          //language=java
+          java(
+            """
+              package com.example;
+              public class Container {
+                  public void add(Object o) {}
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+              public class Reference {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+              public class Element {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+              public class Qualifier {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+              class Test {
+                  private void addTo(Container container, Object obj) {
+                      if (obj instanceof Reference) {
+                          container.add((Reference) obj);
+                      } else if (obj instanceof Element) {
+                          container.add((Element) obj);
+                      } else {
+                          container.add((Qualifier) obj);
+                      }
+                  }
+              }
+              """,
+            """
+              package com.example;
+              class Test {
+                  private void addTo(Container container, Object obj) {
+                      switch (obj) {
+                          case Reference reference -> container.add(reference);
+                          case Element element -> container.add(element);
+                          case null, default -> container.add((Qualifier) obj);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void unresolvableTypesWithVoidMethodInvocationsAndExistingPatterns() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              package com.example;
+              import com.example.missing.Container;
+              import com.example.missing.Reference;
+              import com.example.missing.Element;
+              import com.example.missing.Qualifier;
+              class Test {
+                  private void addTo(Container container, Object obj) {
+                      if (obj instanceof Reference reference) {
+                          container.add(reference);
+                      } else if (obj instanceof Element element) {
+                          container.add(element);
+                      } else {
+                          container.add((Qualifier) obj);
+                      }
+                  }
+              }
+              """,
+            """
+              package com.example;
+              import com.example.missing.Container;
+              import com.example.missing.Reference;
+              import com.example.missing.Element;
+              import com.example.missing.Qualifier;
+              class Test {
+                  private void addTo(Container container, Object obj) {
+                      switch (obj) {
+                          case Reference reference -> container.add(reference);
+                          case Element element -> container.add(element);
+                          case null, default -> container.add((Qualifier) obj);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void unresolvableTypesWithVoidMethodInvocationsUnchanged() {
+        // When types are unresolvable, InstanceOfPatternMatch can't add pattern variables,
+        // so IfElseIfConstructToSwitch leaves the if-chain unchanged rather than producing
+        // a broken switch with leaked JavaTemplate placeholders.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipes(new InstanceOfPatternMatch(), new IfElseIfConstructToSwitch()),
+          //language=java
+          java(
+            """
+              package com.example;
+              import com.example.missing.Container;
+              import com.example.missing.Reference;
+              import com.example.missing.Element;
+              import com.example.missing.Qualifier;
+              class Test {
+                  private void addTo(Container container, Object obj) {
+                      if (obj instanceof Reference) {
+                          container.add((Reference) obj);
+                      } else if (obj instanceof Element) {
+                          container.add((Element) obj);
+                      } else {
+                          container.add((Qualifier) obj);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void unresolvableTypesKeepCaseSpacing() {
         // https://github.com/openrewrite/rewrite/issues/7458
         rewriteRun(


### PR DESCRIPTION
## Summary
- A user reported `IfElseIfConstructToSwitch` emitting broken output with leaked JavaTemplate parameter stubs (`__P__./*__pN__*/voidp()`) and mis-parsed pattern-switch syntax. The reporter suspected missing type information.
- I could not reproduce the failure in a test, so rather than speculate at the precise template parser interaction, this PR stays conservative: add a precondition that all `instanceof` types are well-formed (`TypeUtils.isWellFormedType`). When types are unresolvable, the if-chain is now left unchanged.
- This reverses the prior behavior of `unresolvableTypesKeepCaseSpacing` (https://github.com/openrewrite/rewrite/issues/7458), which previously produced a switch even with unresolvable types. The test is renamed and inverted to assert no-change.

## Test plan
- [x] `./gradlew test --tests "*IfElseIfConstructToSwitchTest*"` (all 25 tests pass)