### PR TITLE
Add Mockito Java agent surefire config in reactor modules

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
@@ -136,7 +136,7 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
                 if (FindPlugin.find(document, "org.apache.maven.plugins", "maven-surefire-plugin").isEmpty()) {
                     doAfterVisit(new AddPlugin("org.apache.maven.plugins", "maven-surefire-plugin", null,
                             String.format(CONFIGURATION_TAG_TEMPLATE, "@{argLine} " + getArgLineJavaAgentArgument()), null,
-                            null, null).getVisitor());
+                            null, "**/pom.xml").getVisitor());
                     return document;
                 }
                 return super.visitDocument(document, ctx);

--- a/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
@@ -1614,4 +1614,131 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
       )
     );
   }
+
+  @Test
+  void addsSurefireAgentToModuleWhenParentReactorPomManagesPluginsWithoutDeclaringThem() {
+    rewriteRun(
+      mavenProject("test-project",
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>1.0</version>
+              <packaging>pom</packaging>
+
+              <modules>
+                <module>test-module1</module>
+              </modules>
+
+              <dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>5.14.0</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </dependencyManagement>
+
+              <build>
+                <pluginManagement>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-dependency-plugin</artifactId>
+                      <version>3.11.0</version>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-surefire-plugin</artifactId>
+                      <version>3.5.6</version>
+                    </plugin>
+                  </plugins>
+                </pluginManagement>
+              </build>
+            </project>
+            """,
+          spec -> spec.path("pom.xml")
+        ),
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test-module1</artifactId>
+              <version>1.0</version>
+
+              <parent>
+                <groupId>org.sample</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0</version>
+                <relativePath>../pom.xml</relativePath>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.mockito</groupId>
+                  <artifactId>mockito-core</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+            </project>
+            """,
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test-module1</artifactId>
+              <version>1.0</version>
+
+              <parent>
+                <groupId>org.sample</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0</version>
+                <relativePath>../pom.xml</relativePath>
+              </parent>
+              <properties>
+                <argLine></argLine>
+              </properties>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.mockito</groupId>
+                  <artifactId>mockito-core</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <goals>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """,
+          spec -> spec.path("test-module1/pom.xml")
+        )
+      )
+    );
+  }
 }


### PR DESCRIPTION
- Fixes #1168

## Problem

In a multi-module (reactor) build where the parent pom manages `maven-surefire-plugin` and `maven-dependency-plugin` in `<pluginManagement>` but does **not** declare them in `<build><plugins>`, running `AddMockitoJavaAgentToMavenSurefirePlugin` on a child module produced a pointless partial change:

- an empty `<argLine></argLine>` property was added,
- the `maven-dependency-plugin` (with the `properties` goal) was added,
- but the `maven-surefire-plugin` with the actual `-javaagent:...` argLine was **never** added.

This is exactly what the reporter saw: an "odd empty argLine and dependency-plugin for no apparent reason", with nothing that actually wires up the Mockito agent.

## Root cause

`AddPluginVisitor.isAcceptable` bails out when `filePattern == null` and the module's parent pom is part of the same reactor:

```java
if (mrr == null || mrr.parentPomIsProjectPom()) {
    return false;
}
```

The surefire `AddPlugin` was invoked with `filePattern == null`, so it was silently skipped on reactor child modules. The dependency-plugin `AddPlugin`, however, is invoked with a `**/pom.xml` filePattern, which bypasses that guard — hence the inconsistent, half-applied result.

## Fix

Pass the same `**/pom.xml` filePattern for the surefire `AddPlugin` so the configuration is applied consistently. The child module now gets a complete, working setup: the `@{argLine}` property, the dependency-plugin `properties` goal, and the surefire plugin with the Java agent argLine that references them.

Added a test reproducing the reporter's structure (parent manages both plugins in `pluginManagement`, child only declares the Mockito test dependency).