### PR TITLE
Skip UseEnumSetOf empty conversion for static fields to avoid circular class-init (#1157)

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
@@ -78,6 +78,14 @@ public class UseEnumSetOf extends Recipe {
                             }
 
                             if (args.get(0) instanceof J.Empty) {
+                                // Skip the empty `Set.of()` -> `EnumSet.noneOf(E.class)` conversion for static
+                                // field initializers: `EnumSet.noneOf` reflectively reads the enum's constants
+                                // during class initialization, which can re-enter a not-yet-initialized enum and
+                                // throw a misleading `ClassCastException` when two enums have a circular static
+                                // dependency (issue #1157).
+                                if (isStaticField(parent)) {
+                                    return mi;
+                                }
                                 JavaType firstTypeParameter = ((JavaType.Parameterized) type).getTypeParameters().get(0);
                                 JavaType.ShallowClass shallowClass = JavaType.ShallowClass.build(firstTypeParameter.toString());
                                 return JavaTemplate.builder("EnumSet.noneOf(" + shallowClass.getClassName() + ".class)")
@@ -118,6 +126,11 @@ public class UseEnumSetOf extends Recipe {
                     }
                 }
                 return false;
+            }
+
+            private boolean isStaticField(Cursor parent) {
+                return parent.getValue() instanceof J.VariableDeclarations &&
+                        ((J.VariableDeclarations) parent.getValue()).hasModifier(J.Modifier.Type.Static);
             }
 
             private boolean isArrayParameter(final List<Expression> args) {

--- a/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseEnumSetOf.java
@@ -78,11 +78,6 @@ public class UseEnumSetOf extends Recipe {
                             }
 
                             if (args.get(0) instanceof J.Empty) {
-                                // Skip the empty `Set.of()` -> `EnumSet.noneOf(E.class)` conversion for static
-                                // field initializers: `EnumSet.noneOf` reflectively reads the enum's constants
-                                // during class initialization, which can re-enter a not-yet-initialized enum and
-                                // throw a misleading `ClassCastException` when two enums have a circular static
-                                // dependency (issue #1157).
                                 if (isStaticField(parent)) {
                                     return mi;
                                 }

--- a/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseEnumSetOfTest.java
@@ -182,6 +182,45 @@ class UseEnumSetOfTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1157")
+    @Test
+    void dontConvertEmptySetOfInStaticField() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package com.helloworld;
+
+              import java.util.Set;
+
+              public enum ConfigType {
+                ENUM,
+                BOOLEAN,
+                INTEGER;
+
+                public static final Set<ConfigProperty> SUBSCRIBE_TO_ALL = Set.<ConfigProperty>of();
+              }
+              """,
+            spec -> spec.markers(javaVersion(25))),
+          java(
+            """
+              package com.helloworld;
+
+              import static com.helloworld.ConfigType.BOOLEAN;
+              import static com.helloworld.ConfigType.ENUM;
+              import static com.helloworld.ConfigType.INTEGER;
+
+              public enum ConfigProperty {
+                TRIAL_TYPE(ENUM),
+                IS_TRIAL_ENABLED(BOOLEAN),
+                MIN_ACCOUNT_AGE_MINUTES(INTEGER);
+
+                ConfigProperty(final ConfigType type) {}
+              }
+              """,
+            spec -> spec.markers(javaVersion(25))));
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/958")
     @Test
     void retainEmptySetOf() {


### PR DESCRIPTION
- Fixes #1157

`UseEnumSetOf` rewrites an empty `Set.of()` to `EnumSet.noneOf(E.class)`. In a **static field initializer**, `EnumSet.noneOf` reflectively reads `E`'s constants during class initialization. When two enums have a circular static dependency (one enum's constants carry a value from a sibling enum that also holds an `EnumSet.noneOf(...)` static field), this can re-enter a not-yet-initialized enum and throw a misleading `ClassCastException("... not an enum")` at runtime — even though the code compiles cleanly.

## Fix

Skip the empty `Set.of()` → `EnumSet.noneOf(E.class)` conversion when the assignment target is a **static field**. Static field initializers run during `<clinit>`, which is the only place the re-entrant class-init hazard exists; local variables and instance fields are unaffected and still convert (e.g. the existing `dontHaveArgs` test). The non-empty `Set.of(E.X, ...)` case is untouched since it does not use the reflective `noneOf` path.

- This mirrors the approach of #1148 (skip when the assignment target is a concrete `HashMap`).