### PR TITLE
Skip explicit type arguments containing wildcards in `UseVarForGenericMethodInvocations`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -117,7 +117,7 @@ public class UseVarForGenericMethodInvocations extends Recipe {
             }
 
             // Add explicit type parameters when the method is generic and the return type's type parameter matches a type parameter from the declaring class
-            if (mi.getTypeParameters() == null && mi.getMethodType() != null && containsGenericTypeVariable(mi.getMethodType().getReturnType())) {
+            if (mi.getTypeParameters() == null && mi.getMethodType() != null && containsGenericTypeVariable(mi.getMethodType().getReturnType()) && !containsWildcard(leftTypeParams)) {
                 // Create JRightPadded list from leftTypeParams
                 List<JRightPadded<Expression>> typeParamsList = new ArrayList<>();
                 for (Expression typeParam : leftTypeParams) {
@@ -139,6 +139,15 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 }
                 return arg;
             }));
+        }
+
+        private static boolean containsWildcard(List<Expression> typeParams) {
+            for (Expression typeParam : typeParams) {
+                if (typeParam instanceof J.Wildcard) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private boolean containsGenericTypeVariable(JavaType type) {

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -425,6 +425,32 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
             );
         }
 
+        @Test
+        void wildcardTypeParameterNoExplicitTypeArgument() {
+            //language=java
+            rewriteRun(
+              version(
+                java(
+                  """
+                    class A {
+                      void m(ClassLoader cl) throws Exception {
+                          Class<?> recipeClass = cl.loadClass("java.lang.String");
+                      }
+                    }
+                    """,
+                  """
+                    class A {
+                      void m(ClassLoader cl) throws Exception {
+                          var recipeClass = cl.loadClass("java.lang.String");
+                      }
+                    }
+                    """
+                ),
+                10
+              )
+            );
+        }
+
         @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/868")
         @Test
         void genericsCollectorsRegression() {


### PR DESCRIPTION
## Summary
- `UseVarForGenericMethodInvocations` was emitting invalid Java when the variable type contained a wildcard, e.g. `Class<?> x = cl.loadClass(...)` became `var x = cl.<?>loadClass(...)`. Wildcards are not valid explicit type arguments on a method invocation.
- Now skip adding explicit type parameters to the method invocation when any of the LHS type parameters is a `J.Wildcard`; the `var` rewrite still proceeds.
- Added a regression test covering `Class<?> recipeClass = cl.loadClass(...)`.

## Test plan
- [x] `./gradlew test --tests UseVarForGenericMethodInvocationsTest`