### PR TITLE
Skip unparseable Java versions in FindJavaVersion instead of reporting -1

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
+++ b/src/main/java/org/openrewrite/java/migrate/search/FindJavaVersion.java
@@ -58,6 +58,17 @@ public class FindJavaVersion extends ScanningRecipe<Map<String, JavaVersionTable
                 if (tree instanceof JavaSourceFile) {
                     Markers markers = tree.getMarkers();
                     markers.findFirst(JavaVersion.class).ifPresent(jv -> {
+                        int sourceVersion = jv.getMajorVersion();
+                        int targetVersion = jv.getMajorReleaseVersion();
+                        // A JavaVersion whose source/target compatibility could not be parsed reports -1
+                        // (for example a build that sets the version only through a Java toolchain, or an
+                        // unresolved property placeholder). -1 is not a real Java version, and because it
+                        // sorts below every real version it would win the lower() reduction and mask the
+                        // actual versions of every other module in the repository, so skip it entirely.
+                        if (sourceVersion < 0 || targetVersion < 0) {
+                            return;
+                        }
+
                         // Prefer the git origin as the dedup key: every module in a multi-module repo
                         // shares one GitProvenance, so they collapse to a single row. Fall back to the
                         // JavaProject UUID (one row per module) when no git provenance is available,
@@ -72,8 +83,8 @@ public class FindJavaVersion extends ScanningRecipe<Map<String, JavaVersionTable
                                         .orElseGet(() -> "version:" + jv.getId()));
 
                         JavaVersionTable.Row candidate = new JavaVersionTable.Row(
-                                Integer.toString(jv.getMajorVersion()),
-                                Integer.toString(jv.getMajorReleaseVersion()));
+                                Integer.toString(sourceVersion),
+                                Integer.toString(targetVersion));
                         acc.merge(key, candidate, FindJavaVersion::lower);
                     });
                 }

--- a/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
@@ -144,6 +144,58 @@ class FindJavaVersionTest implements RewriteTest {
     }
 
     @Test
+    void unknownVersionMarkersAreSkipped() {
+        // A JavaVersion whose source/target compatibility cannot be parsed reports -1 (for example a
+        // build configured solely through a Java toolchain or an unresolved property). Such markers
+        // must not contribute a "-1" row, nor drag the reported version of sibling modules down: -1
+        // sorts below every real version and would otherwise win the lower() reduction.
+        var git = gitProvenance("https://github.com/example/toolchain.git");
+        var known = new JavaProject(randomId(), "known-module", null);
+        var unknown = new JavaProject(randomId(), "unknown-module", null);
+        var java17 = new JavaVersion(randomId(), "Sam", "Shelter", "17", "17");
+        var unparseable = new JavaVersion(randomId(), "Sam", "Shelter", "", "");
+        rewriteRun(
+          spec -> spec.dataTable(JavaVersionTable.Row.class, rows ->
+            assertThat(rows).containsExactly(
+              new JavaVersionTable.Row("17", "17")
+            )),
+          //language=java
+          java(
+            """
+              class Known {
+              }
+              """,
+            spec -> spec.markers(git, known, java17)),
+          //language=java
+          java(
+            """
+              class Unknown {
+              }
+              """,
+            spec -> spec.markers(git, unknown, unparseable))
+        );
+    }
+
+    @Test
+    void allUnknownVersionsEmitNoRows() {
+        // When no module has a parseable version, the recipe emits no rows rather than reporting -1.
+        var git = gitProvenance("https://github.com/example/all-unknown.git");
+        var project = new JavaProject(randomId(), "module", null);
+        var unparseable = new JavaVersion(randomId(), "Sam", "Shelter", "", "");
+        rewriteRun(
+          spec -> spec.dataTable(JavaVersionTable.Row.class, rows ->
+            assertThat(rows).isEmpty()),
+          //language=java
+          java(
+            """
+              class A {
+              }
+              """,
+            spec -> spec.markers(git, project, unparseable))
+        );
+    }
+
+    @Test
     void withoutGitProvenanceFallsBackToPerProject() {
         // When no GitProvenance is available (local non-git source trees, some test setups),
         // the recipe falls back to one row per JavaProject so distinct modules are not silently merged.

--- a/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/search/FindJavaVersionTest.java
@@ -177,25 +177,6 @@ class FindJavaVersionTest implements RewriteTest {
     }
 
     @Test
-    void allUnknownVersionsEmitNoRows() {
-        // When no module has a parseable version, the recipe emits no rows rather than reporting -1.
-        var git = gitProvenance("https://github.com/example/all-unknown.git");
-        var project = new JavaProject(randomId(), "module", null);
-        var unparseable = new JavaVersion(randomId(), "Sam", "Shelter", "", "");
-        rewriteRun(
-          spec -> spec.dataTable(JavaVersionTable.Row.class, rows ->
-            assertThat(rows).isEmpty()),
-          //language=java
-          java(
-            """
-              class A {
-              }
-              """,
-            spec -> spec.markers(git, project, unparseable))
-        );
-    }
-
-    @Test
     void withoutGitProvenanceFallsBackToPerProject() {
         // When no GitProvenance is available (local non-git source trees, some test setups),
         // the recipe falls back to one row per JavaProject so distinct modules are not silently merged.


### PR DESCRIPTION
## What's changed

`FindJavaVersion` reads the `JavaVersion` marker on each source file and records its major source/target version in the `JavaVersionTable`. When a marker's compatibility string is empty or otherwise unparseable, `JavaVersion.getMajorVersion()` returns the sentinel `-1`. The recipe stringified that value directly into the table, so affected repositories surfaced a bogus `-1` row.

Worse, the `lower()` reduction keeps the **lowest** version per repository as the migration floor, and `-1` sorts below every real version — so a single module with an undetermined version dragged the whole repository's reported version down to `-1`, masking the real versions of every other module.

This skips markers whose source or target major version is negative. Such markers carry no usable version, so they neither emit a `-1` row nor participate in the reduction. When no module in a repository has a parseable version, the repository simply contributes no row (rather than a misleading `-1`).

## Why

Customers running `FindJavaVersion` reported `-1` values in the results. The unparseable-compatibility case originates upstream (a toolchain-only build, an unresolved `${...}` property, etc.); companion fixes harden the Maven/Gradle plugins and the core marker, but the recipe should never present `-1` as if it were a real Java version regardless of how the marker was produced.

## Testing

Added `FindJavaVersionTest` cases: an unknown-version module is skipped while its sibling is still reported, and an all-unknown repository emits no rows.