### PR TITLE
fix: do not replace lambda params with underscore when used as assignment target

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscore.java
@@ -102,7 +102,8 @@ public class ReplaceUnusedVariablesWithUnderscore extends Recipe {
             private boolean renameVariableIfUnusedInContext(J.VariableDeclarations.NamedVariable variable, J context) {
                 if (!UNDERSCORE.equals(variable.getName().getSimpleName()) &&
                         VariableReferences.findRhsReferences(context, variable.getName()).isEmpty() &&
-                        !usedInModifyingUnary(variable.getName(), context)) {
+                        !usedInModifyingUnary(variable.getName(), context) &&
+                        !usedAsAssignmentTarget(variable.getName(), context)) {
                     doAfterVisit(new RenameVariable<>(variable, UNDERSCORE));
                     return true;
                 }
@@ -118,6 +119,18 @@ public class ReplaceUnusedVariablesWithUnderscore extends Recipe {
                             atomicBoolean.set(true);
                         }
                         return super.visitUnary(unary, atomicBoolean);
+                    }
+                }.reduce(context, new AtomicBoolean(false)).get();
+            }
+
+            private boolean usedAsAssignmentTarget(J.Identifier identifier, J context) {
+                return new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean atomicBoolean) {
+                        if (SemanticallyEqual.areEqual(identifier, assignment.getVariable())) {
+                            atomicBoolean.set(true);
+                        }
+                        return super.visitAssignment(assignment, atomicBoolean);
                     }
                 }.reduce(context, new AtomicBoolean(false)).get();
             }

--- a/src/test/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscoreTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/ReplaceUnusedVariablesWithUnderscoreTest.java
@@ -514,4 +514,76 @@ class ReplaceUnusedVariablesWithUnderscoreTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotReplaceWhenLambdaParamIsAssignmentTarget() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.BinaryOperator;
+
+              class Test {
+                  void test() {
+                      BinaryOperator<String> op = (a, b) -> a = "value";
+                  }
+              }
+              """,
+            """
+              import java.util.function.BinaryOperator;
+
+              class Test {
+                  void test() {
+                      BinaryOperator<String> op = (a, _) -> a = "value";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotReplaceWhenSecondLambdaParamIsAssignmentTarget() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.BinaryOperator;
+
+              class Test {
+                  void test() {
+                      BinaryOperator<String> op = (a, b) -> b = "value";
+                  }
+              }
+              """,
+            """
+              import java.util.function.BinaryOperator;
+
+              class Test {
+                  void test() {
+                      BinaryOperator<String> op = (_, b) -> b = "value";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotReplaceWhenSingleLambdaParamIsAssignmentTarget() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.UnaryOperator;
+
+              class Test {
+                  void test() {
+                      UnaryOperator<String> op = a -> a = "value";
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Problem
`ReplaceUnusedVariablesWithUnderscore` incorrectly renames lambda parameters to `_` when they appear as LHS assignment targets, producing uncompilable code.

## Fix
Added `usedAsAssignmentTarget()` guard following the same pattern as the existing `usedInModifyingUnary()` method, and wired it into `renameVariableIfUnusedInContext`.

## Tests
Added three test cases covering:
- First param as assignment target, second correctly renamed
- Second param as assignment target, first correctly renamed
- Single param as assignment target

- Fixes #1116