### PR TITLE
Add mapping for CheckForNull to JSpecify annotation

### DIFF
--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -72,6 +72,10 @@ recipeList:
       newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
       ignoreDefinition: true
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.annotation.CheckForNull
+      newFullyQualifiedTypeName: org.jspecify.annotations.Nullable
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Nonnull
       newFullyQualifiedTypeName: org.jspecify.annotations.NonNull
       ignoreDefinition: true

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
@@ -46,6 +46,7 @@ class JSpecifyBestPracticesTest implements RewriteTest {
                 """
                   import javax.annotation.Nonnull;
                   import javax.annotation.Nullable;
+                  import javax.annotation.CheckForNull;
 
                   public class Test {
                       @Nonnull
@@ -54,6 +55,8 @@ class JSpecifyBestPracticesTest implements RewriteTest {
                       public String field2;
                       @Nullable
                       public Foo.Bar foobar;
+                      @CheckForNull
+                      public String checked;
                   }
 
                   interface Foo {
@@ -73,6 +76,8 @@ class JSpecifyBestPracticesTest implements RewriteTest {
                       @Nullable
                       public String field2;
                       public Foo.@Nullable Bar foobar;
+                      @Nullable
+                      public String checked;
                   }
 
                   interface Foo {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
When migrating to JSpecify. `javax.annotation.CheckForNull` is now replaced by `org.jspecify.annotations.Nullable`.
Semantically `CheckForNull` is closer to `org.jspecify.annotations.Nullable` than `javax.annotation.Nullable` is (see [StackOverflow](https://stackoverflow.com/a/12301937/32987888)), so this is a safe change.

## What's your motivation?
* The recipe should remove all null-related annotations that belong to `javax.annotation` to avoid manual steps.
* Currently the recipe changes `@CheckForNull Object[]` to `Object @CheckForNull[]`, but then fails to replace it, resulting in code that does not compile (the old annotation does not have `TYPE_USE` target).

## Anything in particular you'd like reviewers to focus on?
🤷 

## Anyone you would like to review specifically?
🤷

## Have you considered any alternatives or workarounds?
Make a custom .yml recipe.

## Any additional context
Projects using SpotBugs for null analysis likely prefer `@CheckForNull` over `javax.annotation.Nullable`, so they might benefit from this change.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases 
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
