### PR TITLE
javadoc code tag language is not converted to markdown

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
@@ -238,7 +238,12 @@ public class JavadocToMarkdownDocComment extends Recipe {
             String name = element.getName().toLowerCase();
             if (inPre && !"pre".equals(name)) {
                 if ("code".equals(name)) {
+                    // Place the fence (and optional language) on its own line so the
+                    // code content starts fresh; otherwise the first code line would be
+                    // consumed as the fenced code block's info string.
                     currentLine.append(extractCodeLanguage(element));
+                    lines.add(currentLine.toString());
+                    currentLine = new StringBuilder();
                     return;
                 }
                 renderHtmlStartElement(element);
@@ -351,6 +356,13 @@ public class JavadocToMarkdownDocComment extends Recipe {
             switch (name) {
                 case "pre":
                     inPre = false;
+                    // Flush any trailing inline code (e.g. `...);</code></pre>`) so the
+                    // closing fence sits on its own line, as Markdown requires. Only flush
+                    // real content; a whitespace-only line means the fence is already alone.
+                    if (!currentLine.toString().trim().isEmpty()) {
+                        lines.add(currentLine.toString());
+                        currentLine = new StringBuilder();
+                    }
                     currentLine.append("```");
                     break;
                 case "code":

--- a/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
@@ -237,6 +237,10 @@ public class JavadocToMarkdownDocComment extends Recipe {
         private void convertStartElement(Javadoc.StartElement element) {
             String name = element.getName().toLowerCase();
             if (inPre && !"pre".equals(name)) {
+                if ("code".equals(name)) {
+                    currentLine.append(extractCodeLanguage(element));
+                    return;
+                }
                 renderHtmlStartElement(element);
                 return;
             }
@@ -293,6 +297,31 @@ public class JavadocToMarkdownDocComment extends Recipe {
             }
         }
 
+        private String extractCodeLanguage(Javadoc.StartElement element) {
+            return element.getAttributes().stream()
+                    .filter(attr -> attr instanceof Javadoc.Attribute)
+                    .map(attr -> (Javadoc.Attribute) attr)
+                    .filter(a -> "class".equalsIgnoreCase(a.getName()))
+                    .filter(a -> a.getValue() != null)
+                    .map(a -> renderInline(a.getValue()).trim())
+                    .map(JavadocToMarkdownConverter::stripAttributeQuotes)
+                    .findFirst()
+                    .orElse("");
+        }
+
+        private static String stripAttributeQuotes(String value) {
+            if (value.length() < 2) {
+                return value;
+            }
+
+            char first = value.charAt(0);
+            char last = value.charAt(value.length() - 1);
+            if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+                return value.substring(1, value.length() - 1);
+            }
+            return value;
+        }
+
         private void renderHtmlStartElement(Javadoc.StartElement element) {
             currentLine.append('<').append(element.getName());
             for (Javadoc attr : element.getAttributes()) {
@@ -314,7 +343,9 @@ public class JavadocToMarkdownDocComment extends Recipe {
         private void convertEndElement(Javadoc.EndElement element) {
             String name = element.getName().toLowerCase();
             if (inPre && !"pre".equals(name)) {
-                currentLine.append("</").append(element.getName()).append('>');
+                if (!"code".equals(name)) {
+                    currentLine.append("</").append(element.getName()).append('>');
+                }
                 return;
             }
             switch (name) {

--- a/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
@@ -496,6 +496,103 @@ class JavadocToMarkdownDocCommentTest implements RewriteTest {
         );
     }
 
+    @Test
+    public void codeTagConverted() {
+        rewriteRun(
+          spec -> spec.recipe(new JavadocToMarkdownDocComment()),
+          java(
+            """
+              class Test {
+                  /**
+                   * <pre><code> public class TolkienCharacter {
+                   *   String name;
+                   *   double height;
+                   * }
+                   * </code></pre>
+                   */
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  /// ``` public class TolkienCharacter {
+                  ///   String name;
+                  ///   double height;
+                  /// }
+                  /// ```
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """)
+        );
+    }
+
+    @Test
+    public void codeTagWithEmptyLanguageConverted() {
+        rewriteRun(
+          spec -> spec.recipe(new JavadocToMarkdownDocComment()),
+          java(
+            """
+              class Test {
+                  /**
+                   * <pre><code class=''> public class TolkienCharacter {
+                   *   String name;
+                   *   double height;
+                   * }
+                   * </code></pre>
+                   */
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  /// ``` public class TolkienCharacter {
+                  ///   String name;
+                  ///   double height;
+                  /// }
+                  /// ```
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """)
+        );
+    }
+
+    @Test
+    public void codeTagLanguageNotConverted() {
+        rewriteRun(
+          spec -> spec.recipe(new JavadocToMarkdownDocComment()),
+          java(
+            """
+              class Test {
+                  /**
+                   * <pre><code class='java'> public class TolkienCharacter {
+                   *   String name;
+                   *   double height;
+                   * }
+                   * </code></pre>
+                   */
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  /// ```java public class TolkienCharacter {
+                  ///   String name;
+                  ///   double height;
+                  /// }
+                  /// ```
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """)
+        );
+    }
+
+
     @Nested
     class Jep467FlagshipExamples {
 

--- a/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
@@ -516,7 +516,8 @@ class JavadocToMarkdownDocCommentTest implements RewriteTest {
               """,
             """
               class Test {
-                  /// ``` public class TolkienCharacter {
+                  /// ```
+                  /// public class TolkienCharacter {
                   ///   String name;
                   ///   double height;
                   /// }
@@ -548,7 +549,8 @@ class JavadocToMarkdownDocCommentTest implements RewriteTest {
               """,
             """
               class Test {
-                  /// ``` public class TolkienCharacter {
+                  /// ```
+                  /// public class TolkienCharacter {
                   ///   String name;
                   ///   double height;
                   /// }
@@ -580,10 +582,39 @@ class JavadocToMarkdownDocCommentTest implements RewriteTest {
               """,
             """
               class Test {
-                  /// ```java public class TolkienCharacter {
+                  /// ```java
+                  /// public class TolkienCharacter {
                   ///   String name;
                   ///   double height;
                   /// }
+                  /// ```
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """)
+        );
+    }
+
+    @Test
+    public void codeTagClosedInline() {
+        rewriteRun(
+          spec -> spec.recipe(new JavadocToMarkdownDocComment()),
+          java(
+            """
+              class Test {
+                  /**
+                   * <pre><code class='java'> // assertion will pass
+                   * assertThat("abc").contains("ab");</code></pre>
+                   */
+                  public void withErrorMessageForFields() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  /// ```java
+                  /// // assertion will pass
+                  /// assertThat("abc").contains("ab");
                   /// ```
                   public void withErrorMessageForFields() {
                   }


### PR DESCRIPTION
## What's changed?
Javadoc code tag is now converted correctly to Markdown.

## What's your motivation?
Converting AssertJ project from Javadoc to Markdown.

## Anything in particular you'd like reviewers to focus on?
Code style may be different - I can convert functional style to default if required.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Found none.

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
