### PR TITLE
Bump maven-pmd-plugin to 3.28.x for Java 25 support

### DIFF
--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -213,6 +213,10 @@ recipeList:
       groupId: org.apache.maven.plugins
       artifactId: maven-failsafe-plugin
       newVersion: 3.5.x
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-pmd-plugin
+      newVersion: 3.28.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: net.bytebuddy
       artifactId: byte-buddy*

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
@@ -108,6 +108,11 @@ class UpgradeToJava25Test implements RewriteTest {
                                 <artifactId>maven-failsafe-plugin</artifactId>
                                 <version>2.22.2</version>
                             </plugin>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-pmd-plugin</artifactId>
+                                <version>3.21.0</version>
+                            </plugin>
                         </plugins>
                     </build>
                 </project>
@@ -118,6 +123,7 @@ class UpgradeToJava25Test implements RewriteTest {
                   .containsPattern("maven-compiler-plugin</artifactId>\\s*<version>3\\.15\\.")
                   .containsPattern("maven-surefire-plugin</artifactId>\\s*<version>3\\.5\\.")
                   .containsPattern("maven-failsafe-plugin</artifactId>\\s*<version>3\\.5\\.")
+                  .containsPattern("maven-pmd-plugin</artifactId>\\s*<version>3\\.28\\.")
                   .contains("<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>")
                   .actual())
             )


### PR DESCRIPTION
PMD 7.0 does not support parsing Java 25, while `maven-pmd-plugin` 3.28.0 ships PMD 7.17.0 which does. This adds an `UpgradePluginVersion` step to `UpgradePluginsForJava25` to bump `maven-pmd-plugin` to `3.28.x`, and extends `UpgradeToJava25Test.upgradesMavenPluginsForJava25` to cover it.