### PR TITLE
Preserve angle brackets when converting `@param <T>` to Markdown

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
@@ -409,12 +409,20 @@ public class JavadocToMarkdownDocComment extends Recipe {
             currentLine.append("@param");
             convert(param.getSpaceBeforeName());
             J name = param.getName();
-            if (name != null) {
-                currentLine.append(printJ(name));
+            if (name == null) {
+                Javadoc.Reference nameRef = param.getNameReference();
+                if (nameRef != null) {
+                    name = nameRef.getTree();
+                }
             }
-            Javadoc.Reference nameRef = param.getNameReference();
-            if (nameRef != null && nameRef.getTree() != null && name == null) {
-                currentLine.append(printJ(nameRef.getTree()));
+            if (name != null) {
+                if (name instanceof J.TypeParameter) {
+                    // Generic type parameters (e.g. `@param <T>`) are parsed as a J.TypeParameter
+                    // with the surrounding angle brackets stripped, so re-add them here.
+                    currentLine.append('<').append(printJ(name)).append('>');
+                } else {
+                    currentLine.append(printJ(name));
+                }
             }
             convert(param.getDescription());
         }

--- a/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
@@ -93,6 +93,34 @@ class JavadocToMarkdownDocCommentTest implements RewriteTest {
     }
 
     @Test
+    void genericTypeParameter() {
+        rewriteRun(
+          java(
+            """
+              public class A<T> {
+                  /**
+                   * A box.
+                   *
+                   * @param <T> the type of the contained value
+                   * @param value the value to store
+                   */
+                  public <U> void m(U value) {}
+              }
+              """,
+            """
+              public class A<T> {
+                  /// A box.
+                  ///
+                  /// @param <T> the type of the contained value
+                  /// @param value the value to store
+                  public <U> void m(U value) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void javadocWithCodeTag() {
         rewriteRun(
           java(


### PR DESCRIPTION
`JavadocToMarkdownDocComment` was dropping the angle brackets on generic type parameters, converting `@param <T>` into `/// @param T` instead of `/// @param <T>`. This happened because the Javadoc parser models a type-parameter name as a `J.TypeParameter` with the surrounding `<`/`>` stripped, and `printJ` rendered only the inner name. The fix detects a `J.TypeParameter` name in `convertParameter` and re-adds the angle brackets. A `genericTypeParameter` test covering both a type parameter and a regular parameter is included and passes.