### PR TITLE
Migrate JAXB XJC binding files declaring version 2.0/2.1/2.2

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -1041,13 +1041,14 @@ recipeList:
       attributeName: xmlns:jxb
       oldValue: http://java.sun.com/xml/ns/jaxb
       newValue: https://jakarta.ee/xml/ns/jaxb
-  # Update version
+  # Update version (covers JAXB 1.x and 2.x bindings authored before Jakarta EE 9)
   - org.openrewrite.xml.ChangeTagAttribute:
       #language=xpath
       elementName: "//*[namespace-uri() = 'https://jakarta.ee/xml/ns/jaxb' and local-name() = 'bindings']"
       attributeName: version
-      oldValue: 1.0
-      newValue: 3.0
+      oldValue: "1\\.0|2\\.[0-2]"
+      newValue: "3.0"
+      regex: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JavaxXmlSoapToJakartaXmlSoap

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/UpdateXJCBindingsToJakartaEE.java
@@ -17,6 +17,8 @@ package org.openrewrite.java.migrate.jakarta;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
@@ -102,6 +104,31 @@ class UpdateXJCBindingsToJakartaEE implements RewriteTest {
                                 xmlns:xs="http://www.w3.org/2001/XMLSchema">
                   </jxb:bindings>
                   """,
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="3.0"
+                                xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2359")
+        @ParameterizedTest
+        @ValueSource(strings = {"2.0", "2.1", "2.2"})
+        void versionTwoX(String oldVersion) {
+            rewriteRun(
+              //language=xml
+              xml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <jxb:bindings version="%s"
+                                xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                  </jxb:bindings>
+                  """.formatted(oldVersion),
                 """
                   <?xml version="1.0" encoding="UTF-8"?>
                   <jxb:bindings version="3.0"


### PR DESCRIPTION
## Summary
- The `JavaxXmlToJakartaXmlXJCBinding` recipe matched only `version="1.0"` on the `<jxb:bindings>` root, so real-world `.xjb` files declaring `version="2.0"`, `"2.1"`, or `"2.2"` were left with a stale version attribute after the namespace was rewritten. JAXB 3 then rejects them at build time with `JAXB version attribute must be "3.0"`.
- Broaden the version rule to a regex that matches exactly the spec-defined pre-3.0 binding versions: `1.0`, `2.0`, `2.1`, `2.2`. No other rules change; the XPath precondition still scopes updates to JAXB bindings only.
- Adds a parameterized reproducer covering `2.0`, `2.1`, `2.2`. The reproducer was committed first against unmodified `main` and verified to fail before the fix landed.

- Fixes https://github.com/moderneinc/customer-requests/issues/2359 (reported by HMH).

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.migrate.jakarta.UpdateXJCBindingsToJakartaEE"` — all 8 cases pass (including the existing `noMigrate`, `noMigrateIBMFiles`, `both`, `version`, `namespace` regression coverage).
- [x] `./gradlew build` — clean.
- [x] Confirmed the reproducer fails on `main` before the YAML change (3/8 failures on the new parameterized cases).