### PR TITLE
Skip `RenameUnderscoreIdentifier` on Kotlin and Groovy sources

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/RenameUnderscoreIdentifier.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/RenameUnderscoreIdentifier.java
@@ -26,6 +26,8 @@ import org.openrewrite.java.RenameVariable;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -40,7 +42,11 @@ public class RenameUnderscoreIdentifier extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                new UsesJavaVersion<>(1, 8),
+                Preconditions.and(
+                        new UsesJavaVersion<>(1, 8),
+                        Preconditions.not(new KotlinFileChecker<>()),
+                        Preconditions.not(new GroovyFileChecker<>())
+                ),
                 new RenameIdentifierVisitor("_", "__")
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/lang/RenameUnderscoreIdentifierTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/RenameUnderscoreIdentifierTest.java
@@ -25,6 +25,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class RenameUnderscoreIdentifierTest implements RewriteTest {
 
@@ -266,6 +267,25 @@ class RenameUnderscoreIdentifierTest implements RewriteTest {
                   void test() {
                       Stream.of("a", "b")
                           .collect(Collectors.toMap(String::toUpperCase, __ -> "val"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinFileNotChanged() {
+        rewriteRun(
+          spec -> spec.recipe(new RenameUnderscoreIdentifier())
+            .allSources(s -> s.markers(javaVersion(8))),
+          //language=kotlin
+          kotlin(
+            """
+              class Test {
+                  fun test() {
+                      val pairs = listOf(1 to "a", 2 to "b")
+                      pairs.forEach { _, _ -> println("ignored") }
                   }
               }
               """


### PR DESCRIPTION
## Summary

- `RenameUnderscoreIdentifier`'s only precondition was `UsesJavaVersion<>(1, 8)`. In polyglot projects whose Kotlin sources target Java 8 bytecode, the recipe visited Kotlin lambdas and rewrote legal `_` placeholder parameters to `__`, which is reserved in Kotlin 2.0+ (e.g. `{ _, _ -> ... }` became `{ __, __ -> ... }`, producing two compile errors per site).
- Add `Preconditions.not(new KotlinFileChecker<>())` and `Preconditions.not(new GroovyFileChecker<>())` to the precondition, mirroring the gate already present on the sibling `ReplaceUnusedVariablesWithUnderscore` recipe.
- Add a regression test (`kotlinFileNotChanged`) asserting a Java-8-marked Kotlin source containing `{ _, _ -> ... }` is left untouched.

- Resolves moderneinc/customer-requests#2449.

## Test plan

- [x] `./gradlew test --tests 'org.openrewrite.java.migrate.lang.RenameUnderscoreIdentifierTest'` passes, including the new Kotlin regression.
- [x] Existing Java-only tests continue to pass (the new preconditions do not affect plain Java sources).