### PR TITLE
Adopt upstream XML trailing-comment formatting

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
@@ -70,7 +70,8 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new DependencyInsight("org.mockito", "mockito-core", "test", null, false), new MavenIsoVisitor<ExecutionContext>() {
-            private final String CONFIGURATION_TAG_TEMPLATE = "<configuration><!--suppress MavenModelInspection --><argLine>%s</argLine></configuration>";
+            // The newline before the comment keeps auto-format from attaching it to a preceding sibling as a trailing comment
+            private final String CONFIGURATION_TAG_TEMPLATE = "<configuration>\n<!--suppress MavenModelInspection --><argLine>%s</argLine></configuration>";
 
             private String getArgLineJavaAgentArgument() {
                 String mockitoCoreVersion = getResolutionResult().getDependencies().getOrDefault(Scope.Test, emptyList()).stream()

--- a/src/main/java/org/openrewrite/java/migrate/JpaCacheProperties.java
+++ b/src/main/java/org/openrewrite/java/migrate/JpaCacheProperties.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Content;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.openrewrite.xml.AddOrUpdateChild.addOrUpdateChild;
-import static org.openrewrite.xml.FilterTagChildrenVisitor.filterTagChildren;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -185,7 +185,7 @@ class PersistenceXmlVisitor extends XmlVisitor<ExecutionContext> {
         if (sdh.openJPACacheProperty != null) {
             String attrValue = getAttributeValue("value", sdh.openJPACacheProperty);
             if ("true".equalsIgnoreCase(attrValue) || "false".equalsIgnoreCase(attrValue)) {
-                sdh.propertiesElement = filterTagChildren(sdh.propertiesElement, child -> child != sdh.openJPACacheProperty);
+                sdh.propertiesElement = removeContent(sdh.propertiesElement, sdh.openJPACacheProperty, ctx);
                 t = addOrUpdateChild(t, sdh.propertiesElement, getCursor().getParentOrThrow());
             }
         }
@@ -193,10 +193,18 @@ class PersistenceXmlVisitor extends XmlVisitor<ExecutionContext> {
         // if both shared-cache-mode and javax cache property are set, delete the
         // javax cache property
         if (sdh.sharedCacheModeElement != null && sdh.sharedCacheModeProperty != null) {
-            sdh.propertiesElement = filterTagChildren(sdh.propertiesElement, child -> child != sdh.sharedCacheModeProperty);
+            sdh.propertiesElement = removeContent(sdh.propertiesElement, sdh.sharedCacheModeProperty, ctx);
             t = addOrUpdateChild(t, sdh.propertiesElement, getCursor().getParentOrThrow());
         }
         return t;
+    }
+
+    /**
+     * Unlike {@code filterTagChildren}, this hands the removed element's prefix to a comment that trailed it,
+     * so the comment keeps its own line rather than collapsing onto the preceding sibling.
+     */
+    private static Xml.Tag removeContent(Xml.Tag parent, Xml.Tag child, ExecutionContext ctx) {
+        return (Xml.Tag) new RemoveContentVisitor<ExecutionContext>(child, false, false).visitNonNull(parent, ctx);
     }
 
     private SharedDataHolder extractData(Xml.Tag puNode) {

--- a/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
@@ -607,8 +607,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <properties>
                           <!-- Connection properties -->
                           <!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="NONE"/>
-                          <!-- leave -->
+                          <property name="javax.persistence.sharedCache.mode" value="NONE"/><!-- leave -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -644,8 +643,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <properties>
                           <!-- Connection properties -->
                           <!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="ALL"/>
-                          <!-- leave -->
+                          <property name="javax.persistence.sharedCache.mode" value="ALL"/><!-- leave -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -681,8 +679,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <properties>
                           <!-- Connection properties -->
                           <!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="ALL"/>
-                          <!-- change to ALL -->
+                          <property name="javax.persistence.sharedCache.mode" value="ALL"/><!-- change to ALL -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -783,8 +780,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="javax.persistence.sharedCache.mode" value="NONE"/>
-                          <!-- change to NONE -->
+                          <property name="javax.persistence.sharedCache.mode" value="NONE"/><!-- change to NONE -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -909,14 +905,12 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set3">
-                      <!-- flag -->
-                      <!-- add shared-cache-mode ENABLE_SELECTIVE -->
+                      <!-- flag --> <!-- add shared-cache-mode ENABLE_SELECTIVE -->
                       <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="truE(Types=foo.bar.Person;foo.bar.Employee)"/>
-                          <!-- leave - manual fix-->
+                          <property name="openjpa.DataCache" value="truE(Types=foo.bar.Person;foo.bar.Employee)"/><!-- leave - manual fix-->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -947,14 +941,12 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set4">
-                      <!-- flag -->
-                      <!-- add shared-cache-mode DISABLE_SELECTIVE -->
+                      <!-- flag --> <!-- add shared-cache-mode DISABLE_SELECTIVE -->
                       <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="TRUE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/>
-                          <!-- leave - manual fix -->
+                          <property name="openjpa.DataCache" value="TRUE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/><!-- leave - manual fix -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -1139,8 +1131,7 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache3_flagged">
-                      <!-- flag -->
-                      <!-- create shared-cache-mode NONE -->
+                      <!-- flag --><!-- create shared-cache-mode NONE -->
                       <shared-cache-mode>NONE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>

--- a/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
@@ -58,7 +58,9 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -94,7 +96,9 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -130,7 +134,9 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave, change to ALL -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -167,7 +173,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="truE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/><!-- remove -->
+                          <property name="openjpa.DataCache" value="truE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/>
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -202,7 +209,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -237,7 +245,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -272,7 +281,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- change to NONE -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -307,7 +317,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -399,7 +410,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -434,7 +446,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- change to ALL -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -592,8 +605,10 @@ class JpaCachePropertiesTest implements RewriteTest {
                   <persistence-unit name="notset_set_set1"><!-- flag -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="NONE"/><!-- leave -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
+                          <property name="javax.persistence.sharedCache.mode" value="NONE"/>
+                          <!-- leave -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -627,8 +642,10 @@ class JpaCachePropertiesTest implements RewriteTest {
                   <persistence-unit name="notset_set_set2"><!-- flag -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="ALL"/><!-- leave -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
+                          <property name="javax.persistence.sharedCache.mode" value="ALL"/>
+                          <!-- leave -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -662,8 +679,10 @@ class JpaCachePropertiesTest implements RewriteTest {
                   <persistence-unit name="notset_set_set3"><!-- flag -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="ALL"/><!-- change to ALL -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
+                          <property name="javax.persistence.sharedCache.mode" value="ALL"/>
+                          <!-- change to ALL -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -764,7 +783,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="javax.persistence.sharedCache.mode" value="NONE"/><!-- change to NONE -->
+                          <property name="javax.persistence.sharedCache.mode" value="NONE"/>
+                          <!-- change to NONE -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -821,7 +841,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove and insert shared-cache-mode NONE -->
+                          <!-- Connection properties -->
+                          <!-- remove and insert shared-cache-mode NONE -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -856,7 +877,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove and insert shared-cache-mode ALL -->
+                          <!-- Connection properties -->
+                          <!-- remove and insert shared-cache-mode ALL -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -887,12 +909,14 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set3">
-                      <!-- flag --> <!-- add shared-cache-mode ENABLE_SELECTIVE -->
+                      <!-- flag -->
+                      <!-- add shared-cache-mode ENABLE_SELECTIVE -->
                       <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="truE(Types=foo.bar.Person;foo.bar.Employee)"/><!-- leave - manual fix-->
+                          <property name="openjpa.DataCache" value="truE(Types=foo.bar.Person;foo.bar.Employee)"/>
+                          <!-- leave - manual fix-->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -923,12 +947,14 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set4">
-                      <!-- flag --> <!-- add shared-cache-mode DISABLE_SELECTIVE -->
+                      <!-- flag -->
+                      <!-- add shared-cache-mode DISABLE_SELECTIVE -->
                       <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="TRUE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/><!-- leave - manual fix -->
+                          <property name="openjpa.DataCache" value="TRUE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/>
+                          <!-- leave - manual fix -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -1048,7 +1074,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- set to NONE -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties --><!-- remove -->
+                          <!-- Connection properties -->
+                          <!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -1112,7 +1139,8 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache3_flagged">
-                      <!-- flag --><!-- create shared-cache-mode NONE -->
+                      <!-- flag -->
+                      <!-- create shared-cache-mode NONE -->
                       <shared-cache-mode>NONE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>

--- a/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/JpaCachePropertiesTest.java
@@ -58,9 +58,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -96,9 +94,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -134,9 +130,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave, change to ALL -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -173,8 +167,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="truE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/>
-                          <!-- remove -->
+                          <property name="openjpa.DataCache" value="truE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -209,8 +202,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -245,8 +237,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -281,8 +272,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- change to NONE -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -317,8 +307,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -410,8 +399,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- leave -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -446,8 +434,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode><!-- change to ALL -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -605,10 +592,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                   <persistence-unit name="notset_set_set1"><!-- flag -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="NONE"/>
-                          <!-- leave -->
+                          <!-- Connection properties --><!-- remove -->
+                          <property name="javax.persistence.sharedCache.mode" value="NONE"/><!-- leave -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -642,10 +627,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                   <persistence-unit name="notset_set_set2"><!-- flag -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="ALL"/>
-                          <!-- leave -->
+                          <!-- Connection properties --><!-- remove -->
+                          <property name="javax.persistence.sharedCache.mode" value="ALL"/><!-- leave -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -679,10 +662,8 @@ class JpaCachePropertiesTest implements RewriteTest {
                   <persistence-unit name="notset_set_set3"><!-- flag -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
-                          <property name="javax.persistence.sharedCache.mode" value="ALL"/>
-                          <!-- change to ALL -->
+                          <!-- Connection properties --><!-- remove -->
+                          <property name="javax.persistence.sharedCache.mode" value="ALL"/><!-- change to ALL -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -783,8 +764,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="javax.persistence.sharedCache.mode" value="NONE"/>
-                          <!-- change to NONE -->
+                          <property name="javax.persistence.sharedCache.mode" value="NONE"/><!-- change to NONE -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -841,8 +821,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove and insert shared-cache-mode NONE -->
+                          <!-- Connection properties --><!-- remove and insert shared-cache-mode NONE -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -877,8 +856,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>ALL</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove and insert shared-cache-mode ALL -->
+                          <!-- Connection properties --><!-- remove and insert shared-cache-mode ALL -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -909,14 +887,12 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set3">
-                      <!-- flag -->
-                      <!-- add shared-cache-mode ENABLE_SELECTIVE -->
+                      <!-- flag --> <!-- add shared-cache-mode ENABLE_SELECTIVE -->
                       <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="truE(Types=foo.bar.Person;foo.bar.Employee)"/>
-                          <!-- leave - manual fix-->
+                          <property name="openjpa.DataCache" value="truE(Types=foo.bar.Person;foo.bar.Employee)"/><!-- leave - manual fix-->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -947,14 +923,12 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="notset_notset_set4">
-                      <!-- flag -->
-                      <!-- add shared-cache-mode DISABLE_SELECTIVE -->
+                      <!-- flag --> <!-- add shared-cache-mode DISABLE_SELECTIVE -->
                       <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>
                           <!-- Connection properties -->
-                          <property name="openjpa.DataCache" value="TRUE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/>
-                          <!-- leave - manual fix -->
+                          <property name="openjpa.DataCache" value="TRUE(ExcludedTypes=foo.bar.Person;foo.bar.Employee)"/><!-- leave - manual fix -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -1074,8 +1048,7 @@ class JpaCachePropertiesTest implements RewriteTest {
                       <shared-cache-mode>NONE</shared-cache-mode><!-- set to NONE -->
                       <validation-mode>NONE</validation-mode>
                       <properties>
-                          <!-- Connection properties -->
-                          <!-- remove -->
+                          <!-- Connection properties --><!-- remove -->
                       </properties>
                   </persistence-unit>
               </persistence>
@@ -1139,8 +1112,7 @@ class JpaCachePropertiesTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
                   <persistence-unit name="openjpa_cache3_flagged">
-                      <!-- flag -->
-                      <!-- create shared-cache-mode NONE -->
+                      <!-- flag --><!-- create shared-cache-mode NONE -->
                       <shared-cache-mode>NONE</shared-cache-mode>
                       <validation-mode>NONE</validation-mode>
                       <properties>


### PR DESCRIPTION
Fixes the `main` build failure in https://github.com/openrewrite/rewrite-migrate-java/actions/runs/30564092748 (22 tests across two classes).

Depends on openrewrite/rewrite#8355, now merged and published to `8.89.0-SNAPSHOT`.

## Cause

openrewrite/rewrite#8353 made XML auto-format keep a comment on the same line as the element it trails, instead of reflowing it onto its own line. Both failing test classes relied on that reflow.

## `AddMockitoJavaAgentToMavenSurefirePlugin`

The recipe builds `<configuration><!--suppress MavenModelInspection --><argLine>…</argLine></configuration>`. Where there is no existing `<configuration>` the comment is the first content of its tag and still reflows, so those cases never failed. Where the `<argLine>` is appended into an *existing* `<configuration>`, the comment is no longer first content and stayed glued to the preceding sibling:

```diff
-  </systemPropertyVariables>
-  <!--suppress MavenModelInspection -->
+  </systemPropertyVariables><!--suppress MavenModelInspection -->
   <argLine>…</argLine>
```

which reads as suppressing an inspection on `<systemPropertyVariables>` rather than on the `<argLine>` it is meant for. Seeding the comment with a newline prefix keeps it on its own line in both paths.

## `JpaCacheProperties`

The 20 failures here split in two, and only the first half is a formatting bug.

**13 cases — comment orphaned by removal.** The recipe deletes a `<property/>` that had a trailing comment; the deleted element's prefix carried the line break, so the comment had none left and collapsed onto the previous line:

```diff
-  <!-- Connection properties -->
-  <!-- remove -->
+  <!-- Connection properties --><!-- remove -->
```

openrewrite/rewrite#8355 fixed exactly this — but in `RemoveContentVisitor`, whereas this recipe removed via `filterTagChildren`, which drops content outright and never saw the fix. Both call sites remove a single known element, so `RemoveContentVisitor` is the natural fit; switching them over restores the original expectations for these 13 with no test changes.

**7 cases — nothing removed.** Here the element the comment trails is retained (`<!-- leave -->`, `<!-- leave - manual fix -->`) or merely has an attribute updated (`UNSPECIFIED`→`NONE`), and in two cases the comments were never attached to a removed element at all (`<!-- flag --> <!-- add shared-cache-mode … -->`). #8353 now reproduces the inline placement the input used:

```diff
-  <property name="javax.persistence.sharedCache.mode" value="NONE"/>
-  <!-- change to NONE -->
+  <property name="javax.persistence.sharedCache.mode" value="NONE"/><!-- change to NONE -->
```

These expectations were asserting the old reflow, so they are updated to match the source. No behavioural change is warranted — the recipe never intended to relocate these comments.

## Verification

`./gradlew test` green locally against the post-#8355 snapshot.