### PR TITLE
Fix `RefineSwitchCases` generating invalid guard on enum constant labels

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/RefineSwitchCases.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/RefineSwitchCases.java
@@ -66,8 +66,11 @@ public class RefineSwitchCases extends Recipe {
                                 List<Statement> caseStatements = ((J.Block) case_.getBody()).getStatements();
                                 if (caseStatements.size() == 1 && caseStatements.get(0) instanceof J.If) {
                                     J.If if_ = (J.If) caseStatements.get(0);
-                                    if (extractLabelVariables(case_)
-                                            .containsAll(extractConditionVariables(if_.getIfCondition().getTree()))) {
+                                    // Guards (`when`) are only valid on pattern case labels, not on
+                                    // constant labels such as enum constants, so require bound variables
+                                    Set<String> labelVariables = extractLabelVariables(case_);
+                                    if (!labelVariables.isEmpty() &&
+                                            labelVariables.containsAll(extractConditionVariables(if_.getIfCondition().getTree()))) {
                                         // Replace case with multiple cases
                                         return createGuardedCases(case_, if_);
                                     }

--- a/src/test/java/org/openrewrite/java/migrate/lang/RefineSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/RefineSwitchCasesTest.java
@@ -294,6 +294,42 @@ class RefineSwitchCasesTest implements RewriteTest {
         }
 
         @Test
+        void enumConstantLabelWithGuardlessCondition() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Reproducer {
+                      enum EnumOptions {
+                          OPTION_ONE,
+                          OPTION_TWO
+                      }
+
+                      boolean checkMethod() {
+                          return true;
+                      }
+
+                      void handleOptionOne() {
+                      }
+
+                      void buildMenu(EnumOptions item) {
+                          switch (item) {
+                              case OPTION_ONE -> {
+                                  if (checkMethod()) {
+                                      handleOptionOne();
+                                  }
+                              }
+                              case OPTION_TWO -> {
+                              }
+                          }
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void notFormattedWhenNotChanged() {
             rewriteRun(
               //language=java


### PR DESCRIPTION
- Fixes #1123

## Problem

`RefineSwitchCases` (part of `UpgradeToJava25`) converted a case body of the form `case X -> { if (cond) {...} }` into a guarded case `case X when cond -> ...`. However `when` guards are only valid on **pattern** case labels — not on constant labels such as enum constants.

The match guard was `labelVariables.containsAll(conditionVariables)`. For an enum constant label like `case OPTION_ONE`, `extractLabelVariables` returns an empty set, and when the `if` condition referenced no label-bound variables (e.g. `checkMethod()`), `conditionVariables` was also empty — so `emptySet.containsAll(emptySet)` was trivially true. This produced uncompilable code (and a duplicate `case OPTION_ONE` label):

```java
switch (item) {
    case OPTION_ONE when checkMethod() -> handleOptionOne();
    case OPTION_ONE -> {}
    case OPTION_TWO -> {}
}
```

## Fix

Require the case label to bind at least one pattern variable before refining, so constant/enum/null labels are left untouched.

## Testing

Added a regression test (`enumConstantLabelWithGuardlessCondition`) asserting no change; all existing tests still pass.