### PR TITLE
Skip `UseMapOf` for `HashMap` subclasses like `LinkedHashMap` and `TreeMap`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -28,6 +28,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +55,8 @@ public class UseMapOf extends Recipe {
                     public J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
                         J.NewClass n = (J.NewClass) super.visitNewClass(newClass, ctx);
                         J.Block body = n.getBody();
-                        if (NEW_HASH_MAP.matches(n) && body != null && body.getStatements().size() == 1) {
+                        if (NEW_HASH_MAP.matches(n) && body != null && body.getStatements().size() == 1 &&
+                                TypeUtils.isOfClassType(n.getClazz() != null ? n.getClazz().getType() : null, "java.util.HashMap")) {
                             Statement statement = body.getStatements().get(0);
                             if (statement instanceof J.Block) {
                                 List<Statement> putStatements = ((J.Block) statement).getStatements();

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -205,6 +205,49 @@ class UseMapOfTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1112")
+    @Test
+    void doNotChangeLinkedHashMap() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.LinkedHashMap;
+              import java.util.Map;
+
+              class Test {
+                  static final Map<String, String> ORDERED = new LinkedHashMap<>() {{
+                      put("a", "1");
+                      put("b", "2");
+                      put("c", "3");
+                  }};
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1112")
+    @Test
+    void doNotChangeTreeMap() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Map;
+              import java.util.TreeMap;
+
+              class Test {
+                  static final Map<String, String> SORTED = new TreeMap<>() {{
+                      put("a", "1");
+                      put("b", "2");
+                  }};
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/566")
     @Test
     void changeDoubleBraceInitForNonStringTypes() {


### PR DESCRIPTION
- Fixes #1112.

`Map.of(..)` makes no iteration-order guarantee, so converting an order-sensitive `LinkedHashMap` (or `TreeMap`) silently drops the ordering contract callers rely on. The `NEW_HASH_MAP` matcher used `matchOverrides=true` to catch the `new HashMap<>() {{...}}` anonymous-subclass idiom, which also caused it to match non-anonymous `HashMap` subclasses. Added a `TypeUtils.isOfClassType` check on the declared class so only `java.util.HashMap` is rewritten, with regression tests for `LinkedHashMap` and `TreeMap`.