### PR TITLE
Load sun.internal.new[Class].jar directly to fix CI test failures

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/IBMSemeruTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/IBMSemeruTest.java
@@ -17,11 +17,17 @@ package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import static java.util.Collections.singletonList;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.java;
@@ -34,8 +40,17 @@ class IBMSemeruTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "sun.internal.new"))
+            .classpath(singletonList(resourceJar("sun.internal.new.jar"))))
           .recipeFromResource("/META-INF/rewrite/ibm-java.yml", "org.openrewrite.java.migrate.IBMSemeru");
+    }
+
+    private static Path resourceJar(String name) {
+        URL url = IBMSemeruTest.class.getClassLoader().getResource("META-INF/rewrite/classpath/" + name);
+        try {
+            return Paths.get(Objects.requireNonNull(url, "Resource not found: " + name).toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/migrate/InternalBindPackagesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/InternalBindPackagesTest.java
@@ -17,11 +17,17 @@ package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import static java.util.Collections.singletonList;
 import static org.openrewrite.java.Assertions.java;
 
 class InternalBindPackagesTest implements RewriteTest {
@@ -29,8 +35,17 @@ class InternalBindPackagesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "sun.internal.newClass"))
+            .classpath(singletonList(resourceJar("sun.internal.newClass.jar"))))
           .recipeFromResources("org.openrewrite.java.migrate.InternalBindPackages");
+    }
+
+    private static Path resourceJar(String name) {
+        URL url = InternalBindPackagesTest.class.getClassLoader().getResource("META-INF/rewrite/classpath/" + name);
+        try {
+            return Paths.get(Objects.requireNonNull(url, "Resource not found: " + name).toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @DocumentExample


### PR DESCRIPTION
## Summary

- `classpathFromResources("sun.internal.new")` uses `Pattern.compile(artifactName + ".*")` to match against artifact-version strings; the `.` chars are regex wildcards, and the static `TypeTable.classesDirByArtifact` cache means the local-JAR fallback can be skipped depending on what's on the runtime classpath and which tests have run before.
- After #1096 routed Maven through the Moderne Artifactory cache mirror, the four type-attribution-sensitive `IBMSemeruTest` cases started failing on every scheduled CI run with "LST contains missing or invalid type information."
- Switch `IBMSemeruTest` and `InternalBindPackagesTest` to load the JAR directly via `classpath(Collection<Path>)` and a `getResource` lookup, bypassing both the regex matching and the shared static cache.

- Fixes #1100

## Test plan

- [x] `./gradlew test --tests "org.openrewrite.java.migrate.IBMSemeruTest" --tests "org.openrewrite.java.migrate.InternalBindPackagesTest"` passes locally
- [ ] Scheduled CI run no longer reports the four `IBMSemeruTest` failures