### PR TITLE
Skip `UseSetOf`/`UseListOf` for `HashSet`/`ArrayList` subclasses

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseListOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseListOf.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -90,7 +91,8 @@ public class UseListOf extends Recipe {
 
                         // Anonymous-class form (original UseListOf logic, unchanged).
                         J.Block body = n.getBody();
-                        if (NEW_ARRAY_LIST.matches(n) && body != null && body.getStatements().size() == 1) {
+                        if (NEW_ARRAY_LIST.matches(n) && body != null && body.getStatements().size() == 1 &&
+                                isExactlyArrayList(n)) {
                             Statement statement = body.getStatements().get(0);
                             if (statement instanceof J.Block) {
                                 List<Expression> args = new ArrayList<>();
@@ -240,11 +242,23 @@ public class UseListOf extends Recipe {
                         if (!NEW_ARRAY_LIST.matches(nc)) {
                             return null;
                         }
+                        if (!isExactlyArrayList(nc)) {
+                            return null;
+                        }
                         // A body would put us in the anonymous-class case handled by visitNewClass directly.
                         if (nc.getBody() != null) {
                             return null;
                         }
                         return nv.getSimpleName();
+                    }
+
+                    /**
+                     * Skip `ArrayList` subclasses: `new ArrayList<>(..)` is not assignable to a subclass
+                     * declared type, and the subclass may carry behavior beyond a plain `ArrayList`
+                     * (issue #1181, matching #1113).
+                     */
+                    private boolean isExactlyArrayList(J.NewClass nc) {
+                        return TypeUtils.isOfClassType(nc.getClazz() != null ? nc.getClazz().getType() : null, "java.util.ArrayList");
                     }
 
                     /**

--- a/src/main/java/org/openrewrite/java/migrate/util/UseSetOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseSetOf.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -90,7 +91,8 @@ public class UseSetOf extends Recipe {
 
                         // Anonymous-class form (original UseSetOf logic, unchanged).
                         J.Block body = n.getBody();
-                        if (NEW_HASH_SET.matches(n) && body != null && body.getStatements().size() == 1) {
+                        if (NEW_HASH_SET.matches(n) && body != null && body.getStatements().size() == 1 &&
+                                isExactlyHashSet(n)) {
                             Statement statement = body.getStatements().get(0);
                             if (statement instanceof J.Block) {
                                 List<Expression> args = new ArrayList<>();
@@ -221,10 +223,23 @@ public class UseSetOf extends Recipe {
                         if (!NEW_HASH_SET.matches(nc)) {
                             return null;
                         }
+                        if (!isExactlyHashSet(nc)) {
+                            return null;
+                        }
                         if (nc.getBody() != null) {
                             return null;
                         }
                         return nv.getSimpleName();
+                    }
+
+                    /**
+                     * Skip `HashSet` subclasses like `LinkedHashSet`/`TreeSet`: `Set.of(..)` makes no
+                     * iteration-order guarantee, so converting them would silently drop the ordering
+                     * contract the original code relied on, and `new HashSet<>(..)` is not assignable
+                     * to a `LinkedHashSet` declared type (issue #1181, matching #1113).
+                     */
+                    private boolean isExactlyHashSet(J.NewClass nc) {
+                        return TypeUtils.isOfClassType(nc.getClazz() != null ? nc.getClazz().getType() : null, "java.util.HashSet");
                     }
 
                     private Expression matchAddCallOn(Statement stmt, String targetName) {

--- a/src/test/java/org/openrewrite/java/migrate/util/UseListOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseListOfTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.util;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -293,6 +294,34 @@ class UseListOfTest implements RewriteTest {
                               "alice",
                               "Charlie"));
                       names.sort(null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1181")
+    @Test
+    void doNotChangeArrayListSubclass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.ArrayList;
+
+              class Names extends ArrayList<String> {}
+              """
+          ),
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  void m() {
+                      List<String> names = new Names();
+                      names.add("alpha");
+                      names.add("beta");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/migrate/util/UseSetOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseSetOfTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate.util;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -291,6 +292,71 @@ class UseSetOfTest implements RewriteTest {
                               "beta",
                               "gamma"));
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1181")
+    @Test
+    void doNotChangeLinkedHashSetBuiltWithAddStatements() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.LinkedHashSet;
+
+              class Test {
+                  void m() {
+                      LinkedHashSet<String> tags = new LinkedHashSet<>();
+                      tags.add("alpha");
+                      tags.add("beta");
+                      tags.add("gamma");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1181")
+    @Test
+    void doNotChangeTreeSetBuiltWithAddStatements() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Set;
+              import java.util.TreeSet;
+
+              class Test {
+                  void m() {
+                      Set<String> tags = new TreeSet<>();
+                      tags.add("alpha");
+                      tags.add("beta");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1181")
+    @Test
+    void doNotChangeAnonymousLinkedHashSet() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.LinkedHashSet;
+              import java.util.Set;
+
+              class Test {
+                  static final Set<String> ORDERED = new LinkedHashSet<>() {{
+                      add("alpha");
+                      add("beta");
+                  }};
               }
               """
           )


### PR DESCRIPTION
- Fixes #1181

`new LinkedHashSet<>()` matched the `java.util.HashSet <constructor>()` matcher (which uses `matchOverrides`, needed for the anonymous-subclass form), so:

```java
LinkedHashSet<TestObject> ordered = new LinkedHashSet<>();
ordered.add(t1);
ordered.add(t2);
```

became `LinkedHashSet<TestObject> ordered = new HashSet<>(Set.of(t1, t2));` — which doesn't compile, and would silently drop the iteration-order contract if it did.

- Both the prose `add(..)`-chain form and the anonymous double-brace form now require the instantiated type to be exactly `java.util.HashSet` (resp. `java.util.ArrayList`), mirroring the guards already present in `UseMapOf` from #1113 and #1163.