### PR TITLE
Fix jakarta.enterprise.concurrent-api version for EE9 and EE10

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-10.yml
@@ -99,6 +99,10 @@ recipeList:
       artifactId: jakarta.enterprise.cdi-api
       newVersion: 4.0.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: jakarta.enterprise.concurrent
+      artifactId: jakarta.enterprise.concurrent-api
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.el
       artifactId: jakarta.el-api
       newVersion: 5.0.x

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -439,6 +439,7 @@ recipeList:
       oldArtifactId: javax.enterprise.concurrent-api
       newGroupId: jakarta.enterprise.concurrent
       newArtifactId: jakarta.enterprise.concurrent-api
+      newVersion: 2.0.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.enterprise.concurrent
       artifactId: jakarta.enterprise.concurrent-api

--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -442,7 +442,7 @@ recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: jakarta.enterprise.concurrent
       artifactId: jakarta.enterprise.concurrent-api
-      newVersion: 3.0.x
+      newVersion: 2.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: javax.enterprise
       oldArtifactId: cdi-api


### PR DESCRIPTION
Source:
EE 9: https://github.com/jakartaee/jakartaee-api/blob/9.1.0/pom.xml#L72

EE 10: https://github.com/jakartaee/jakartaee-api/blob/10.0.0/pom.xml#L77