### PR TITLE
Skip `var` when target type inference widens a generic argument

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -270,6 +270,51 @@ final class DeclarationCheck {
         }.reduce(method, new AtomicBoolean(false)).get();
     }
 
+    /**
+     * Determine whether the method invocation's resolved parameter types reveal that target type inference
+     * widened a generic argument. For example, in {@code List<I> x = singletonList(c)} where {@code c} is a
+     * {@code C extends I}, the parameter type for {@code T} is resolved to {@code I} (widened from {@code C}).
+     * Switching to {@code var} drops the target type, so javac re-infers {@code List<C>} and breaks any usage
+     * that requires the declared supertype.
+     */
+    public static boolean targetTypeInferenceWidens(J.MethodInvocation invocation) {
+        JavaType.Method methodType = invocation.getMethodType();
+        if (methodType == null) {
+            return false;
+        }
+        List<JavaType> parameterTypes = methodType.getParameterTypes();
+        List<Expression> arguments = invocation.getArguments();
+        if (parameterTypes.isEmpty() || arguments.isEmpty()) {
+            return false;
+        }
+        int lastParamIndex = parameterTypes.size() - 1;
+        JavaType varargComponentType = null;
+        if (methodType.hasFlags(Flag.Varargs)) {
+            JavaType last = parameterTypes.get(lastParamIndex);
+            varargComponentType = last instanceof JavaType.Array ? ((JavaType.Array) last).getElemType() : last;
+        }
+        for (int i = 0; i < arguments.size(); i++) {
+            Expression argument = arguments.get(i);
+            if (argument instanceof J.Empty || J.Literal.isLiteralValue(argument, null)) {
+                continue;
+            }
+            JavaType parameterType = varargComponentType != null && i >= lastParamIndex ?
+                    varargComponentType :
+                    i < parameterTypes.size() ? parameterTypes.get(i) : null;
+            // Only flag when the parameter type is a bare class (not parameterized) that is a strict
+            // supertype of the argument's type. That pattern indicates a type variable like `<T>` that
+            // target inference widened from the argument's concrete type to the variable's declared type.
+            JavaType argumentType = argument.getType();
+            if (parameterType instanceof JavaType.FullyQualified &&
+                    !(parameterType instanceof JavaType.Parameterized) &&
+                    !TypeUtils.isOfType(parameterType, argumentType) &&
+                    TypeUtils.isAssignableTo(parameterType, argumentType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static J.VariableDeclarations transformToVar(J.VariableDeclarations vd) {
         return transformToVar(vd, it -> it);
     }

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -86,6 +86,10 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 return vd;
             }
 
+            if (DeclarationCheck.targetTypeInferenceWidens(invocation)) {
+                return vd;
+            }
+
             if (vd.getType() instanceof JavaType.FullyQualified) {
                 maybeRemoveImport((JavaType.FullyQualified) vd.getType());
             }

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -135,6 +135,37 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
             }
 
             @Test
+            void declaredSupertypeWidensTypeArgument() {
+                // Switching to var narrows List<I> to List<C>, which breaks
+                // a later usage that requires the declared (super)type.
+                //language=java
+                rewriteRun(
+                  version(
+                    java(
+                      """
+                          package com.example.app;
+
+                          import java.util.List;
+
+                          class A {
+                            interface I {}
+                            static class C implements I {}
+
+                            void process(List<I> items) {}
+
+                            void m() {
+                                C c = new C();
+                                List<I> items = List.of(c);
+                                process(items);
+                            }
+                          }
+                        """),
+                    10
+                  )
+                );
+            }
+
+            @Test
             void forEmptyJDKFactoryMethod() {
                 // TODO: this could be `var strs = List.<String>of();`
                 //language=java


### PR DESCRIPTION
## Summary

`List<I> x = singletonList(c)` where `c` is a `C extends I` keeps the LST type as `List<I>` via target type inference, but converting to `var x = List.of(c)` makes javac re-infer `List<C>` — breaking any downstream usage that requires the declared supertype.

`UseVarForGenericMethodInvocations` now detects this by checking each argument against its resolved parameter type: when the parameter is a bare (non-parameterized) class that is a strict supertype of the argument, target inference widened a `<T>` substitution and the conversion is skipped.

## Test plan
- [x] New test `declaredSupertypeWidensTypeArgument` in `UseVarForGenericMethodInvocationsTest`
- [x] All existing tests in `org.openrewrite.java.migrate.lang.var.*` pass