### PR TITLE
Add the Mockito agent properties goal in its own execution

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.migrate;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
@@ -27,15 +26,14 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.maven.AddPlugin;
 import org.openrewrite.maven.AddPropertyVisitor;
-import org.openrewrite.maven.ChangePluginExecutions;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.maven.search.DependencyInsight;
 import org.openrewrite.maven.search.FindPlugin;
+import org.openrewrite.maven.trait.MavenPlugin;
 import org.openrewrite.maven.tree.Plugin;
 import org.openrewrite.maven.tree.ResolvedDependency;
 import org.openrewrite.maven.tree.Scope;
 import org.openrewrite.semver.LatestRelease;
-import org.openrewrite.xml.AddOrUpdateChildTag;
 import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlIsoVisitor;
@@ -54,14 +52,11 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
     private static final String MAVEN_SUREFIRE_PLUGIN_ARTIFACT_ID = "maven-surefire-plugin";
     private static final String MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID = "maven-dependency-plugin";
 
-    @Language("xpath")
-    private static final String MAVEN_DEPENDENCY_PLUGIN_EXECUTION_MATCHER = "/project/build/plugins/plugin[artifactId='maven-dependency-plugin']/executions/execution";
+    private static final String PROPERTIES_GOAL = "properties";
 
     @Language("xml")
-    private static final String MAVEN_DEPENDENCY_PLUGIN_PROPERTIES_GOAL = "<goal>properties</goal>";
-
-    @Language("xml")
-    private static final String MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG = "<execution><goals>"+ MAVEN_DEPENDENCY_PLUGIN_PROPERTIES_GOAL + "</goals></execution>";
+    private static final String MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG =
+            "<execution><id>get-mockito-agent-path</id><goals><goal>" + PROPERTIES_GOAL + "</goal></goals></execution>";
 
     @Getter
     final String displayName = "Add Mockito Java Agent to Maven Surefire Plugin";
@@ -105,24 +100,6 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
                         declaresJacocoPlugin(getCursor().firstEnclosingOrThrow(Xml.Document.class));
             }
 
-            private void maybeAddMavenDependencyPluginWithPropertiesGoal() {
-                Optional<Plugin> mavenDependencyPlugin = getResolutionResult().getPom().getPlugins().stream()
-                        .filter(plugin -> isMavenPlugin(plugin, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID)).findFirst();
-
-                if (!mavenDependencyPlugin.isPresent()) {
-                    doAfterVisit(new AddPlugin(MAVEN_PLUGINS_GROUP_ID, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID, null, null, null,
-                            "<executions>" + MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG + "</executions>", "**/pom.xml").getVisitor());
-                } else if (mavenDependencyPlugin.get().getExecutions().isEmpty()) {
-                    doAfterVisit(new ChangePluginExecutions(MAVEN_PLUGINS_GROUP_ID, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID, MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG).getVisitor());
-                } else if (mavenDependencyPlugin.get().getExecutions().stream().noneMatch(execution -> execution.getGoals() != null)) {
-                    doAfterVisit(new AddOrUpdateChildTag(MAVEN_DEPENDENCY_PLUGIN_EXECUTION_MATCHER, "<goals>" + MAVEN_DEPENDENCY_PLUGIN_PROPERTIES_GOAL + "</goals>", false).getVisitor());
-                } else if (!hasPropertiesGoal(mavenDependencyPlugin.get())) {
-                    doAfterVisit(new AppendChildTagToParentVisitor(
-                            new XPathMatcher(MAVEN_DEPENDENCY_PLUGIN_EXECUTION_MATCHER + "/goals"),
-                            Xml.Tag.build(MAVEN_DEPENDENCY_PLUGIN_PROPERTIES_GOAL)));
-                }
-            }
-
             private @Nullable String surefireArgLineWithAgent(List<Plugin> plugins) {
                 String agentArgument = getArgLineJavaAgentArgument();
                 return plugins.stream()
@@ -130,11 +107,6 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
                         .map(plugin -> plugin.getConfigurationStringValue("argLine"))
                         .filter(argLine -> argLine != null && argLine.contains(agentArgument))
                         .findFirst().orElse(null);
-            }
-
-            private boolean mavenDependencyPluginHasPropertiesGoal() {
-                return getResolutionResult().getPom().getPlugins().stream()
-                        .anyMatch(plugin -> isMavenPlugin(plugin, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID) && hasPropertiesGoal(plugin));
             }
 
             @Override
@@ -145,12 +117,23 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
                 // Nothing to add when the surefire agent, the properties goal, and any `@{argLine}` property
                 // are already present, whether declared here or inherited from a parent's `build/plugins` (#1164).
                 String pluginArgLine = surefireArgLineWithAgent(getResolutionResult().getPom().getPlugins());
-                if (pluginArgLine != null && mavenDependencyPluginHasPropertiesGoal() &&
+                boolean mavenDependencyPluginRunsPropertiesGoalAtDefaultPhase = getResolutionResult().getPom().getPlugins().stream()
+                        .anyMatch(plugin -> isMavenPlugin(plugin, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID) &&
+                                plugin.getExecutions().stream()
+                                        .anyMatch(execution -> execution.getPhase() == null &&
+                                                execution.getGoals() != null && execution.getGoals().contains(PROPERTIES_GOAL)));
+                if (pluginArgLine != null && mavenDependencyPluginRunsPropertiesGoalAtDefaultPhase &&
                         (!pluginArgLine.contains("@{argLine}") || getResolutionResult().getPom().getProperties().containsKey("argLine"))) {
                     return document;
                 }
 
-                maybeAddMavenDependencyPluginWithPropertiesGoal();
+                if (!mavenDependencyPluginRunsPropertiesGoalAtDefaultPhase) {
+                    // AddPlugin no-ops when the plugin exists; the visitor below appends only to an already declared plugin.
+                    doAfterVisit(new AddPlugin(MAVEN_PLUGINS_GROUP_ID, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID, null, null, null,
+                            "<executions>" + MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG + "</executions>", "**/pom.xml").getVisitor());
+                    doAfterVisit(new AddPropertiesGoalExecutionVisitor());
+                }
+
                 if (usesRuntimeArgLineProperty()) {
                     doAfterVisit(new AddPropertyVisitor("argLine", "", true));
                 }
@@ -246,23 +229,36 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
         }.reduce(document, new AtomicBoolean()).get();
     }
 
-    private static boolean hasPropertiesGoal(Plugin plugin) {
-        return plugin.getExecutions().stream()
-                .anyMatch(execution -> execution.getGoals() != null && execution.getGoals().contains("properties"));
-    }
-
-    @RequiredArgsConstructor
-    private static class AppendChildTagToParentVisitor extends XmlIsoVisitor<ExecutionContext> {
-        private final XPathMatcher parentXPathMatcher;
-        private final Xml.Tag newChildTag;
+    // Matching the plugin, not each execution, keeps this to one new execution however many the plugin already has.
+    private static class AddPropertiesGoalExecutionVisitor extends XmlIsoVisitor<ExecutionContext> {
+        private static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("/project/build/plugins/plugin");
 
         @Override
         public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
-            if (parentXPathMatcher.matches(getCursor()) &&
-                    tag.getChildren(newChildTag.getName()).stream().noneMatch(child -> child.getValue().equals(newChildTag.getValue()))) {
-                return autoFormat(AddToTagVisitor.addToTag(tag, newChildTag, getCursor()), ctx);
+            Xml.Tag t = super.visitTag(tag, ctx);
+            // A missing groupId is Maven's own; the matcher excludes pluginManagement.
+            if (!"plugin".equals(t.getName()) ||
+                    !MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID.equals(t.getChildValue("artifactId").orElse(null)) ||
+                    !MAVEN_PLUGINS_GROUP_ID.equals(t.getChildValue("groupId").orElse(MAVEN_PLUGINS_GROUP_ID)) ||
+                    !PLUGIN_MATCHER.matches(getCursor())) {
+                return t;
             }
-            return super.visitTag(tag, ctx);
+
+            Optional<Xml.Tag> executions = t.getChild("executions");
+            if (executions.isPresent() && executions.get().getChildren("execution").stream()
+                    .anyMatch(execution -> !execution.getChild("phase").isPresent() &&
+                            execution.getChildren("goals").stream()
+                                    .flatMap(goals -> goals.getChildren("goal").stream())
+                                    .anyMatch(goal -> PROPERTIES_GOAL.equals(goal.getValue().orElse(null))))) {
+                return t;
+            }
+
+            Xml.Tag scope = executions.orElse(t);
+            Xml.Tag tagToAdd = executions.isPresent() ?
+                    Xml.Tag.build(MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG) :
+                    Xml.Tag.build("<executions>" + MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG + "</executions>");
+            return (Xml.Tag) new AddToTagVisitor<ExecutionContext>(scope, tagToAdd)
+                    .visitNonNull(t, ctx, getCursor().getParentOrThrow());
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
+++ b/src/main/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePlugin.java
@@ -29,7 +29,6 @@ import org.openrewrite.maven.AddPropertyVisitor;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.maven.search.DependencyInsight;
 import org.openrewrite.maven.search.FindPlugin;
-import org.openrewrite.maven.trait.MavenPlugin;
 import org.openrewrite.maven.tree.Plugin;
 import org.openrewrite.maven.tree.ResolvedDependency;
 import org.openrewrite.maven.tree.Scope;
@@ -122,29 +121,27 @@ public class AddMockitoJavaAgentToMavenSurefirePlugin extends Recipe {
                                 plugin.getExecutions().stream()
                                         .anyMatch(execution -> execution.getPhase() == null &&
                                                 execution.getGoals() != null && execution.getGoals().contains(PROPERTIES_GOAL)));
-                if (pluginArgLine != null && mavenDependencyPluginRunsPropertiesGoalAtDefaultPhase &&
+                if (mavenDependencyPluginRunsPropertiesGoalAtDefaultPhase && pluginArgLine != null &&
                         (!pluginArgLine.contains("@{argLine}") || getResolutionResult().getPom().getProperties().containsKey("argLine"))) {
                     return document;
                 }
 
+                Xml.Document d = document;
                 if (!mavenDependencyPluginRunsPropertiesGoalAtDefaultPhase) {
                     // AddPlugin no-ops when the plugin exists; the visitor below appends only to an already declared plugin.
-                    doAfterVisit(new AddPlugin(MAVEN_PLUGINS_GROUP_ID, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID, null, null, null,
-                            "<executions>" + MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG + "</executions>", "**/pom.xml").getVisitor());
-                    doAfterVisit(new AddPropertiesGoalExecutionVisitor());
+                    d = (Xml.Document) new AddPlugin(MAVEN_PLUGINS_GROUP_ID, MAVEN_DEPENDENCY_PLUGIN_ARTIFACT_ID, null, null, null,
+                            "<executions>" + MAVEN_DEPENDENCY_PLUGIN_EXECUTION_TAG + "</executions>", "**/pom.xml")
+                            .getVisitor().visitNonNull(d, ctx);
+                    d = (Xml.Document) new AddPropertiesGoalExecutionVisitor().visitNonNull(d, ctx);
                 }
-
                 if (usesRuntimeArgLineProperty()) {
-                    doAfterVisit(new AddPropertyVisitor("argLine", "", true));
+                    d = (Xml.Document) new AddPropertyVisitor("argLine", "", true).visitNonNull(d, ctx);
                 }
-
-                if (FindPlugin.find(document, "org.apache.maven.plugins", "maven-surefire-plugin").isEmpty()) {
-                    doAfterVisit(new AddPlugin("org.apache.maven.plugins", "maven-surefire-plugin", null,
-                            String.format(CONFIGURATION_TAG_TEMPLATE, newArgLineValue(getArgLineJavaAgentArgument())), null,
-                            null, "**/pom.xml").getVisitor());
-                    return document;
-                }
-                return super.visitDocument(document, ctx);
+                return FindPlugin.find(d, MAVEN_PLUGINS_GROUP_ID, MAVEN_SUREFIRE_PLUGIN_ARTIFACT_ID).isEmpty() ?
+                        (Xml.Document) new AddPlugin(MAVEN_PLUGINS_GROUP_ID, MAVEN_SUREFIRE_PLUGIN_ARTIFACT_ID, null,
+                                String.format(CONFIGURATION_TAG_TEMPLATE, newArgLineValue(getArgLineJavaAgentArgument())), null,
+                                null, "**/pom.xml").getVisitor().visitNonNull(d, ctx) :
+                        super.visitDocument(d, ctx);
             }
 
             @Override

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -245,6 +245,7 @@ examples:
               <artifactId>maven-dependency-plugin</artifactId>
               <executions>
                 <execution>
+                  <id>get-mockito-agent-path</id>
                   <goals>
                     <goal>properties</goal>
                   </goals>

--- a/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/AddMockitoJavaAgentToMavenSurefirePluginTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.migrate;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -99,6 +100,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -206,6 +208,9 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                         <configuration>
                           <foobar />
                         </configuration>
+                      </execution>
+                      <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -640,6 +645,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -720,6 +726,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -825,6 +832,9 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                         <configuration>
                           <foobar />
                         </configuration>
+                      </execution>
+                      <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -935,6 +945,362 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                         </configuration>
                         <goals>
                           <goal>analyize</goal>
+                        </goals>
+                      </execution>
+                      <execution>
+                        <id>get-mockito-agent-path</id>
+                        <goals>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """
+        )
+      )
+    );
+  }
+
+  @Issue("https://github.com/moderneinc/customer-requests/issues/2968")
+  @Test
+  void addsSeparateExecutionWhenExistingExecutionRunsAfterTests() {
+    rewriteRun(
+      mavenProject("test-project",
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>${revision}</version>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>copy-dependencies</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """,
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>${revision}</version>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>copy-dependencies</goal>
+                        </goals>
+                      </execution>
+                      <execution>
+                        <id>get-mockito-agent-path</id>
+                        <goals>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """
+        )
+      )
+    );
+  }
+
+  @Test
+  void addsSeparateExecutionWhenPropertiesGoalIsBoundToAPhase() {
+    rewriteRun(
+      mavenProject("test-project",
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>${revision}</version>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>copy-dependencies</goal>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """,
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>${revision}</version>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>copy-dependencies</goal>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                      <execution>
+                        <id>get-mockito-agent-path</id>
+                        <goals>
+                          <goal>properties</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """
+        )
+      )
+    );
+  }
+
+  @Test
+  void addsSingleExecutionWhenMavenDependencyPluginHasSeveralExecutions() {
+    rewriteRun(
+      mavenProject("test-project",
+        pomXml(
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>${revision}</version>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>copy-dependencies</goal>
+                        </goals>
+                      </execution>
+                      <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                          <goal>unpack-dependencies</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                      <!--suppress MavenModelInspection -->
+                      <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
+                  </plugin>
+                </plugins>
+              </build>
+            </project>
+            """,
+          """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>test</artifactId>
+              <version>${revision}</version>
+
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.4</version>
+                <relativePath/>
+              </parent>
+
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-test</artifactId>
+                  <scope>test</scope>
+                </dependency>
+              </dependencies>
+              <build>
+                <plugins>
+                  <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>copy-dependencies</goal>
+                        </goals>
+                      </execution>
+                      <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                          <goal>unpack-dependencies</goal>
+                        </goals>
+                      </execution>
+                      <execution>
+                        <id>get-mockito-agent-path</id>
+                        <goals>
                           <goal>properties</goal>
                         </goals>
                       </execution>
@@ -1238,6 +1604,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                       <artifactId>maven-dependency-plugin</artifactId>
                       <executions>
                         <execution>
+                          <id>get-mockito-agent-path</id>
                           <goals>
                             <goal>properties</goal>
                           </goals>
@@ -1328,6 +1695,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -1684,6 +2052,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -1752,6 +2121,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -1836,6 +2206,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -1934,6 +2305,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>
@@ -2007,6 +2379,7 @@ class AddMockitoJavaAgentToMavenSurefirePluginTest implements RewriteTest {
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                       <execution>
+                        <id>get-mockito-agent-path</id>
                         <goals>
                           <goal>properties</goal>
                         </goals>


### PR DESCRIPTION
- Fixes https://github.com/moderneinc/customer-requests/issues/2968

### The problem

The recipe adds `-javaagent:${org.mockito:mockito-core:jar}` to Surefire's `argLine`, and needs the `maven-dependency-plugin` `properties` goal to define that property. When a project already declared that plugin, the recipe merged `<goal>properties</goal>` into an execution the project owns:

```xml
<execution>
  <id>copy-dependencies</id>
  <phase>package</phase>          <!-- runs after test -->
  <goals>
    <goal>copy-dependencies</goal>
    <goal>properties</goal>       <!-- merged in -->
  </goals>
</execution>
```

An execution owns the phase and the configuration of every goal it lists, so the merged goal inherited both. Bound to `package`, `properties` runs after Surefire forks, the placeholder is passed through verbatim, and the build fails with:

```
Error opening zip file or JAR manifest missing : ${org.mockito:mockito-core:jar}
[ERROR] Error occurred during initialization of VM
```

Two further problems came from the same merge:

- The XPath `.../executions/execution/goals` had no positional predicate and the visitor no one-shot guard, so a plugin with N executions got `<goal>properties</goal>` appended to **all N** goal lists.
- `PropertiesMojo` and `AbstractDependencyMojo` (the base of `copy-dependencies`, `unpack`, `analyze`, …) both declare a `skip` parameter. Maven's configuration finalizer matches by parameter name, so an execution carrying `<skip>` silently skipped the merged goal — the same broken build, with a phase that looks perfectly fine.

### The fix

The `properties` goal now always lands in an execution of its own, never merged into one the project declares:

```xml
<execution>
  <id>get-mockito-agent-path</id>
  <goals>
    <goal>properties</goal>
  </goals>
</execution>
```

No `<phase>`, so Maven binds each goal of the execution to that goal's own default — `initialize` for `dependency:properties`, verified against the mojo descriptor in every published plugin version from 2.4 to 3.11.0.

The explicit `<id>` is load-bearing rather than cosmetic. Maven merges executions by id — for parent inheritance and for `pluginManagement` injection alike — and an omitted id is `default`. Without an id this execution would be captured by any id-less execution declared upstream and handed its `<phase>`, re-entering the same bug from another direction; and appending an id-less execution next to a project's own id-less one is a duplicate-id model validation error.

The guard is `runsPropertiesGoalAtDefaultPhase`: we rely on an existing `properties` goal only when its execution declares no `<phase>`, because that is the one case where its timing is self-evident. Where a project binds the goal to a phase of its own, deciding whether that lands before the tests would mean reasoning about lifecycle ordering, inheritance and property interpolation, so the goal gets its own execution instead. Worst case that is a second run of a goal which only sets properties; it is never a broken build. The check is mirrored against the document because the resolved model is not refreshed between cycles.

This collapses the four-branch cascade to a single path and retires `ChangePluginExecutions` and `AddOrUpdateChildTag` from this recipe. Neither can express the operation: `ChangePluginExecutions` replaces the whole `<executions>` element, and `AddOrUpdateChildTag` is name-keyed and so cannot append a sibling `<execution>`. Dropping the former also closes a second route to the reported error — it matches groupId with `.orElse(null)` where `AddPluginVisitor` defaults the implied Apache group, so a `<plugin>` declared without a `<groupId>` used to no-op silently while the `argLine` was still written.

### Tests

Four scenarios added:

- `addsSeparateExecutionWhenExistingExecutionRunsAfterTests` — the reported reproduction
- `addsSeparateExecutionWhenPropertiesGoalIsBoundToAPhase` — we do not rely on a phase-bound `properties` goal
- `addsSingleExecutionWhenMavenDependencyPluginHasSeveralExecutions` — one execution added regardless of how many exist, with an implied groupId
- plus the existing suite, where twelve expected outputs changed: nine gained the `<id>` line, three moved the goal out of the project's execution into its own

### Notes for review

The three restructured fixtures did **not** encode broken behaviour. Their executions are phase-less, and Maven binds each goal of a phase-less execution to that goal's own default, so the previous merge was functionally correct there. This change is a correctness fix for the explicit-late-phase case, plus hardening against configuration inheritance and the N-execution amplification.

One pre-existing gap is untouched and worth a separate look: branch selection reads the resolved model, which includes parent-inherited and active-profile plugins, while the edit is anchored at `/project/build/plugins` of the current document. A plugin declared only in a parent or only in a profile therefore gets the `argLine` without the `properties` goal. It is not the failure reported here, and no test covers it today.
