### PR TITLE
Keep `\t` and `\f` escapes in UseTextBlocks to avoid incidental whitespace stripping

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/UseTextBlocks.java
@@ -168,6 +168,11 @@ public class UseTextBlocks extends Recipe {
                 content = sb.toString();
                 // escape backslashes
                 content = content.replace("\\", "\\\\");
+                // re-escape tab and form feed characters as escape sequences. A literal tab or form feed is
+                // indistinguishable from incidental leading whitespace, so javac may strip it during text block
+                // whitespace processing (JLS 3.10.6), silently changing the string's value.
+                content = content.replace("\t", "\\t");
+                content = content.replace("\f", "\\f");
                 // escape triple quotes
                 content = content.replace("\"\"\"", "\"\"\\\"");
                 // preserve trailing spaces before a newline

--- a/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/UseTextBlocksTest.java
@@ -560,6 +560,54 @@ class UseTextBlocksTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1158")
+    @Test
+    void keepTabEscapeToAvoidIncidentalWhitespaceStripping() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Main {
+                  String s =
+                      ""
+                          + "\\tb";
+              }
+              """,
+            """
+              class Main {
+                  String s =
+                      \"""
+                      \\tb\""";
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1158")
+    @Test
+    void keepFormFeedEscapeToAvoidIncidentalWhitespaceStripping() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Main {
+                  String s =
+                      ""
+                          + "\\fb";
+              }
+              """,
+            """
+              class Main {
+                  String s =
+                      \"""
+                      \\fb\""";
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/195")
     @Test
     void newlinesAlignment() {


### PR DESCRIPTION
## What's changed

`UseTextBlocks` decodes each concatenated string literal to its value before emitting text-block content, which turns escape sequences like `\t` and `\f` into literal tab/form-feed characters. When such a literal ends up on a content line's leading edge, `javac` cannot distinguish it from incidental leading whitespace and strips it during text-block whitespace processing (JLS 3.10.6) — silently changing the string's value (e.g. `"\tb"` compiles to `"b"`).

This re-escapes tab and form-feed characters back to `\t` / `\f` escape sequences when generating text-block content, right after backslash escaping so the introduced backslashes aren't doubled. Indentation added later is unaffected.

## Testing

Added `keepTabEscapeToAvoidIncidentalWhitespaceStripping` and `keepFormFeedEscapeToAvoidIncidentalWhitespaceStripping`, matching the reproduction in the issue. Full `UseTextBlocksTest` suite passes.

- Fixes #1158