### PR TITLE
Migrate web.xml xsi:schemaLocation from J2EE 1.4 namespace

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-faces-3.yml
@@ -214,7 +214,7 @@ recipeList:
   - org.openrewrite.xml.ChangeTagAttribute:
       attributeName: xsi:schemaLocation
       elementName: web-app
-      oldValue: (?s).*xml/ns/javaee.*
+      oldValue: (?s).*xml/ns/(j2ee|javaee).*
       newValue: https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd
       regex: true
   - org.openrewrite.xml.ChangeTagValue:

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxWebXmlToJakartaWebXmlTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JavaxWebXmlToJakartaWebXmlTest.java
@@ -67,6 +67,33 @@ class JavaxWebXmlToJakartaWebXmlTest implements RewriteTest {
     }
 
     @Test
+    void migrateJ2ee() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <web-app version="2.4"
+                       xmlns="http://java.sun.com/xml/ns/j2ee"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+                                           http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+              </web-app>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <web-app version="5.0"
+                       xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+              </web-app>
+              """,
+            sourceSpecs -> sourceSpecs.path("web.xml")
+          )
+        );
+    }
+
+    @Test
     void migrateWithSQLDataSource() {
         rewriteRun(
           //language=xml


### PR DESCRIPTION
The `JavaxWebXmlToJakartaWebXml` recipe updated `xmlns` and `version` attributes on J2EE 1.4 web.xml descriptors (`http://java.sun.com/xml/ns/j2ee`, `version="2.4"`) but left `xsi:schemaLocation` pointing at the old j2ee schema. The `ChangeTagAttribute` step for `xsi:schemaLocation` gated on a regex `(?s).*xml/ns/javaee.*` that only matched the newer `javaee` namespace, so J2EE 1.4 descriptors fell through and produced this inconsistent output:

```xml
<web-app version="5.0"
         xmlns="https://jakarta.ee/xml/ns/jakartaee"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
                             http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
```

Broaden the regex to `(?s).*xml/ns/(j2ee|javaee).*` so J2EE 1.4 descriptors also have `xsi:schemaLocation` rewritten to the Jakarta EE 9 `web-app_5_0.xsd`, per the [Eclipse Foundation's Jakarta EE XML Schemas index](https://jakarta.ee/xml/ns/jakartaee/) (Jakarta EE 9+ descriptors share the `https://jakarta.ee/xml/ns/jakartaee` namespace, and `web-app_5_0.xsd` is the Servlet 5.0 deployment descriptor schema).

Sibling recipes for `faces-config`, `facelet-taglib`, and `web-fragment` overwrite `xsi:schemaLocation` unconditionally (no `oldValue`), so they don't have this bug. Added a `migrateJ2ee` test covering the 2.4 → 5.0 case.