### PR TITLE
Skip `IfElseIfConstructToSwitch` when a trailing non-`== null` binary check is present

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -118,6 +118,9 @@ public class IfElseIfConstructToSwitch extends Recipe {
                     return;
                 }
             }
+            if (!potentialCandidate) {
+                return;
+            }
             potentialCandidate = validatePotentialCandidate();
         }
 

--- a/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
@@ -905,6 +905,32 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
         }
 
         @Test
+        void noSwitchBlockWithTrailingNonEqualsBinaryCheck() {
+            // https://github.com/openrewrite/rewrite-migrate-java/issues/1108
+            // The trailing `else if (o != null)` is not a recognised null check and must not be silently dropped.
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class A {
+                      void test(Object o) {
+                          if (o instanceof String s) {
+                              System.out.println(s);
+                          } else if (o instanceof Integer i) {
+                              System.out.println(i);
+                          } else if (o instanceof Boolean b) {
+                              System.out.println(b);
+                          } else if (o != null) {
+                              System.out.println(o);
+                          }
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void noSwitchBlockWhenElseBlockReturns() {
             rewriteRun(
               //language=java


### PR DESCRIPTION
- Fixes #1108.

When an `if (o instanceof ...) ... else if (o != null) { ... }` chain was processed, the trailing branch's body was silently dropped: `handleNullCheck` rejected the `!=` binary by setting `potentialCandidate = false`, but the constructor unconditionally re-ran `validatePotentialCandidate()` which only inspects the recorded pattern matchers and overwrote the flag back to true. The recipe then emitted a switch with `case null, default -> {}` and lost the original logic.

Bail out of the constructor before re-validating when the loop has already disqualified the chain, and add a regression test covering the issue's repro.