### PR TITLE
Aggregate FindJavaVersion to one row per repository

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
@@ -21,19 +21,16 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.migrate.table.JavaVersionTable;
 import org.openrewrite.java.tree.J;
-
-import java.util.HashSet;
-import java.util.Set;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class FindJavaVersion extends Recipe {
 
     transient JavaVersionTable table = new JavaVersionTable(this);
-    transient Set<JavaVersion> seen = new HashSet<>();
 
     String displayName = "Find Java versions in use";
 
@@ -45,11 +42,15 @@ public class FindJavaVersion extends Recipe {
             @Override
             public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
                 cu.getMarkers().findFirst(JavaVersion.class)
-                        .filter(seen::add)
-                        .map(jv -> new JavaVersionTable.Row(
-                                Integer.toString(jv.getMajorVersion()),
-                                Integer.toString(jv.getMajorReleaseVersion())))
-                        .ifPresent(row -> table.insertRow(ctx, row));
+                        .ifPresent(jv -> {
+                            String projectName = cu.getMarkers().findFirst(JavaProject.class)
+                                    .map(JavaProject::getProjectName)
+                                    .orElse("");
+                            table.insertRow(ctx, new JavaVersionTable.Row(
+                                    projectName,
+                                    Integer.toString(jv.getMajorVersion()),
+                                    Integer.toString(jv.getMajorReleaseVersion())));
+                        });
                 return cu;
             }
         };

--- a/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
@@ -31,11 +31,10 @@ import org.openrewrite.marker.Markers;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 
-public class FindJavaVersion extends ScanningRecipe<Map<Object, JavaVersionTable.Row>> {
+public class FindJavaVersion extends ScanningRecipe<Map<String, JavaVersionTable.Row>> {
 
     transient JavaVersionTable table = new JavaVersionTable(this);
 
@@ -47,12 +46,12 @@ public class FindJavaVersion extends ScanningRecipe<Map<Object, JavaVersionTable
             "(the lowest source/target compatibility across modules in that repository).";
 
     @Override
-    public Map<Object, JavaVersionTable.Row> getInitialValue(ExecutionContext ctx) {
+    public Map<String, JavaVersionTable.Row> getInitialValue(ExecutionContext ctx) {
         return new LinkedHashMap<>();
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getScanner(Map<Object, JavaVersionTable.Row> acc) {
+    public TreeVisitor<?, ExecutionContext> getScanner(Map<String, JavaVersionTable.Row> acc) {
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public Tree preVisit(Tree tree, ExecutionContext ctx) {
@@ -64,15 +63,13 @@ public class FindJavaVersion extends ScanningRecipe<Map<Object, JavaVersionTable
                         // JavaProject UUID (one row per module) when no git provenance is available,
                         // and finally to the JavaVersion UUID so disconnected source files still
                         // produce one row per file rather than silently merging.
-                        Optional<GitProvenance> gp = markers.findFirst(GitProvenance.class);
-                        Object key;
-                        if (gp.isPresent() && gp.get().getOrigin() != null) {
-                            key = gp.get().getOrigin();
-                        } else {
-                            key = markers.findFirst(JavaProject.class)
-                                    .<Object>map(JavaProject::getId)
-                                    .orElseGet(jv::getId);
-                        }
+                        // Prefixes keep the three key namespaces from colliding.
+                        String key = markers.findFirst(GitProvenance.class)
+                                .map(GitProvenance::getOrigin)
+                                .map(origin -> "origin:" + origin)
+                                .orElseGet(() -> markers.findFirst(JavaProject.class)
+                                        .map(jp -> "project:" + jp.getId())
+                                        .orElseGet(() -> "version:" + jv.getId()));
 
                         JavaVersionTable.Row candidate = new JavaVersionTable.Row(
                                 Integer.toString(jv.getMajorVersion()),
@@ -86,7 +83,7 @@ public class FindJavaVersion extends ScanningRecipe<Map<Object, JavaVersionTable
     }
 
     @Override
-    public Collection<? extends SourceFile> generate(Map<Object, JavaVersionTable.Row> acc, ExecutionContext ctx) {
+    public Collection<? extends SourceFile> generate(Map<String, JavaVersionTable.Row> acc, ExecutionContext ctx) {
         for (JavaVersionTable.Row row : acc.values()) {
             table.insertRow(ctx, row);
         }

--- a/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
@@ -15,44 +15,94 @@
  */
 package org.openrewrite.java.migrate.search;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.Getter;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.migrate.table.JavaVersionTable;
-import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.marker.GitProvenance;
+import org.openrewrite.marker.Markers;
 
-@EqualsAndHashCode(callSuper = false)
-@Value
-public class FindJavaVersion extends Recipe {
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+
+public class FindJavaVersion extends ScanningRecipe<Map<Object, JavaVersionTable.Row>> {
 
     transient JavaVersionTable table = new JavaVersionTable(this);
 
-    String displayName = "Find Java versions in use";
+    @Getter
+    final String displayName = "Find Java versions in use";
 
-    String description = "Finds Java versions in use.";
+    @Getter
+    final String description = "Finds Java versions in use, emitting one row per git repository " +
+            "(the lowest source/target compatibility across modules in that repository).";
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+    public Map<Object, JavaVersionTable.Row> getInitialValue(ExecutionContext ctx) {
+        return new LinkedHashMap<>();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Map<Object, JavaVersionTable.Row> acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
-            public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                cu.getMarkers().findFirst(JavaVersion.class)
-                        .ifPresent(jv -> {
-                            String projectName = cu.getMarkers().findFirst(JavaProject.class)
-                                    .map(JavaProject::getProjectName)
-                                    .orElse("");
-                            table.insertRow(ctx, new JavaVersionTable.Row(
-                                    projectName,
-                                    Integer.toString(jv.getMajorVersion()),
-                                    Integer.toString(jv.getMajorReleaseVersion())));
-                        });
-                return cu;
+            public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                if (tree instanceof JavaSourceFile) {
+                    Markers markers = tree.getMarkers();
+                    markers.findFirst(JavaVersion.class).ifPresent(jv -> {
+                        // Prefer the git origin as the dedup key: every module in a multi-module repo
+                        // shares one GitProvenance, so they collapse to a single row. Fall back to the
+                        // JavaProject UUID (one row per module) when no git provenance is available,
+                        // and finally to the JavaVersion UUID so disconnected source files still
+                        // produce one row per file rather than silently merging.
+                        Optional<GitProvenance> gp = markers.findFirst(GitProvenance.class);
+                        Object key;
+                        if (gp.isPresent() && gp.get().getOrigin() != null) {
+                            key = gp.get().getOrigin();
+                        } else {
+                            key = markers.findFirst(JavaProject.class)
+                                    .<Object>map(JavaProject::getId)
+                                    .orElseGet(jv::getId);
+                        }
+
+                        JavaVersionTable.Row candidate = new JavaVersionTable.Row(
+                                Integer.toString(jv.getMajorVersion()),
+                                Integer.toString(jv.getMajorReleaseVersion()));
+                        acc.merge(key, candidate, FindJavaVersion::lower);
+                    });
+                }
+                return tree;
             }
         };
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(Map<Object, JavaVersionTable.Row> acc, ExecutionContext ctx) {
+        for (JavaVersionTable.Row row : acc.values()) {
+            table.insertRow(ctx, row);
+        }
+        return emptyList();
+    }
+
+    // Lower target compatibility wins; tiebreak on lower source compatibility.
+    // The retained row is the migration floor for the repository.
+    private static JavaVersionTable.Row lower(JavaVersionTable.Row a, JavaVersionTable.Row b) {
+        int aTarget = Integer.parseInt(a.getTargetVersion());
+        int bTarget = Integer.parseInt(b.getTargetVersion());
+        if (aTarget != bTarget) {
+            return aTarget < bTarget ? a : b;
+        }
+        int aSource = Integer.parseInt(a.getSourceVersion());
+        int bSource = Integer.parseInt(b.getSourceVersion());
+        return aSource <= bSource ? a : b;
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/table/JavaVersionTable.java
+++ b/src/main/java/org/openrewrite/java/migrate/table/JavaVersionTable.java
@@ -28,10 +28,6 @@ public class JavaVersionTable extends DataTable<JavaVersionTable.Row> {
 
     @Value
     public static class Row {
-        @Column(displayName = "Project name",
-                description = "The name of the project that produced the LST.")
-        String projectName;
-
         @Column(displayName = "Source compatibility",
                 description = "The major version of Java used to compile the source code")
         String sourceVersion;

--- a/src/main/java/org/openrewrite/java/migrate/table/JavaVersionTable.java
+++ b/src/main/java/org/openrewrite/java/migrate/table/JavaVersionTable.java
@@ -28,6 +28,10 @@ public class JavaVersionTable extends DataTable<JavaVersionTable.Row> {
 
     @Value
     public static class Row {
+        @Column(displayName = "Project name",
+                description = "The name of the project that produced the LST.")
+        String projectName;
+
         @Column(displayName = "Source compatibility",
                 description = "The major version of Java used to compile the source code")
         String sourceVersion;

--- a/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.migrate.table.JavaVersionTable;
+import org.openrewrite.marker.GitProvenance;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -34,74 +35,141 @@ class FindJavaVersionTest implements RewriteTest {
         spec.recipe(new FindJavaVersion());
     }
 
+    private static GitProvenance gitProvenance(String origin) {
+        return new GitProvenance(randomId(), origin, "main", "abc123", null, null, null);
+    }
+
     @DocumentExample
     @Test
-    void twoClassesInSameProjectLeadToTwoRows() {
-        var project = new JavaProject(randomId(), "demo", null);
+    void multiModuleRepositoryCollapsesToOneRow() {
+        // All modules in a multi-module repository share one GitProvenance, so the recipe
+        // emits a single row identifying the repository as a whole.
+        var git = gitProvenance("https://github.com/example/demo.git");
+        var moduleA = new JavaProject(randomId(), "module-a", null);
+        var moduleB = new JavaProject(randomId(), "module-b", null);
         var jv = new JavaVersion(randomId(), "Sam", "Shelter", "17", "8");
         rewriteRun(
-          spec -> spec.dataTable(JavaVersionTable.Row.class, rows -> {
-              assertThat(rows).containsExactly(
-                new JavaVersionTable.Row("demo", "17", "8"),
-                new JavaVersionTable.Row("demo", "17", "8")
-              );
-          }),
+          spec -> spec.dataTable(JavaVersionTable.Row.class, rows ->
+            assertThat(rows).containsExactly(
+              new JavaVersionTable.Row("17", "8")
+            )),
           //language=java
           java(
             """
               class A {
               }
               """,
-            spec -> spec.markers(project, jv)),
+            spec -> spec.markers(git, moduleA, jv)),
           //language=java
           java(
             """
               class B {
               }
               """,
-            spec -> spec.markers(project, jv))
+            spec -> spec.markers(git, moduleB, jv))
         );
     }
 
     @Test
-    void identicalJavaVersionMarkersAcrossProjectsAreEachReported() {
-        // Reproduces customer-requests#2409: across multiple projects with the same JDK,
-        // every project must appear as its own row in the data table. Previously a
-        // recipe-instance HashSet deduplicated by JavaVersion content, so identical
-        // markers in different projects were silently dropped.
-        var projectA = new JavaProject(randomId(), "project-a", null);
-        var projectB = new JavaProject(randomId(), "project-b", null);
-        var projectC = new JavaProject(randomId(), "project-c", null);
+    void heterogeneousVersionsInOneRepoPickLowestTarget() {
+        // When modules in the same repo target different JDKs, the row reports the lowest
+        // target — the migration floor for the repository.
+        var git = gitProvenance("https://github.com/example/mixed.git");
+        var legacy = new JavaProject(randomId(), "legacy-module", null);
+        var modern = new JavaProject(randomId(), "modern-module", null);
+        var java8 = new JavaVersion(randomId(), "Sam", "Shelter", "8", "8");
+        var java17 = new JavaVersion(randomId(), "Sam", "Shelter", "17", "17");
+        rewriteRun(
+          spec -> spec.dataTable(JavaVersionTable.Row.class, rows ->
+            assertThat(rows).containsExactly(
+              new JavaVersionTable.Row("8", "8")
+            )),
+          //language=java
+          java(
+            """
+              class Legacy {
+              }
+              """,
+            spec -> spec.markers(git, legacy, java8)),
+          //language=java
+          java(
+            """
+              class Modern {
+              }
+              """,
+            spec -> spec.markers(git, modern, java17))
+        );
+    }
+
+    @Test
+    void identicalJavaVersionMarkersAcrossRepositoriesAreEachReported() {
+        // Reproduces customer-requests#2409: across multiple repositories with the same JDK,
+        // every repository must contribute its own row in the data table. Previously a
+        // recipe-instance HashSet deduplicated by JavaVersion content, so identical markers
+        // in different repositories were silently dropped.
+        var gitA = gitProvenance("https://github.com/example/repo-a.git");
+        var gitB = gitProvenance("https://github.com/example/repo-b.git");
+        var gitC = gitProvenance("https://github.com/example/repo-c.git");
+        var project = new JavaProject(randomId(), "service", null);
         var jv = new JavaVersion(randomId(), "Sam", "Shelter", "17", "8");
         rewriteRun(
-          spec -> spec.dataTable(JavaVersionTable.Row.class, rows -> {
-              assertThat(rows).containsExactlyInAnyOrder(
-                new JavaVersionTable.Row("project-a", "17", "8"),
-                new JavaVersionTable.Row("project-b", "17", "8"),
-                new JavaVersionTable.Row("project-c", "17", "8")
-              );
-          }),
+          spec -> spec.dataTable(JavaVersionTable.Row.class, rows ->
+            assertThat(rows).containsExactly(
+              new JavaVersionTable.Row("17", "8"),
+              new JavaVersionTable.Row("17", "8"),
+              new JavaVersionTable.Row("17", "8")
+            )),
           //language=java
           java(
             """
               class A {
               }
               """,
-            spec -> spec.markers(projectA, jv)),
+            spec -> spec.markers(gitA, project, jv)),
           //language=java
           java(
             """
               class B {
               }
               """,
-            spec -> spec.markers(projectB, jv)),
+            spec -> spec.markers(gitB, project, jv)),
           //language=java
           java(
             """
               class C {
               }
               """,
-            spec -> spec.markers(projectC, jv))
+            spec -> spec.markers(gitC, project, jv))
+        );
+    }
+
+    @Test
+    void withoutGitProvenanceFallsBackToPerProject() {
+        // When no GitProvenance is available (local non-git source trees, some test setups),
+        // the recipe falls back to one row per JavaProject so distinct modules are not silently merged.
+        var projectOne = new JavaProject(randomId(), "module-a", null);
+        var projectTwo = new JavaProject(randomId(), "module-b", null);
+        var jv = new JavaVersion(randomId(), "Sam", "Shelter", "17", "8");
+        rewriteRun(
+          spec -> spec.dataTable(JavaVersionTable.Row.class, rows ->
+            assertThat(rows).containsExactly(
+              new JavaVersionTable.Row("17", "8"),
+              new JavaVersionTable.Row("17", "8")
+            )),
+          //language=java
+          java(
+            """
+              class A {
+              }
+              """,
+            spec -> spec.markers(projectOne, jv)),
+          //language=java
+          java(
+            """
+              class B {
+              }
+              """,
+            spec -> spec.markers(projectTwo, jv))
         );
     }
 }

--- a/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.migrate.table.JavaVersionTable;
 import org.openrewrite.test.RecipeSpec;
@@ -35,12 +36,14 @@ class FindJavaVersionTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void twoClassesWithSameMarkerLeadToOneRow() {
+    void twoClassesInSameProjectLeadToTwoRows() {
+        var project = new JavaProject(randomId(), "demo", null);
         var jv = new JavaVersion(randomId(), "Sam", "Shelter", "17", "8");
         rewriteRun(
           spec -> spec.dataTable(JavaVersionTable.Row.class, rows -> {
               assertThat(rows).containsExactly(
-                new JavaVersionTable.Row("17", "8")
+                new JavaVersionTable.Row("demo", "17", "8"),
+                new JavaVersionTable.Row("demo", "17", "8")
               );
           }),
           //language=java
@@ -49,14 +52,56 @@ class FindJavaVersionTest implements RewriteTest {
               class A {
               }
               """,
-            spec -> spec.markers(jv)),
+            spec -> spec.markers(project, jv)),
           //language=java
           java(
             """
               class B {
               }
               """,
-            spec -> spec.markers(jv))
+            spec -> spec.markers(project, jv))
+        );
+    }
+
+    @Test
+    void identicalJavaVersionMarkersAcrossProjectsAreEachReported() {
+        // Reproduces customer-requests#2409: across multiple projects with the same JDK,
+        // every project must appear as its own row in the data table. Previously a
+        // recipe-instance HashSet deduplicated by JavaVersion content, so identical
+        // markers in different projects were silently dropped.
+        var projectA = new JavaProject(randomId(), "project-a", null);
+        var projectB = new JavaProject(randomId(), "project-b", null);
+        var projectC = new JavaProject(randomId(), "project-c", null);
+        var jv = new JavaVersion(randomId(), "Sam", "Shelter", "17", "8");
+        rewriteRun(
+          spec -> spec.dataTable(JavaVersionTable.Row.class, rows -> {
+              assertThat(rows).containsExactlyInAnyOrder(
+                new JavaVersionTable.Row("project-a", "17", "8"),
+                new JavaVersionTable.Row("project-b", "17", "8"),
+                new JavaVersionTable.Row("project-c", "17", "8")
+              );
+          }),
+          //language=java
+          java(
+            """
+              class A {
+              }
+              """,
+            spec -> spec.markers(projectA, jv)),
+          //language=java
+          java(
+            """
+              class B {
+              }
+              """,
+            spec -> spec.markers(projectB, jv)),
+          //language=java
+          java(
+            """
+              class C {
+              }
+              """,
+            spec -> spec.markers(projectC, jv))
         );
     }
 }


### PR DESCRIPTION
## Summary

- Convert `FindJavaVersion` to a `ScanningRecipe` keyed on `GitProvenance.origin`, so each git repository contributes exactly one row regardless of how many modules or compilation units it contains
- When modules in a repository disagree on JDK, retain the row with the **lowest** target compatibility (tiebreak: lowest source) — the migration floor for the repository
- No schema change: `JavaVersionTable.Row` keeps its two original columns, `sourceVersion` and `targetVersion`

## Problem

The recipe originally kept a `transient HashSet<JavaVersion> seen` on the recipe instance. Two things conspired to drop rows:

1. `JavaVersion` excludes its UUID from `equals`/`hashCode`.
2. The Moderne CLI **reuses one recipe instance across every repository in a working-set run** (verified empirically — see below).

The combination silently dropped every repository's row except the first one processed. The previous attempt on this branch removed the dedup and emitted one row per compilation unit — correct counts, but thousands of identical rows per project and no aggregation at the repository level (the unit that actually matters for portfolio-wide JDK inventory).

## Solution

- `ScanningRecipe<Map<String, Row>>`. The scanner reads `JavaVersion` and `GitProvenance` markers from each `JavaSourceFile` and merges into the accumulator.
- Key: `origin:<GitProvenance.origin>` → `project:<JavaProject.getId()>` → `version:<JavaVersion.getId()>` (in that fallback order). Prefixed string keys keep the three namespaces from colliding and make the accumulator readable at a glance.
- Merge: lower `targetVersion` wins; tiebreak on lower `sourceVersion`.
- `generate` flushes accumulated rows to the data table. No recipe-instance mutable state.

## Validation

### Unit tests

- [x] `multiModuleRepositoryCollapsesToOneRow` — modules sharing one `GitProvenance` produce a single row
- [x] `heterogeneousVersionsInOneRepoPickLowestTarget` — Java 8 + Java 17 modules in one repo produce a single row showing Java 8
- [x] `identicalJavaVersionMarkersAcrossRepositoriesAreEachReported` — three repos sharing one `JavaVersion` produce three rows (regression for moderneinc/customer-requests#2409)
- [x] `withoutGitProvenanceFallsBackToPerProject` — no `GitProvenance` → one row per `JavaProject`
- [x] `./gradlew test --tests '*FindJavaVersionTest*'` passes

### CLI reproduction on real repositories

Ran `mod run working-set --recipe org.openrewrite.java.migrate.search.FindJavaVersion` against the 8 repositories in the **Spinnaker** organization (clouddriver, echo, fiat, front50, halyard, kayenta, kork, spinnaker-gradle-project — 4448 source files in clouddriver alone, varied submodule structures).

To confirm the bug is real on the CLI (not just a theoretical concern) I swapped in the pre-fix code from commit `4beeb8a1` and reran identically:

| Code version | Rows in aggregated CSV | Per-repo distribution |
|---|---|---|
| **Pre-fix (`transient seen` HashSet)** | **1** | Only `clouddriver` (processed first) wrote a `JavaVersionTable.csv.gz`. All 7 other repos: no data table file emitted at all. |
| **This PR (`ScanningRecipe`)** | **8** | One row per repo. 7 × Java 17, 1 × Java 11 (`spinnaker-gradle-project`). |

This proves three things on real LSTs:

1. **The CLI does reuse the recipe instance across repositories** in a working-set run. The buggy `seen` HashSet leaked across all 8 repos and silently dropped 7 of them.
2. **Multi-module aggregation works**: `clouddriver` (4448 source files, ~30 submodules) collapses to a single row under the fix. Previously this would have been the only row, masking the much worse cross-repo bug.
3. **Cross-repo non-collapse works** (regression for #2409): 7 repositories sharing Java 17 each appear as their own row instead of merging into one.

The "lowest version wins" branch (heterogeneous JDKs within one repo) isn't exercised by Spinnaker — every repo's submodules agree on a single JDK — but it's covered deterministically by the unit test.

Fixes moderneinc/customer-requests#2409