### PR TITLE
Convert Javadoc `<br>` tags to Markdown line breaks

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocComment.java
@@ -128,6 +128,7 @@ public class JavadocToMarkdownDocComment extends Recipe {
         private final List<String> lines = new ArrayList<>();
         private StringBuilder currentLine = new StringBuilder();
         private boolean inPre = false;
+        private boolean suppressNextLineBreak = false;
         private final Deque<String> listStack = new ArrayDeque<>();
         private final Deque<Integer> listCounterStack = new ArrayDeque<>();
 
@@ -153,11 +154,17 @@ public class JavadocToMarkdownDocComment extends Recipe {
         }
 
         private void convertNode(Javadoc node) {
+            // A `<br>` already ended the current line; an immediately following physical
+            // line break is the same break, so don't let it add a spurious blank line.
+            boolean afterBr = suppressNextLineBreak;
+            suppressNextLineBreak = false;
             if (node instanceof Javadoc.Text) {
                 currentLine.append(decodeHtmlEntities(((Javadoc.Text) node).getText()));
             } else if (node instanceof Javadoc.LineBreak) {
-                lines.add(currentLine.toString());
-                currentLine = new StringBuilder();
+                if (!afterBr) {
+                    lines.add(currentLine.toString());
+                    currentLine = new StringBuilder();
+                }
             } else if (node instanceof Javadoc.Literal) {
                 convertLiteral((Javadoc.Literal) node);
             } else if (node instanceof Javadoc.Link) {
@@ -265,6 +272,15 @@ public class JavadocToMarkdownDocComment extends Recipe {
                     lines.add(currentLine.toString());
                     lines.add("");
                     currentLine = new StringBuilder();
+                    break;
+                case "br":
+                    // Line break: end the current line. Suppress the physical line break that
+                    // usually follows so the two collapse into a single break rather than a
+                    // blank line; a redundant break before a `<p>` is absorbed when blank lines
+                    // are collapsed.
+                    lines.add(currentLine.toString());
+                    currentLine = new StringBuilder();
+                    suppressNextLineBreak = true;
                     break;
                 case "em":
                 case "i":

--- a/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/JavadocToMarkdownDocCommentTest.java
@@ -165,6 +165,56 @@ class JavadocToMarkdownDocCommentTest implements RewriteTest {
     }
 
     @Test
+    void javadocWithLineBreakBeforeParagraph() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  /**
+                   * Verifies the value.<br>
+                   * <p>
+                   * More details.
+                   */
+                  public void m() {}
+              }
+              """,
+            """
+              public class A {
+                  /// Verifies the value.
+                  ///
+                  /// More details.
+                  public void m() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void javadocWithLineBreak() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  /**
+                   * First line.<br>
+                   * Second line.
+                   */
+                  public void m() {}
+              }
+              """,
+            """
+              public class A {
+                  /// First line.
+                  /// Second line.
+                  public void m() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void javadocWithEmphasis() {
         rewriteRun(
           java(


### PR DESCRIPTION
The `JavadocToMarkdownDocComment` recipe previously emitted `<br>` tags verbatim because they fell through to the default unknown-HTML-element case. This adds a `case "br"` that ends the current line, and a `suppressNextLineBreak` flag so a `<br>` at the end of a physical line collapses with the following line break instead of producing a spurious blank line (a redundant `<br>` before a `<p>` is absorbed by the existing blank-line collapsing). Two tests cover a `<br>` before a `<p>` and a mid-text `<br>` split across two `///` lines.