### PR TITLE
Do not add `java.io.IO` import in `ReplaceSystemOutWithIOPrint`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrint.java
+++ b/src/main/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrint.java
@@ -54,7 +54,6 @@ public class ReplaceSystemOutWithIOPrint extends Recipe {
                         if (!isSystemOutMethod(m)) {
                             return m;
                         }
-                        maybeAddImport("java.io.IO", false);
                         String methodName = m.getName().getSimpleName();
                         return m.getArguments().isEmpty() ?
                                 JavaTemplate.apply( "IO.#{}()", getCursor(), m.getCoordinates().replace(), methodName ) :

--- a/src/test/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrintTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/io/ReplaceSystemOutWithIOPrintTest.java
@@ -53,8 +53,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
-              import java.io.IO;
-
               class Example {
                   void test() {
                       IO.print("Hello");
@@ -77,8 +75,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
-              import java.io.IO;
-
               class Example {
                   void test() {
                       IO.println("Hello");
@@ -103,8 +99,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
-              import java.io.IO;
-
               class Example {
                   void test() {
                       IO.println("Hello");
@@ -128,8 +122,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
-              import java.io.IO;
-
               class Example {
                   void test() {
                       String message = "Hello World";
@@ -153,8 +145,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
-              import java.io.IO;
-
               class Example {
                   void test() {
                       IO.println();
@@ -180,8 +170,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
-              import java.io.IO;
-
               class Example {
                   void test() {
                       IO.print("Hello");
@@ -210,8 +198,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               }
               """,
             """
-              import java.io.IO;
-
               class Example {
                   void test() {
                       String name = "John";
@@ -261,7 +247,7 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
     }
 
     @Test
-    void addsImportForRegularClassWithPackage() {
+    void doesNotAddImportForRegularClassWithPackage() {
         rewriteRun(
           java(
             """
@@ -275,8 +261,6 @@ class ReplaceSystemOutWithIOPrintTest implements RewriteTest {
               """,
             """
               package com.helloworld;
-
-              import java.io.IO;
 
               public class Main {
                   public void greet() {


### PR DESCRIPTION
- Fixes #1115. JEP 512 finalized the new `IO` console class in `java.lang.IO` for the Java 25 release, where it is implicitly imported by every source file — the `java.io.IO` location only ever existed in the preview JEPs 477 and 495. This reverts the `maybeAddImport("java.io.IO", false)` added in #1093, which produced an import of the non-existent `java.io.IO` class. Tests are updated to expect no import, and the former `addsImportForRegularClassWithPackage` test is renamed to `doesNotAddImportForRegularClassWithPackage` to lock in the regression.