### PR TITLE
Make subpackage recursion explicit in the Jackson JAX-RS JSON rename

### DIFF
--- a/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+++ b/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
@@ -1316,6 +1316,7 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: com.fasterxml.jackson.jaxrs.json
       newPackageName: com.fasterxml.jackson.jakarta.rs.json
+      recursive: true
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
       newFullyQualifiedTypeName: com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule

--- a/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jakarta/JacksonJavaxtoJakartaTest.java
@@ -396,4 +396,35 @@ class JacksonJavaxtoJakartaTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void migrateTypeInJaxrsJsonSubpackage() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
+            """
+              package com.fasterxml.jackson.jaxrs.json.annotation;
+              public @interface JSONP {}
+              """
+          )),
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.jaxrs.json.annotation.JSONP;
+
+              class A {
+                  @JSONP
+                  void method() {}
+              }
+              """,
+            """
+              import com.fasterxml.jackson.jakarta.rs.json.annotation.JSONP;
+
+              class A {
+                  @JSONP
+                  void method() {}
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
`com.fasterxml.jackson.jaxrs.json` → `com.fasterxml.jackson.jakarta.rs.json` in `jakarta-ee-9.yml` omits `recursive` while depending on it, so types in the `.annotation` subpackage were never migrated.

Verified against the published artifacts — jackson-jaxrs-json-provider 2.14.3 → jackson-jakarta-rs-json-provider 2.15.4:

| old | new |
| --- | --- |
| `com.fasterxml.jackson.jaxrs.json.annotation` | `com.fasterxml.jackson.jakarta.rs.json.annotation` |

The subpackage maps exactly under prefix substitution, so recursion is both safe and required here.

I audited the other 18 `recursive`-omitting rules in this repo the same way (the DataNucleus set, `org.apache.shiro.codec`, `javax.annotation.security` / `.sql`, `javax.security.cert`, `org.apache.commons.fileupload2.jakarta.servlet5`, …) and they are all leaf packages, so this is the only one that needs changing. Two are deliberately left non-recursive because recursion would be *wrong*: `com.alibaba.fastjson` → `com.alibaba.fastjson2` (only `.annotation` has a counterpart; fastjson2 has no `.parser` / `.serializer` / `.support.*`), and `com.sun.net.ssl` → `javax.net.ssl` (no `.internal` counterpart).

## Why the tests didn't catch this

`ChangePackage.recursive` is `@Nullable` with `required = false` and no documented default, and a null was read **two different ways inside the same recipe**: non-recursive by its preconditions, recursive by its visitor. The upshot is that a subpackage type gets renamed only if the file *also* references a type sitting directly in `oldPackageName` — which every existing fixture happens to do. A real source file importing only the subpackage type was never migrated.

- So this is a latent bug being fixed, not a test fixup. openrewrite/rewrite#8382 settles null as non-recursive, which is what surfaced it; I found this while auditing declarative `ChangePackage` usages against the published artifacts.

## Verification

- Full `./gradlew test` green. Each new test fails without the `recursive: true` line and passes with it. Correct on its own merits and safe to merge now, independently of rewrite#8382.
