### PR TITLE
Migrate `com.sun.xml.bind.marshaller.NamespacePrefixMapper` to `org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper`

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -986,6 +986,10 @@ recipeList:
       oldPackageName: javax.xml.bind
       newPackageName: jakarta.xml.bind
       recursive: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.sun.xml.bind.marshaller.NamespacePrefixMapper
+      newFullyQualifiedTypeName: org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper
+      ignoreDefinition: true
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.codehaus.mojo
       artifactId: jaxb2-maven-plugin

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxXmlBindMigrationToJakartaXmlBindTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxXmlBindMigrationToJakartaXmlBindTest.java
@@ -53,6 +53,24 @@ class JavaxXmlBindMigrationToJakartaXmlBindTest implements RewriteTest {
       public @interface XmlElement {}
       """;
 
+    @Language("java")
+    private static final String SUN_NAMESPACE_PREFIX_MAPPER_STUB = """
+      package com.sun.xml.bind.marshaller;
+      public abstract class NamespacePrefixMapper {
+          public abstract String[] getPreDeclaredNamespaceUris();
+          public abstract String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix);
+      }
+      """;
+
+    @Language("java")
+    private static final String GLASSFISH_NAMESPACE_PREFIX_MAPPER_STUB = """
+      package org.glassfish.jaxb.runtime.marshaller;
+      public abstract class NamespacePrefixMapper {
+          public abstract String[] getPreDeclaredNamespaceUris();
+          public abstract String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix);
+      }
+      """;
+
     @DocumentExample
     @Test
     void dontRetainJaxbApiWhenJacksonNotPresent() {
@@ -208,6 +226,47 @@ class JavaxXmlBindMigrationToJakartaXmlBindTest implements RewriteTest {
                   .contains("jaxb-api")
                   .contains("jackson-module-jaxb-annotations")
                   .actual())
+          )
+        );
+    }
+
+    @Test
+    void migrateNamespacePrefixMapper() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            .dependsOn(SUN_NAMESPACE_PREFIX_MAPPER_STUB, GLASSFISH_NAMESPACE_PREFIX_MAPPER_STUB)),
+          //language=java
+          java(
+            """
+              import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+
+              public class MyPrefixMapper extends NamespacePrefixMapper {
+                  @Override
+                  public String[] getPreDeclaredNamespaceUris() {
+                      return new String[0];
+                  }
+
+                  @Override
+                  public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+                      return suggestion;
+                  }
+              }
+              """,
+            """
+              import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
+
+              public class MyPrefixMapper extends NamespacePrefixMapper {
+                  @Override
+                  public String[] getPreDeclaredNamespaceUris() {
+                      return new String[0];
+                  }
+
+                  @Override
+                  public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+                      return suggestion;
+                  }
+              }
+              """
           )
         );
     }


### PR DESCRIPTION
## Summary
- The JAXB RI relocated `com.sun.xml.bind.marshaller.NamespacePrefixMapper` to `org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper` as part of the 2.x → 3.x repackaging that accompanies the `javax.xml.bind` → `jakarta.xml.bind` move. Subclassing `NamespacePrefixMapper` is a common pattern for controlling XML namespace prefixes during marshalling, and these references were not being rewritten by any existing recipe.
- Wires a declarative `ChangeType` into `JavaxXmlBindMigrationToJakartaXmlBind` (in `jakarta-ee-9.yml`), placed alongside the existing `javax.xml.bind` → `jakarta.xml.bind` `ChangePackage` and `com.sun.xml.bind:jaxb-impl` → `org.glassfish.jaxb:jaxb-runtime` dependency change, so the type rename rides along with the rest of the Jakarta XML Binding 3.0 wave.
- `ignoreDefinition: true` is required since the old type is not on the classpath of the project being migrated; it's referenced via FQN by user code.

- Addresses item 8 of moderneinc/customer-requests#2462.

## Test plan
- [x] Added `migrateNamespacePrefixMapper` to `JavaxXmlBindMigrationToJakartaXmlBindTest` with stubs for both old and new types, asserting the import + `extends` reference are rewritten on a subclass.
- [x] `./gradlew test --tests JavaxXmlBindMigrationToJakartaXmlBindTest` — BUILD SUCCESSFUL.