### PR TITLE
Skip AddMockitoJavaAgentToMavenSurefirePlugin when agent already configured in build/plugins

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.migrate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -102,11 +103,36 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
                 }
             }
 
+            private @Nullable String surefireArgLineWithAgent(List<Plugin> plugins) {
+                return plugins.stream()
+                        .filter(plugin -> "org.apache.maven.plugins".equals(plugin.getGroupId()) &&
+                                "maven-surefire-plugin".equals(plugin.getArtifactId()))
+                        .map(plugin -> plugin.getConfigurationStringValue("argLine"))
+                        .filter(argLine -> argLine != null && argLine.contains(getArgLineJavaAgentArgument()))
+                        .findFirst().orElse(null);
+            }
+
+            private boolean mavenDependencyPluginHasPropertiesGoal() {
+                return getResolutionResult().getPom().getPlugins().stream()
+                        .filter(plugin -> "org.apache.maven.plugins".equals(plugin.getGroupId()) &&
+                                "maven-dependency-plugin".equals(plugin.getArtifactId()))
+                        .flatMap(plugin -> plugin.getExecutions().stream())
+                        .anyMatch(execution -> execution.getGoals() != null && execution.getGoals().contains("properties"));
+            }
+
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-                if (getResolutionResult().getPom().getPluginManagement().stream().anyMatch(
-                        plugin -> "org.apache.maven.plugins".equals(plugin.getGroupId()) && "maven-surefire-plugin"
-                                .equals(plugin.getArtifactId()) && plugin.getConfigurationStringValue("argLine") != null && plugin.getConfigurationStringValue("argLine").contains(getArgLineJavaAgentArgument()))) {
+                // When a parent pom manages the surefire plugin with the agent, leave the whole reactor alone.
+                if (surefireArgLineWithAgent(getResolutionResult().getPom().getPluginManagement()) != null) {
+                    return document;
+                }
+                // When the surefire plugin (possibly inherited from a parent's `build/plugins`) already carries
+                // the agent, the supporting `maven-dependency-plugin` properties goal is present, and any
+                // `@{argLine}` reference can already resolve, there is nothing left to add; adding an `argLine`
+                // property here would be redundant (see #1164).
+                String pluginArgLine = surefireArgLineWithAgent(getResolutionResult().getPom().getPlugins());
+                if (pluginArgLine != null && mavenDependencyPluginHasPropertiesGoal() &&
+                        (!pluginArgLine.contains("@{argLine}") || getResolutionResult().getPom().getProperties().containsKey("argLine"))) {
                     return document;
                 }
 

--- a/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
@@ -122,14 +122,11 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
 
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-                // When a parent pom manages the surefire plugin with the agent, leave the whole reactor alone.
                 if (surefireArgLineWithAgent(getResolutionResult().getPom().getPluginManagement()) != null) {
                     return document;
                 }
-                // When the surefire plugin (possibly inherited from a parent's `build/plugins`) already carries
-                // the agent, the supporting `maven-dependency-plugin` properties goal is present, and any
-                // `@{argLine}` reference can already resolve, there is nothing left to add; adding an `argLine`
-                // property here would be redundant (see #1164).
+                // Nothing to add when the surefire agent, the properties goal, and any `@{argLine}` property
+                // are already present, whether declared here or inherited from a parent's `build/plugins` (#1164).
                 String pluginArgLine = surefireArgLineWithAgent(getResolutionResult().getPom().getPlugins());
                 if (pluginArgLine != null && mavenDependencyPluginHasPropertiesGoal() &&
                         (!pluginArgLine.contains("@{argLine}") || getResolutionResult().getPom().getProperties().containsKey("argLine"))) {

--- a/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
@@ -50,6 +50,7 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
 
     private static final String MAVEN_PLUGINS_GROUP_ID = "org.apache.maven.plugins";
     private static final String MAVEN_SUREFIRE_PLUGIN_ARTIFACT_ID = "maven-surefire-plugin";
+    private static final String MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID = "maven-dependency-plugin";
 
     @Language("xpath")
     private static final String MAVEN_DEPENDENCY_PLUGIN_EXECUTION_MATCHER = "/project/build/plugins/plugin[artifactId='maven-dependency-plugin']/executions/execution";
@@ -86,17 +87,16 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
 
             private void maybeAddMavenDependencyPluginWithPropertiesGoal() {
                 Optional<Plugin> mavenDependencyPlugin = getResolutionResult().getPom().getPlugins().stream()
-                        .filter(plugin -> "org.apache.maven.plugins".equals(plugin.getGroupId()) &&
-                                "maven-dependency-plugin".equals(plugin.getArtifactId())).findFirst();
+                        .filter(plugin -> isMavenPlugin(plugin, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID)).findFirst();
 
                 if (!mavenDependencyPlugin.isPresent()) {
-                    doAfterVisit(new AddPlugin("org.apache.maven.plugins", "maven-dependency-plugin", null, null, null,
+                    doAfterVisit(new AddPlugin(MAVEN_PLUGINS_GROUP_ID, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID, null, null, null,
                             "<executions>" + MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG + "</executions>", "**/pom.xml").getVisitor());
                 } else if (mavenDependencyPlugin.get().getExecutions().isEmpty()) {
-                    doAfterVisit(new ChangePluginExecutions("org.apache.maven.plugins", "maven-dependency-plugin", MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG).getVisitor());
+                    doAfterVisit(new ChangePluginExecutions(MAVEN_PLUGINS_GROUP_ID, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID, MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG).getVisitor());
                 } else if (mavenDependencyPlugin.get().getExecutions().stream().noneMatch(execution -> execution.getGoals() != null)) {
                     doAfterVisit(new AddOrUpdateChildTag(MAVEN_DEPENDENCY_PLUGIN_EXECUTION_MATCHER, "<goals>" + MAVEN_DEPENDENCY_PLUGIN_PROPERTIES_GOAL + "</goals>", false).getVisitor());
-                } else if (mavenDependencyPlugin.get().getExecutions().stream().noneMatch(execution -> execution.getGoals() != null && execution.getGoals().contains("properties"))) {
+                } else if (!hasPropertiesGoal(mavenDependencyPlugin.get())) {
                     doAfterVisit(new AppendChildTagToParentVisitor(
                             new XPathMatcher(MAVEN_DEPENDENCY_PLUGIN_EXECUTION_MATCHER + "/goals"),
                             Xml.Tag.build(MAVEN_DEPENDENCY_PLUGIN_PROPERTIES_GOAL)));
@@ -104,20 +104,17 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
             }
 
             private @Nullable String surefireArgLineWithAgent(List<Plugin> plugins) {
+                String agentArgument = getArgLineJavaAgentArgument();
                 return plugins.stream()
-                        .filter(plugin -> "org.apache.maven.plugins".equals(plugin.getGroupId()) &&
-                                "maven-surefire-plugin".equals(plugin.getArtifactId()))
+                        .filter(plugin -> isMavenPlugin(plugin, MAVEN_SUREFIRE_PLUGIN_ARTIFACT_ID))
                         .map(plugin -> plugin.getConfigurationStringValue("argLine"))
-                        .filter(argLine -> argLine != null && argLine.contains(getArgLineJavaAgentArgument()))
+                        .filter(argLine -> argLine != null && argLine.contains(agentArgument))
                         .findFirst().orElse(null);
             }
 
             private boolean mavenDependencyPluginHasPropertiesGoal() {
                 return getResolutionResult().getPom().getPlugins().stream()
-                        .filter(plugin -> "org.apache.maven.plugins".equals(plugin.getGroupId()) &&
-                                "maven-dependency-plugin".equals(plugin.getArtifactId()))
-                        .flatMap(plugin -> plugin.getExecutions().stream())
-                        .anyMatch(execution -> execution.getGoals() != null && execution.getGoals().contains("properties"));
+                        .anyMatch(plugin -> isMavenPlugin(plugin, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID) && hasPropertiesGoal(plugin));
             }
 
             @Override
@@ -189,6 +186,20 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
                 return t;
             }
         });
+    }
+
+    /**
+     * Matches a plugin under the {@code org.apache.maven.plugins} group, tolerating an implied (omitted) groupId,
+     * which Maven defaults to that group for {@code maven-*-plugin} declarations.
+     */
+    private static boolean isMavenPlugin(Plugin plugin, String artifactId) {
+        return artifactId.equals(plugin.getArtifactId()) &&
+                (plugin.getGroupId() == null || MAVEN_PLUGINS_GROUP_ID.equals(plugin.getGroupId()));
+    }
+
+    private static boolean hasPropertiesGoal(Plugin plugin) {
+        return plugin.getExecutions().stream()
+                .anyMatch(execution -> execution.getGoals() != null && execution.getGoals().contains("properties"));
     }
 
     @RequiredArgsConstructor

--- a/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
@@ -1373,6 +1373,86 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
   }
 
   @Test
+  void makesNoChangesWhenParentPomDeclaresSurefirePluginWithAgentConfiguration() {
+    rewriteRun(
+      mavenProject("test-project",
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>1.0</version>
+              <packaging>pom</packaging>
+
+              <modules>
+                <module>test-module1</module>
+              </modules>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <goals>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-Xmx204m -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """,
+          spec -> spec.path("pom.xml")
+        ),
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test-module1</artifactId>
+              <version>1.0</version>
+
+              <parent>
+                <groupId>org.sample</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0</version>
+                <relativePath>../pom.xml</relativePath>
+              </parent>
+            </project>
+            """,
+          spec -> spec.path("test-module1/pom.xml")
+        )
+      )
+    );
+  }
+
+  @Test
   void augmentsSurefirePluginDeclaredInPluginManagement() {
     rewriteRun(
       mavenProject("test-project",

--- a/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
@@ -1453,6 +1453,60 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
   }
 
   @Test
+  void makesNoChangesWhenAgentConfiguredOnPluginsWithImpliedGroupId() {
+    rewriteRun(
+      mavenProject("test-project",
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>1.0</version>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <goals>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-Xmx204m -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """
+        )
+      )
+    );
+  }
+
+  @Test
   void augmentsSurefirePluginDeclaredInPluginManagement() {
     rewriteRun(
       mavenProject("test-project",


### PR DESCRIPTION
- Fixes #1164

## Problem

In a multi-module project where the **root pom declares the surefire plugin under `build/plugins`** (not `pluginManagement`) with an `argLine` that already contains the Mockito javaagent, `AddMockitoJavaAgentToMavenSurefirePlugin` added a redundant empty `<argLine></argLine>` property to the root **and every submodule** (which inherit the plugin), instead of making no changes.

The early-return guard in `visitDocument` only inspected `getPluginManagement()`, so a surefire declaration in `build/plugins` was missed.

## Fix

The guard now also returns early when the effective surefire plugin (declared locally or inherited via a parent's `build/plugins`) already carries the agent **and** the setup is complete:

- the supporting `maven-dependency-plugin` `properties` goal is present (needed to resolve `${org.mockito:mockito-core:jar}`), and
- any `@{argLine}` reference can already resolve (an `argLine` property exists).

The existing `pluginManagement` blanket behavior is preserved, and scenarios where the agent is present but the `properties` goal is still missing continue to be completed by the recipe (covered by existing tests).

## Testing

Added `makesNoChangesWhenParentPomDeclaresSurefirePluginWithAgentConfiguration` mirroring the reporter's minimal reproduction. All existing tests continue to pass.