### PR TITLE
Preserve significant trailing space in UseTextBlocks (#1132)

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -170,8 +170,14 @@ public class UseTextBlocks extends Recipe {
                 content = content.replace("\\", "\\\\");
                 // escape triple quotes
                 content = content.replace("\"\"\"", "\"\"\\\"");
-                // preserve trailing spaces
+                // preserve trailing spaces before a newline
                 content = content.replace(" \n", "\\s\n");
+                // preserve a trailing space on the final content line, which a text block would otherwise strip,
+                // silently changing the string's value
+                boolean endsWithTrailingSpace = content.endsWith(" ");
+                if (endsWithTrailingSpace) {
+                    content = content.substring(0, content.length() - 1) + "\\s";
+                }
                 // handle preceding indentation
                 content = content.replace("\n", "\n" + indentation);
                 // handle line continuations
@@ -181,8 +187,9 @@ public class UseTextBlocks extends Recipe {
                 content = "\n" + indentation + content;
 
                 // add last line to ensure the closing delimiter is in a new line to manage indentation & remove the
-                // need to escape ending quote in the content
-                if (isEndsWithSpecialCharacters(sb.toString())) {
+                // need to escape ending quote in the content. A trailing space additionally requires a line
+                // continuation so the closing delimiter does not introduce a spurious newline.
+                if (isEndsWithSpecialCharacters(sb.toString()) || endsWithTrailingSpace) {
                     content = content + "\\\n" + indentation;
                 }
 

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -130,7 +130,36 @@ class UseTextBlocksTest implements RewriteTest {
                       String query = \"""
                           SELECT * FROM   \\s
                           my_table   \\s
-                          WHERE something = 1; \""";
+                          WHERE something = 1;\\s\\
+                          \""";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1132")
+    void preserveTrailingSpaceOnLastLine() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                String message =
+                    "Connection failed:\\n"
+                        + " connect timed out\\n"
+                        + "Transfer id: ";
+              }
+              """,
+            """
+              class Test {
+                String message =
+                    \"""
+                    Connection failed:
+                     connect timed out
+                    Transfer id:\\s\\
+                    \""";
               }
               """
           )


### PR DESCRIPTION
- Fixes #1132

## Problem

When the last (or only) piece of content in a concatenation ends with a significant trailing space and no newline, `UseTextBlocks` placed the closing `"""` on the same line as that content:

```java
String message = """
    Connection failed:
     connect timed out
    Transfer id: """;
```

A text block strips trailing whitespace from every line *before* escape processing, so the space before the closing delimiter is removed. The runtime value silently changed from `...Transfer id: ` to `...Transfer id:` — no exception, compiles fine, easy to miss.

The recipe already handled trailing spaces *before a newline* via the ` \n` → `\s\n` replacement, but the trailing space on the final line (no following newline) fell through.

## Fix

When the joined content ends with a space, escape that trailing space as `\s` (which is interpreted *after* whitespace stripping) and add a `\` line continuation so the closing delimiter sits on its own line without introducing a spurious trailing newline:

```java
String message = """
    Connection failed:
     connect timed out
    Transfer id:\s\
    """;
```

This produces a value byte-for-byte identical to the original.

## Tests

- Added `preserveTrailingSpaceOnLastLine` reproducing the issue.
- Updated the existing `preserveTrailingWhiteSpaces` test, which previously asserted the buggy `WHERE something = 1; """` output that dropped the trailing space.