### PR TITLE
Fix Jakarta EE 10 web.xml migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
@@ -197,6 +197,8 @@ tags:
   - faces
   - jsf
 preconditions:
+  - org.openrewrite.FindSourceFiles:
+      filePattern: '**/web.xml'
   - org.openrewrite.Singleton
 recipeList:
   - org.openrewrite.xml.ChangeTagAttribute:
@@ -215,14 +217,16 @@ recipeList:
       oldValue: (?s).*xml/ns/javaee.*
       newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd
       regex: true
-  - org.openrewrite.text.FindAndReplace:
-      find: "javax."
-      replace: "jakarta."
-      filePattern: '**/web.xml'
-  - org.openrewrite.text.FindAndReplace:
-      find: "jakarta.sql."
-      replace: "javax.sql."
-      filePattern: '**/web.xml'
+  - org.openrewrite.xml.ChangeTagValue:
+      elementName: //*
+      oldValue: "javax\\."
+      newValue: "jakarta."
+      regex: true
+  - org.openrewrite.xml.ChangeTagValue:
+      elementName: //*
+      oldValue: "jakarta\\.sql\\."
+      newValue: "javax.sql."
+      regex: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.migrate.jakarta.JakartaFacesEcmaScript

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxWebXmlToJakartaWebXmlTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxWebXmlToJakartaWebXmlTest.java
@@ -179,6 +179,43 @@ class JavaxWebXmlToJakartaWebXmlTest implements RewriteTest {
         );
     }
 
+    @Test
+    void jakartaEE10UpdatesWebXmlToVersion6AfterJavaxReplacement() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.migrate.jakarta.JakartaEE10"),
+          //language=xml
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+              <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+                       version="4.0">
+                  <display-name>example-project</display-name>
+                  <context-param>
+                      <param-name>javax.faces.PROJECT_STAGE</param-name>
+                      <param-value>Production</param-value>
+                  </context-param>
+              </web-app>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+              <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+                       version="6.0">
+                  <display-name>example-project</display-name>
+                  <context-param>
+                      <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+                      <param-value>Production</param-value>
+                  </context-param>
+              </web-app>
+              """,
+            sourceSpecs -> sourceSpecs.path("src/main/webapp/WEB-INF/web.xml")
+          )
+        );
+    }
+
     @Nested
     class NoChanges {
         @Test


### PR DESCRIPTION
- Fixes openrewrite/rewrite#7471.

Replaces the plain text `FindAndReplace` steps for `web.xml` with XML-aware `ChangeTagValue` steps so `web.xml` remains an XML LST. This allows the later `JakartaWebXml6` recipe in the `JakartaEE10` chain to update `web.xml` from version `5.0` to `6.0`.

Adds a regression test for the `JakartaEE10` chain.

Verified:
- `./gradlew test --tests "org.openrewrite.java.migrate.jakarta.JavaxWebXmlToJakartaWebXmlTest"`
- `./gradlew test --tests "org.openrewrite.java.migrate.jakarta.JakartaEE10Test"`