### PR TITLE
Skip `UseMapOf` when the anonymous `HashMap` is assigned to a concrete `HashMap` variable

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -111,6 +111,12 @@ public class UseMapOf extends Recipe {
                                 TypeUtils.isOfClassType(n.getClazz() != null ? n.getClazz().getType() : null, "java.util.HashMap")) {
                             Statement statement = body.getStatements().get(0);
                             if (statement instanceof J.Block) {
+                                // Skip when the result is assigned to a concrete `HashMap` declared type rather
+                                // than `Map`: the immutable `Map.of(..)` is not assignable to `HashMap`, and
+                                // `HashMap`-only methods may be invoked on the variable later (issue #1148).
+                                if (isAssignedToConcreteHashMap()) {
+                                    return n;
+                                }
                                 List<Statement> putStatements = ((J.Block) statement).getStatements();
                                 List<Expression> args = new ArrayList<>();
                                 boolean useEntries = putStatements.size() > 10;
@@ -192,6 +198,19 @@ public class UseMapOf extends Recipe {
                             withPrefixes.add(arg);
                         }
                         return nc.withArguments(Collections.singletonList(mapCall.withArguments(withPrefixes)));
+                    }
+
+                    /**
+                     * Returns {@code true} when the {@code new HashMap<>() {{ ... }}} currently being visited is
+                     * the initializer of a variable whose declared type is the concrete {@code java.util.HashMap}
+                     * rather than the {@code Map} interface. In that case the immutable {@code Map.of(..)} result
+                     * would not be assignable, and {@code HashMap}-specific methods may be used later, so the
+                     * rewrite is skipped (issue #1148).
+                     */
+                    private boolean isAssignedToConcreteHashMap() {
+                        Object parent = getCursor().getParentTreeCursor().getValue();
+                        return parent instanceof J.VariableDeclarations.NamedVariable &&
+                                TypeUtils.isOfClassType(((J.VariableDeclarations.NamedVariable) parent).getType(), "java.util.HashMap");
                     }
 
                     @Override

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -205,6 +205,48 @@ class UseMapOfTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1148")
+    @Test
+    void doNotChangeConcreteHashMapField() {
+        //language=java
+        rewriteRun(
+          spec -> spec.allSources(s -> s.markers(javaVersion(25))),
+          java(
+            """
+              import java.util.HashMap;
+
+              class Main {
+                  private static final HashMap<String, String> VALUES = new HashMap<String, String>() {{
+                      put("key", "value");
+                  }};
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1148")
+    @Test
+    void doNotChangeConcreteHashMapLocalVariable() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.HashMap;
+
+              class Main {
+                  void m() {
+                      HashMap<String, Integer> ages = new HashMap<>() {{
+                          put("Bob", 42);
+                          put("alice", 30);
+                      }};
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1112")
     @Test
     void doNotChangeLinkedHashMap() {


### PR DESCRIPTION
Fixes #1148

### Problem

For the anonymous-class form, `UseMapOf` replaced `new HashMap<>() {{ put(..); }}` with an immutable `Map.of(..)` but left the declared type untouched. When the variable was declared with the concrete type `HashMap` (rather than the `Map` interface), the result no longer compiled, since `Map.of(..)` returns an immutable `java.util.Map` that is not assignable to a `HashMap` variable:

```java
private static final HashMap<String, String> VALUES = new HashMap<>() {{ put("key", "value"); }};
// became uncompilable:
private static final HashMap<String, String> VALUES = Map.of("key", "value");
```

### Fix

Skip the anonymous-class rewrite when its result is assigned to a variable whose declared type is the concrete `HashMap` rather than the `Map` interface (option 2 in the issue). Beyond the assignability problem, widening the declared type to `Map` would also risk breaking later calls to `HashMap`-specific methods, so leaving such declarations untouched is the safer behaviour.

The guard checks the enclosing variable's declared type straight off the `NamedVariable`:

```java
private boolean isAssignedToConcreteHashMap() {
    Object parent = getCursor().getParentTreeCursor().getValue();
    return parent instanceof J.VariableDeclarations.NamedVariable &&
            TypeUtils.isOfClassType(((J.VariableDeclarations.NamedVariable) parent).getType(), "java.util.HashMap");
}
```

The common cases — assigning to a `Map`-typed variable, returning, or using the value inline — are unaffected and still rewrite to `Map.of(..)`. The mutable prose form (`new HashMap<>(); x.put(..)` → `new HashMap<>(Map.of(..))`) already stays a `HashMap` and so was never affected.

### Tests

Added field and local-variable cases asserting that a concrete `HashMap` declaration is left unchanged (the field case mirrors the issue's reproducer with `javaVersion(25)`). Existing tests — including the `Map`-interface, `LinkedHashMap`/`TreeMap`, null-bail, and prose-form cases — continue to pass.