### PR TITLE
Update NoGuavaRefaster expected output for upstream static-import change

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaRefasterTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaRefasterTest.java
@@ -128,11 +128,12 @@ class NoGuavaRefasterTest implements RewriteTest {
               }
               """,
             """
+              import static java.lang.String.valueOf;
               import static java.util.Objects.requireNonNull;
 
               class A {
                   Object foo(Object obj, StringBuilder description) {
-                      return requireNonNull(obj, String.valueOf(description));
+                      return requireNonNull(obj, valueOf(description));
                   }
               }
               """


### PR DESCRIPTION
## What's changed?

The 2026-07-20 `openrewrite/rewrite` snapshot changed `NoGuavaRefaster` so that:

```java
Preconditions.checkNotNull(obj, description)
```

now migrates to `requireNonNull(obj, valueOf(description))` with a static import of `java.lang.String.valueOf`, instead of `requireNonNull(obj, String.valueOf(description))`.

This updates the expected output of `preconditionsCheckNotNullToObjectsRequireNonNullTwoArgumentsSecondObject` to match current behavior, unblocking the scheduled CI.

## Why?

- Scheduled CI went red on 2026-07-20 (green through 07-19): [run #29769956822](https://github.com/openrewrite/rewrite-migrate-java/actions/runs/29769956822) — `1 test failed`. Reproduced locally against the current snapshot.

> Note for reviewers: the new output adds `import static java.lang.String.valueOf` for a single use, which is arguably noisier than the qualified `String.valueOf`. If that static-import behavior is considered undesirable, the fix belongs upstream in `openrewrite/rewrite` (Refaster/static-import handling) rather than here — happy to redirect. This PR simply realigns the expectation with shipped behavior.