### PR TITLE
Skip `UseMapOf` for `LinkedHashMap`/`TreeMap` in the prose `put()` form (#1163)

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -302,6 +302,12 @@ public class UseMapOf extends Recipe {
                         if (!NEW_HASH_MAP.matches(nc)) {
                             return null;
                         }
+                        // Skip `HashMap` subclasses like `LinkedHashMap`/`TreeMap`: `Map.of(..)` makes no
+                        // iteration-order guarantee, so absorbing their `put(..)` chain would silently drop
+                        // the ordering contract the original code relied on (issue #1163, matching #1113).
+                        if (!TypeUtils.isOfClassType(nc.getClazz() != null ? nc.getClazz().getType() : null, "java.util.HashMap")) {
+                            return null;
+                        }
                         if (nc.getBody() != null) {
                             return null;
                         }

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -290,6 +290,30 @@ class UseMapOfTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1163")
+    @Test
+    void doNotChangeLinkedHashMapBuiltWithPutStatements() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.LinkedHashMap;
+              import java.util.Map;
+
+              class Test {
+                  static Map<String, String> ordered() {
+                      Map<String, String> m = new LinkedHashMap<>();
+                      m.put("a", "1");
+                      m.put("b", "2");
+                      m.put("c", "3");
+                      return m;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/566")
     @Test
     void changeDoubleBraceInitForNonStringTypes() {


### PR DESCRIPTION
- Fixes #1163

- `UseMapOf` recognizes two input shapes: the anonymous-class (double-brace) initializer and a `new HashMap<>()` declaration followed by a chain of `put(..)` statements. #1113 taught the anonymous-class path to skip `HashMap` subclasses like `LinkedHashMap`/`TreeMap` — since `Map.of(..)` makes no iteration-order guarantee, converting an order-sensitive map silently drops its ordering contract.

The prose/statement path missed the same guard. `NEW_HASH_MAP` is built with `matchOverrides=true`, so `NEW_HASH_MAP.matches(new LinkedHashMap<>())` is `true`, and the chain was still collapsed into `new HashMap<>(Map.of(..))` — dropping insertion order and swapping the `LinkedHashMap` import for `HashMap`.

`matchingTargetName` now applies the same exact-type check used by the anonymous-class path (`TypeUtils.isOfClassType(..., "java.util.HashMap")`), so only an exact `HashMap` declaration is absorbed.

Added a regression test mirroring the issue's reproduction.