### PR TITLE
Skip `UseTextBlocks` when literal value matches its source

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -247,7 +247,11 @@ public class UseTextBlocks extends Recipe {
             J.Literal l = (J.Literal) expr;
             return TypeUtils.isString(l.getType()) &&
                    l.getValueSource() != null &&
-                   !l.getValueSource().startsWith("\"\"\"");
+                   !l.getValueSource().startsWith("\"\"\"") &&
+                   // Defend against literals whose value still looks like the source (e.g. parser failed to
+                   // decode supplementary characters encoded as surrogate pairs); skipping prevents emitting
+                   // a broken text block that drops or re-escapes content.
+                   !l.getValueSource().equals(l.getValue());
         }
         return false;
     }

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -995,6 +995,27 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1110")
+    @Test
+    void supplementaryCharacterAsSurrogatePair() {
+        // The Java parser currently returns a corrupted value/valueSource for string literals containing
+        // supplementary characters encoded as surrogate pairs. Until that is fixed upstream, the recipe
+        // must bail out rather than emit a broken text block that drops or re-escapes content.
+        rewriteRun(
+          spec -> spec.recipe(new UseTextBlocks()),
+          java(
+            """
+             class Test {
+               String json =
+                   "{\\n"
+                       + "  \\"euro\\": 1,\\n"
+                       + "  \\"ligature\\": 2,\\n"
+                       + "  \\"\\ud834\\udd20\\": 3\\n"
+                       + "}";
+             }""",
+            src -> src.markers(javaVersion(17))));
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/555")
     @Test
     void textBlockTrailingEscape() {


### PR DESCRIPTION
## Summary

- `UseTextBlocks` was emitting broken text blocks for string literals containing supplementary characters encoded as surrogate pairs (e.g. `"𝄠"`), dropping the character and re-escaping content.
- Root cause: the Java parser returns a corrupted `J.Literal` for these literals, where `value` equals `valueSource` (both stripped of the surrogate pair). The recipe then treated that quoted source form as content.
- Fix: bail out of the conversion when `value.equals(valueSource)`; that condition is impossible for a correctly decoded string literal, so it's a safe sentinel for parser corruption.

- Fixes #1110

## Test plan

- [x] Added regression test `supplementaryCharacterAsSurrogatePair` asserting the recipe leaves the original concatenation unchanged.
- [x] Full `UseTextBlocksTest` suite passes.