### PR TITLE
feat(migrate): support return statements in IfElseIfConstructToSwitch recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitch.java
@@ -37,7 +37,6 @@ import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -167,11 +166,6 @@ public class IfElseIfConstructToSwitch extends Recipe {
             if (patternMatchers.keySet().stream().anyMatch(instanceOf -> instanceOf.getPattern() == null)) {
                 return false;
             }
-            // The blocks cannot do a return as that would lead to all blocks having to do a return,
-            // the block/expression difference in return for switch statements / expressions being different...
-            if (returns(nullCheckedStatement) || patternMatchers.values().stream().anyMatch(this::returns) || returns(else_)) {
-                return false;
-            }
             // Do no harm -> If we do not know how to replace(yet), do not replace
             if (patternMatchers.keySet().stream().anyMatch(instanceOf -> {
                 J clazz = instanceOf.getClazz();
@@ -188,15 +182,6 @@ public class IfElseIfConstructToSwitch extends Recipe {
                     (hasLastElseBlock ? 1 : 0);
         }
 
-        private boolean returns(@Nullable Statement statement) {
-            return statement != null && new JavaIsoVisitor<AtomicBoolean>() {
-                @Override
-                public J.Return visitReturn(J.Return return_, AtomicBoolean atomicBoolean) {
-                    atomicBoolean.set(true);
-                    return return_;
-                }
-            }.reduce(statement, new AtomicBoolean(false)).get();
-        }
 
         public J.@Nullable Switch buildSwitchTemplate() {
             Optional<Expression> switchOn = switchOn();
@@ -208,22 +193,39 @@ public class IfElseIfConstructToSwitch extends Recipe {
             StringBuilder switchBody = new StringBuilder("switch (#{any()}) {\n");
             int i = 1;
             if (nullCheckedParameter != null) {
-                switchBody.append("case null -> #{any()};\n");
-                arguments[i++] = getStatement(Objects.requireNonNull(nullCheckedStatement));
+                Statement nullStmt = getStatement(Objects.requireNonNull(nullCheckedStatement));
+                if (nullStmt instanceof J.Return) {
+                    switchBody.append("case null -> {#{any()};}\n");
+                } else {
+                    switchBody.append("case null -> #{any()};\n");
+                }
+                arguments[i++] = nullStmt;
             }
             for (Map.Entry<J.InstanceOf, Statement> entry : patternMatchers.entrySet()) {
                 J.InstanceOf instanceOf = entry.getKey();
-                switchBody.append("case #{}#{} -> #{any()};\n");
+                Statement patternStmt = getStatement(entry.getValue());
+                if (patternStmt instanceof J.Return) {
+                    switchBody.append("case #{}#{} -> {#{any()};}\n");
+                } else {
+                    switchBody.append("case #{}#{} -> #{any()};\n");
+                }
                 arguments[i++] = getClassName(instanceOf);
                 arguments[i++] = getPattern(instanceOf);
-                arguments[i++] = getStatement(entry.getValue());
+                arguments[i++] = patternStmt;
             }
-            switchBody.append(nullCheckedParameter != null ? "default" : "case null, default").append(" -> #{any()};\n");
+            Statement defaultStmt;
             if (else_ != null) {
-                arguments[i] = getStatement(else_);
+                defaultStmt = getStatement(else_);
             } else {
-                arguments[i] = createEmptyBlock();
+                defaultStmt = createEmptyBlock();
             }
+            String defaultPrefix = nullCheckedParameter != null ? "default" : "case null, default";
+            if (defaultStmt instanceof J.Return) {
+                switchBody.append(defaultPrefix).append(" -> {#{any()};}\n");
+            } else {
+                switchBody.append(defaultPrefix).append(" -> #{any()};\n");
+            }
+            arguments[i] = defaultStmt;
             switchBody.append("}\n");
 
             J.Switch result = JavaTemplate.apply(switchBody.toString(), cursor, if_.getCoordinates().replace(), arguments).withPrefix(if_.getPrefix());

--- a/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/IfElseIfConstructToSwitchTest.java
@@ -846,63 +846,9 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
             );
         }
 
-        @Test
-        void noSwitchBlockWhenNullBlockReturns() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  class Test {
-                      static String formatter(Object obj) {
-                          String formatted = "initialValue";
-                          if (obj == null) {
-                              return "null";
-                          } else if (obj instanceof Integer i)
-                              formatted = String.format("int %d", i);
-                          else if (obj instanceof Long l) {
-                              formatted = String.format("long %d", l);
-                          } else if (obj instanceof Double d) {
-                              formatted = String.format("double %f", d);
-                          } else if (obj instanceof String s) {
-                              String str = "String";
-                              formatted = String.format("%s %s", str, s);
-                          }
-                          return formatted;
-                      }
-                  }
-                  """
-              )
-            );
-        }
 
-        @Test
-        void noSwitchBlockWhenInstanceOfBlockReturns() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  class Test {
-                      static String formatter(Object obj) {
-                          String formatted = "initialValue";
-                          if (obj == null) {
-                              formatted = "null";
-                          } else if (obj instanceof Integer i)
-                              return String.format("int %d", i);
-                          else if (obj instanceof Long l) {
-                              formatted = String.format("long %d", l);
-                          } else if (obj instanceof Double d) {
-                              formatted = String.format("double %f", d);
-                          } else if (obj instanceof String s) {
-                              String str = "String";
-                              formatted = String.format("%s %s", str, s);
-                          }
-                          return formatted;
-                      }
-                  }
-                  """
-              )
-            );
-        }
+
+
 
         @Test
         void noSwitchBlockWithTrailingNonEqualsBinaryCheck() {
@@ -930,36 +876,7 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
             );
         }
 
-        @Test
-        void noSwitchBlockWhenElseBlockReturns() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  class Test {
-                      static String formatter(Object obj) {
-                          String formatted = "initialValue";
-                          if (obj == null) {
-                              formatted = "null";
-                          } else if (obj instanceof Integer i)
-                              formatted = String.format("int %d", i);
-                          else if (obj instanceof Long l) {
-                              formatted = String.format("long %d", l);
-                          } else if (obj instanceof Double d) {
-                              formatted = String.format("double %f", d);
-                          } else if (obj instanceof String s) {
-                              String str = "String";
-                              formatted = String.format("%s %s", str, s);
-                          } else {
-                              return "Unknown test result";
-                          }
-                          return formatted;
-                      }
-                  }
-                  """
-              )
-            );
-        }
+
     }
 
     @Test
@@ -1141,5 +1058,293 @@ class IfElseIfConstructToSwitchTest implements RewriteTest {
               )
             );
         }
+    }
+
+    @Test
+    void switchBlockWhenNullBlockReturns() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      if (obj == null) {
+                          return "null";
+                      } else if (obj instanceof Integer i)
+                          formatted = String.format("int %d", i);
+                      else if (obj instanceof Long l) {
+                          formatted = String.format("long %d", l);
+                      } else if (obj instanceof Double d) {
+                          formatted = String.format("double %f", d);
+                      } else if (obj instanceof String s) {
+                          String str = "String";
+                          formatted = String.format("%s %s", str, s);
+                      }
+                      return formatted;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case null -> {
+                              return "null";
+                          }
+                          case Integer i -> formatted = String.format("int %d", i);
+                          case Long l -> formatted = String.format("long %d", l);
+                          case Double d -> formatted = String.format("double %f", d);
+                          case String s -> {
+                              String str = "String";
+                              formatted = String.format("%s %s", str, s);
+                          }
+                          default -> {}
+                      }
+                      return formatted;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void switchBlockWhenInstanceOfBlockReturns() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      if (obj == null) {
+                          formatted = "null";
+                      } else if (obj instanceof Integer i)
+                          return String.format("int %d", i);
+                      else if (obj instanceof Long l) {
+                          formatted = String.format("long %d", l);
+                      } else if (obj instanceof Double d) {
+                          formatted = String.format("double %f", d);
+                      } else if (obj instanceof String s) {
+                          String str = "String";
+                          formatted = String.format("%s %s", str, s);
+                      }
+                      return formatted;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case null -> formatted = "null";
+                          case Integer i -> {
+                              return String.format("int %d", i);
+                          }
+                          case Long l -> formatted = String.format("long %d", l);
+                          case Double d -> formatted = String.format("double %f", d);
+                          case String s -> {
+                              String str = "String";
+                              formatted = String.format("%s %s", str, s);
+                          }
+                          default -> {}
+                      }
+                      return formatted;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void switchBlockWhenElseBlockReturns() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      if (obj == null) {
+                          formatted = "null";
+                      } else if (obj instanceof Integer i)
+                          formatted = String.format("int %d", i);
+                      else if (obj instanceof Long l) {
+                          formatted = String.format("long %d", l);
+                      } else if (obj instanceof Double d) {
+                          formatted = String.format("double %f", d);
+                      } else if (obj instanceof String s) {
+                          String str = "String";
+                          formatted = String.format("%s %s", str, s);
+                      } else {
+                          return "Unknown test result";
+                      }
+                      return formatted;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case null -> formatted = "null";
+                          case Integer i -> formatted = String.format("int %d", i);
+                          case Long l -> formatted = String.format("long %d", l);
+                          case Double d -> formatted = String.format("double %f", d);
+                          case String s -> {
+                              String str = "String";
+                              formatted = String.format("%s %s", str, s);
+                          }
+                          default -> {
+                              return "Unknown test result";
+                          }
+                      }
+                      return formatted;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void switchBlockWithBracelessReturns() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      if (obj == null)
+                          return "null";
+                      else if (obj instanceof Integer i)
+                          return String.format("int %d", i);
+                      else if (obj instanceof Long l)
+                          return String.format("long %d", l);
+                      else
+                          return "unknown";
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      switch (obj) {
+                          case null -> {
+                              return "null";
+                          }
+                          case Integer i -> {
+                              return String.format("int %d", i);
+                          }
+                          case Long l -> {
+                              return String.format("long %d", l);
+                          }
+                          default -> {
+                              return "unknown";
+                          }
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void switchBlockWithMixedReturnBranches() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      if (obj == null)
+                          return "null";
+                      else if (obj instanceof Integer i)
+                          formatted = String.format("int %d", i);
+                      else if (obj instanceof Long l)
+                          return String.format("long %d", l);
+                      else
+                          formatted = "unknown";
+                      return formatted;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static String formatter(Object obj) {
+                      String formatted = "initialValue";
+                      switch (obj) {
+                          case null -> {
+                              return "null";
+                          }
+                          case Integer i -> formatted = String.format("int %d", i);
+                          case Long l -> {
+                              return String.format("long %d", l);
+                          }
+                          default -> formatted = "unknown";
+                      }
+                      return formatted;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void switchBlockWithNestedReturnsInLoopOrLambda() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  static void process(Object obj, List<String> list) {
+                      if (obj == null) {
+                          list.forEach(s -> {
+                              if (s.isEmpty()) return;
+                              System.out.println(s);
+                          });
+                      } else if (obj instanceof Integer i) {
+                          for (int j = 0; j < i; j++) {
+                              if (j == 5) return;
+                              System.out.println(j);
+                          }
+                      } else if (obj instanceof Long l) {
+                          System.out.println(l);
+                      }
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              class Test {
+                  static void process(Object obj, List<String> list) {
+                      switch (obj) {
+                          case null -> list.forEach(s -> {
+                              if (s.isEmpty()) return;
+                              System.out.println(s);
+                          });
+                          case Integer i -> {
+                              for (int j = 0; j < i; j++) {
+                                  if (j == 5) return;
+                                  System.out.println(j);
+                              }
+                          }
+                          case Long l -> System.out.println(l);
+                          default -> {}
+                      }
+                  }
+              }
+              """
+          )
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Allows converting if-else-if chains containing return statements to switch statements.
* Removed the blanket `returns(...)` guard in `validatePotentialCandidate()` within `IfElseIfConstructToSwitch.java`.
* Updated `buildSwitchTemplate()` to check if the branch statement is a bare `J.Return`. If so, it wraps it in block braces at the template-compilation level (`case X -> {#{any()};}`).
* Updated the existing return-related tests in `IfElseIfConstructToSwitchTest.java` to expect successful switch conversions, and added new tests to cover mixed branches, braceless return chains, and nested returns.

## What's your motivation?
- Closes #776

## Anything in particular you'd like reviewers to focus on?
* The template compilation logic using `{#{any()};}` to ensure the mock code parsed in `JavaTemplate` is valid while avoiding double semicolons during replacement.
* The test cases covering nested returns (e.g. returns inside lambda loops) to ensure they are preserved correctly.

## Anyone you would like to review specifically?


## Have you considered any alternatives or workarounds?
An alternative would have been to manually synthesize `J.Block` AST nodes in the visitor before applying `JavaTemplate`. However, wrapping the raw return in explicit braces at the template-string level is much cleaner and less error-prone.

## Any additional context


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files