### PR TITLE
Avoid hardcoded patch version in UpdateSdkManTest

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -191,10 +191,11 @@ class UpdateSdkManTest implements RewriteTest {
             """
               java=21.0.10-jbr
               """,
-            """
-              java=21.0.11-tem
-              """,
             spec -> spec.path(".sdkmanrc")
+              .after(str -> assertThat(str)
+                .startsWith("java=21.0.")
+                .endsWith("-tem")
+                .actual())
           )
         );
     }


### PR DESCRIPTION
The nightly SDKMAN! candidates refresh ([a6935d7](https://github.com/openrewrite/rewrite-migrate-java/commit/a6935d7a)) added `21.0.12-tem`, which broke `upgradeIfNewVersionIsStillSameVersionBasisAndDifferentDistribution`'s hardcoded `21.0.11-tem` expectation and failed the [nightly main build](https://github.com/openrewrite/rewrite-migrate-java/actions/runs/30843187198).

Switched the assertion to check the version basis and distribution rather than the exact patch version, matching the style of the neighbouring tests.