### PR TITLE
Preserve explicit type arguments in MigrateCollections* recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyList.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyList.java
@@ -53,10 +53,11 @@ public class MigrateCollectionsEmptyList extends Recipe {
                 if (EMPTY_LIST.matches(m)) {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.List");
-                    return JavaTemplate.builder("List.of()")
+                    J.MethodInvocation result = JavaTemplate.builder("List.of()")
                             .imports("java.util.List")
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace());
+                    return result.withTypeParameters(m.getPadding().getTypeParameters());
                 }
 
                 return m;

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMap.java
@@ -53,10 +53,11 @@ public class MigrateCollectionsEmptyMap extends Recipe {
                 if (EMPTY_MAP.matches(m)) {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.Map");
-                    return JavaTemplate.builder("Map.of()")
+                    J.MethodInvocation result = JavaTemplate.builder("Map.of()")
                             .imports("java.util.Map")
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace());
+                    return result.withTypeParameters(m.getPadding().getTypeParameters());
                 }
 
                 return m;

--- a/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptySet.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptySet.java
@@ -53,10 +53,11 @@ public class MigrateCollectionsEmptySet extends Recipe {
                 if (EMPTY_SET.matches(m)) {
                     maybeRemoveImport("java.util.Collections");
                     maybeAddImport("java.util.Set");
-                    return JavaTemplate.builder("Set.of()")
+                    J.MethodInvocation result = JavaTemplate.builder("Set.of()")
                             .imports("java.util.Set")
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace());
+                    return result.withTypeParameters(m.getPadding().getTypeParameters());
                 }
 
                 return m;

--- a/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMapTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/MigrateCollectionsEmptyMapTest.java
@@ -111,6 +111,35 @@ class MigrateCollectionsEmptyMapTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1097")
+    @Test
+    void preserveExplicitTypeArgumentsInTernary() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Collections;
+              import java.util.Map;
+
+              class Main<K, V> {
+                  Map<K, V> get(final Map<K, V> input) {
+                      return input == null ? Collections.<K, V>emptyMap() : input;
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class Main<K, V> {
+                  Map<K, V> get(final Map<K, V> input) {
+                      return input == null ? Map.<K, V>of() : input;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void emptyMapInSwitchExpression() {
         rewriteRun(


### PR DESCRIPTION
## Summary
- Fixes #1097: `Collections.<K, V>emptyMap()` was being rewritten to `Map.of()`, dropping the type witness and producing code that no longer compiles in ternary expressions where the compiler cannot infer type parameters from context.
- Carry over the original method invocation's `typeParameters` onto the rewritten `Map.of()` / `List.of()` / `Set.of()` call.
- Applied the same fix to the sibling `MigrateCollectionsEmptyList` and `MigrateCollectionsEmptySet` recipes, which had the same bug.

## Test plan
- [x] Added `preserveExplicitTypeArgumentsInTernary` regression test to `MigrateCollectionsEmptyMapTest`.
- [x] `./gradlew test --tests "org.openrewrite.java.migrate.util.MigrateCollectionsEmpty*Test"` passes.