### PR TITLE
Don't rewrite non-JDK `Optional` in OptionalNot{Present,Empty} recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresent.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresent.java
@@ -49,6 +49,21 @@ public class OptionalNotEmptyToIsPresent extends Recipe {
                 new UsesMethod<>(optionalIsPresentMatcher));
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
+            public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                // A type whose method invocations are misattributed to `java.util.Optional` (e.g. when a
+                // third-party `Optional` is off the recipe classpath) can fool the `MethodMatcher`, producing
+                // an uncompilable `isPresent()` call. Skip the file when the simple name `Optional` is bound to
+                // some other explicitly imported type.
+                for (J.Import anImport : cu.getImports()) {
+                    if (!anImport.isStatic() && "Optional".equals(anImport.getClassName()) &&
+                            !"java.util.Optional".equals(anImport.getTypeName())) {
+                        return cu;
+                    }
+                }
+                return super.visitCompilationUnit(cu, ctx);
+            }
+
+            @Override
             public J visitStatement(Statement s, ExecutionContext ctx) {
                 if (s instanceof J.Unary) {
                     J.Unary unary = (J.Unary) s;

--- a/src/main/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmpty.java
@@ -49,6 +49,21 @@ public class OptionalNotPresentToIsEmpty extends Recipe {
                 new UsesMethod<>(optionalIsPresentMatcher));
         return Preconditions.check(check, new JavaVisitor<ExecutionContext>() {
             @Override
+            public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                // A type whose method invocations are misattributed to `java.util.Optional` (e.g. when a
+                // third-party `Optional` is off the recipe classpath) can fool the `MethodMatcher`, producing
+                // an uncompilable `isEmpty()` call. Skip the file when the simple name `Optional` is bound to
+                // some other explicitly imported type.
+                for (J.Import anImport : cu.getImports()) {
+                    if (!anImport.isStatic() && "Optional".equals(anImport.getClassName()) &&
+                            !"java.util.Optional".equals(anImport.getTypeName())) {
+                        return cu;
+                    }
+                }
+                return super.visitCompilationUnit(cu, ctx);
+            }
+
+            @Override
             public J visitStatement(Statement s, ExecutionContext ctx) {
                 if (s instanceof J.Unary) {
                     J.Unary unary = (J.Unary) s;

--- a/src/test/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresentTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/OptionalNotEmptyToIsPresentTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
@@ -56,6 +57,32 @@ class OptionalNotEmptyToIsPresentTest implements RewriteTest {
                 class App {
                     boolean notEmpty(Optional<String> bar){
                         return bar.isPresent();
+                    }
+                }
+                """
+            ),
+            11
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNonJdkOptionalMisattributedToJdk() {
+        // When a third-party `Optional` is off the recipe classpath, `bar.isEmpty()` can be misattributed
+        // to `java.util.Optional` (here via the `java.util.*` import), which would otherwise fool the
+        // `MethodMatcher` into emitting an uncompilable `isPresent()` call. See issue #1146.
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          version(
+            java(
+              """
+                package com.example.app;
+                import java.util.*;
+                import com.bazaarvoice.jolt.common.Optional;
+                class App {
+                    boolean notEmpty(Optional<String> bar){
+                        return !bar.isEmpty();
                     }
                 }
                 """

--- a/src/test/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/OptionalNotPresentToIsEmptyTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
@@ -32,6 +33,64 @@ class OptionalNotPresentToIsEmptyTest implements RewriteTest {
         spec
           .recipe(new OptionalNotPresentToIsEmpty())
           .parser(JavaParser.fromJavaVersion());
+    }
+
+    @Test
+    void doNotChangeNonJdkOptionalMisattributedToJdk() {
+        // When a third-party `Optional` is off the recipe classpath, `bar.isPresent()` can be misattributed
+        // to `java.util.Optional` (here via the `java.util.*` import), which would otherwise fool the
+        // `MethodMatcher` into emitting an uncompilable `isEmpty()` call. See issue #1146.
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          version(
+            java(
+              """
+                package com.example.app;
+                import java.util.*;
+                import com.bazaarvoice.jolt.common.Optional;
+                class App {
+                    boolean notPresent(Optional<String> bar){
+                        return !bar.isPresent();
+                    }
+                }
+                """
+            ),
+            11
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNonJdkOptional() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                package com.bazaarvoice.jolt.common;
+                public class Optional<T> {
+                    public boolean isPresent() { return true; }
+                }
+                """
+            ),
+            11
+          ),
+          version(
+            java(
+              """
+                package com.example.app;
+                import com.bazaarvoice.jolt.common.Optional;
+                class App {
+                    boolean notPresent(Optional<String> bar){
+                        return !bar.isPresent();
+                    }
+                }
+                """
+            ),
+            11
+          )
+        );
     }
 
     @DocumentExample


### PR DESCRIPTION
## What's changed?

`OptionalNotPresentToIsEmpty` and `OptionalNotEmptyToIsPresent` now skip a source file when the simple name `Optional` is bound to an explicitly imported type other than `java.util.Optional`.

## Why?

- Fixes #1146.

When a third-party `Optional` (e.g. `com.bazaarvoice.jolt.common.Optional`, which has `isPresent()` but no `isEmpty()`) is off the recipe's typed classpath, javac can misattribute `bar.isPresent()` to `java.util.Optional` — for instance when a `java.util.*` import is in scope. The `MethodMatcher` (`java.util.Optional isPresent()`) then matches and the recipe rewrites the call to `isEmpty()`, which does not exist on the third-party type, so the module no longer compiles.

Because the type information is uniformly (mis)attributed to `java.util.Optional` in this scenario, a type-based guard on the receiver can't distinguish the cases. The reliable signal is the source itself: if the file explicitly imports a non-JDK type named `Optional`, the bare `Optional` name cannot be `java.util.Optional`, so the recipe conservatively leaves the file untouched.

The sibling `OptionalNotEmptyToIsPresent` has the identical structure and the same failure mode, so it gets the same guard.

## Tests

Added `doNotChangeNonJdkOptionalMisattributedToJdk` to both recipe test classes. Both reproduce the misfire (they fail on `main` and pass with this change). A test covering a fully-resolved third-party `Optional` is also added.