### PR TITLE
Do not apply `var` when the generic return type needs the declared type

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -23,12 +23,14 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
+import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
@@ -226,12 +228,10 @@ final class DeclarationCheck {
 
     /**
      * Checks whether the initializer {@linkplain Expression} is a {@linkplain J.MethodInvocation} of a generic method
-     * whose type parameter can only be inferred from the assignment target, as in {@code <T> T getArgument(int index)}.
-     * Replacing the declared type with {@code var} drops that target type, so the type parameter is inferred as
-     * {@linkplain Object} instead of the declared type.
+     * whose type parameter is only inferable from the declared type, as in {@code <T> T getArgument(int index)}.
      *
      * @param initializer {@linkplain J.VariableDeclarations.NamedVariable#getInitializer()} value
-     * @return true iff is initialized by a generic method whose return type cannot be resolved without the declared type
+     * @return true iff is initialized by a generic method that needs the declared type to infer its return type
      */
     public static boolean initializedByUnresolvableGenericMethod(@Nullable Expression initializer) {
         J.MethodInvocation invocation = getMethodInvocation(initializer);
@@ -256,25 +256,71 @@ final class DeclarationCheck {
         if (mt == null || mi.getTypeParameters() != null) {
             return false;
         }
-        // The invocation's return type is already resolved to the declared type, so the declaration is consulted instead.
-        // Methods mentioning their own type parameters in their signature fail this lookup, as the invocation's parameter
-        // types are resolved while the declaration's are not; those are also the methods javac infers from arguments alone.
-        Optional<JavaType.Method> maybeDeclaredMethod = TypeUtils.findDeclaredMethod(mt.getDeclaringType(), mt.getName(), mt.getParameterTypes());
-        if (!maybeDeclaredMethod.isPresent()) {
+        // The invocation's types are already resolved against the declared type, so the declaration is consulted instead
+        return declaresUninferableReturnType(mt.getDeclaringType(), mt.getName(), mt.getParameterTypes().size(), newIdentitySet());
+    }
+
+    private static boolean declaresUninferableReturnType(JavaType.@Nullable FullyQualified clazz, String name, int arity, Set<JavaType> seen) {
+        if (clazz == null || !seen.add(clazz)) {
             return false;
         }
-
-        JavaType.Method declaredMethod = maybeDeclaredMethod.get();
-        JavaType returnType = declaredMethod.getReturnType();
-        while (returnType instanceof JavaType.Array) {
-            returnType = ((JavaType.Array) returnType).getElemType();
+        for (JavaType.Method method : clazz.getMethods()) {
+            if (name.equals(method.getName()) && method.getParameterTypes().size() == arity && returnsUninferableTypeParameter(method)) {
+                return true;
+            }
         }
-        if (!(returnType instanceof JavaType.GenericTypeVariable)) {
+        if (declaresUninferableReturnType(clazz.getSupertype(), name, arity, seen)) {
+            return true;
+        }
+        for (JavaType.FullyQualified anInterface : clazz.getInterfaces()) {
+            if (declaresUninferableReturnType(anInterface, name, arity, seen)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean returnsUninferableTypeParameter(JavaType.Method method) {
+        for (String typeParameterName : method.getDeclaredFormalTypeNames()) {
+            if (mentions(method.getReturnType(), typeParameterName, newIdentitySet()) &&
+                    !mentionsAny(method.getParameterTypes(), typeParameterName, newIdentitySet())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean mentions(JavaType type, String typeParameterName, Set<JavaType> seen) {
+        if (!seen.add(type)) {
             return false;
         }
+        if (type instanceof JavaType.GenericTypeVariable) {
+            JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) type;
+            if (typeParameterName.equals(generic.getName())) {
+                return true;
+            }
+            return mentionsAny(generic.getBounds(), typeParameterName, seen);
+        }
+        if (type instanceof JavaType.Array) {
+            return mentions(((JavaType.Array) type).getElemType(), typeParameterName, seen);
+        }
+        if (type instanceof JavaType.Parameterized) {
+            return mentionsAny(((JavaType.Parameterized) type).getTypeParameters(), typeParameterName, seen);
+        }
+        return false;
+    }
 
-        // Type parameters declared by the class are resolved through the receiver, not the assignment target
-        return declaredMethod.getDeclaredFormalTypeNames().contains(((JavaType.GenericTypeVariable) returnType).getName());
+    private static boolean mentionsAny(List<JavaType> types, String typeParameterName, Set<JavaType> seen) {
+        for (JavaType type : types) {
+            if (mentions(type, typeParameterName, seen)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<JavaType> newIdentitySet() {
+        return newSetFromMap(new IdentityHashMap<>());
     }
 
     /**

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.UnaryOperator;
 
@@ -216,23 +217,60 @@ final class DeclarationCheck {
      * @return true iff is initialized by static method
      */
     public static boolean initializedByStaticMethod(@Nullable Expression initializer) {
-        if (initializer == null) {
+        J.MethodInvocation invocation = getMethodInvocation(initializer);
+        if (invocation == null || invocation.getMethodType() == null) {
             return false;
+        }
+        return invocation.getMethodType().hasFlags(Flag.Static);
+    }
+
+    public static boolean initializedByUnresolvableGenericMethod(@Nullable Expression initializer) {
+        J.MethodInvocation invocation = getMethodInvocation(initializer);
+        return invocation != null && isUnresolvableGenericMethod(invocation);
+    }
+
+    private J.@Nullable MethodInvocation getMethodInvocation(@Nullable Expression initializer) {
+        if (initializer == null) {
+            return null;
         }
         initializer = initializer.unwrap();
 
         if (!(initializer instanceof J.MethodInvocation)) {
-            // no MethodInvocation -> false
+            return null;
+        }
+
+        return (J.MethodInvocation) initializer;
+    }
+
+    private static boolean isUnresolvableGenericMethod(J.MethodInvocation mi) {
+        JavaType.Method mt = mi.getMethodType();
+        if (mt == null || mi.getTypeParameters() != null) {
+            return false;
+        }
+        JavaType.FullyQualified clazz = mt.getDeclaringType();
+        Optional<JavaType.Method> maybeDeclaredMethod = TypeUtils.findDeclaredMethod(clazz, mt.getName(), mt.getParameterTypes());
+        if (!maybeDeclaredMethod.isPresent()) {
             return false;
         }
 
-        J.MethodInvocation invocation = (J.MethodInvocation) initializer;
-        if (invocation.getMethodType() == null) {
-            // not a static method -> false
+        JavaType returnType = maybeDeclaredMethod.get().getReturnType();
+        JavaType.GenericTypeVariable genericReturnType;
+        if (returnType instanceof JavaType.GenericTypeVariable) {
+            genericReturnType = (JavaType.GenericTypeVariable) returnType;
+        } else if (returnType instanceof JavaType.Array && ((JavaType.Array) returnType).getElemType() instanceof JavaType.GenericTypeVariable) {
+            genericReturnType = (JavaType.GenericTypeVariable) ((JavaType.Array) returnType).getElemType();
+        } else {
             return false;
         }
 
-        return invocation.getMethodType().hasFlags(Flag.Static);
+        for (JavaType classParam : clazz.getTypeParameters()) {
+            if (classParam instanceof JavaType.GenericTypeVariable &&
+                ((JavaType.GenericTypeVariable) classParam).getName().equals(genericReturnType.getName())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -224,12 +224,21 @@ final class DeclarationCheck {
         return invocation.getMethodType().hasFlags(Flag.Static);
     }
 
+    /**
+     * Checks whether the initializer {@linkplain Expression} is a {@linkplain J.MethodInvocation} of a generic method
+     * whose type parameter can only be inferred from the assignment target, as in {@code <T> T getArgument(int index)}.
+     * Replacing the declared type with {@code var} drops that target type, so the type parameter is inferred as
+     * {@linkplain Object} instead of the declared type.
+     *
+     * @param initializer {@linkplain J.VariableDeclarations.NamedVariable#getInitializer()} value
+     * @return true iff is initialized by a generic method whose return type cannot be resolved without the declared type
+     */
     public static boolean initializedByUnresolvableGenericMethod(@Nullable Expression initializer) {
         J.MethodInvocation invocation = getMethodInvocation(initializer);
         return invocation != null && isUnresolvableGenericMethod(invocation);
     }
 
-    private J.@Nullable MethodInvocation getMethodInvocation(@Nullable Expression initializer) {
+    private static J.@Nullable MethodInvocation getMethodInvocation(@Nullable Expression initializer) {
         if (initializer == null) {
             return null;
         }
@@ -247,30 +256,25 @@ final class DeclarationCheck {
         if (mt == null || mi.getTypeParameters() != null) {
             return false;
         }
-        JavaType.FullyQualified clazz = mt.getDeclaringType();
-        Optional<JavaType.Method> maybeDeclaredMethod = TypeUtils.findDeclaredMethod(clazz, mt.getName(), mt.getParameterTypes());
+        // The invocation's return type is already resolved to the declared type, so the declaration is consulted instead.
+        // Methods mentioning their own type parameters in their signature fail this lookup, as the invocation's parameter
+        // types are resolved while the declaration's are not; those are also the methods javac infers from arguments alone.
+        Optional<JavaType.Method> maybeDeclaredMethod = TypeUtils.findDeclaredMethod(mt.getDeclaringType(), mt.getName(), mt.getParameterTypes());
         if (!maybeDeclaredMethod.isPresent()) {
             return false;
         }
 
-        JavaType returnType = maybeDeclaredMethod.get().getReturnType();
-        JavaType.GenericTypeVariable genericReturnType;
-        if (returnType instanceof JavaType.GenericTypeVariable) {
-            genericReturnType = (JavaType.GenericTypeVariable) returnType;
-        } else if (returnType instanceof JavaType.Array && ((JavaType.Array) returnType).getElemType() instanceof JavaType.GenericTypeVariable) {
-            genericReturnType = (JavaType.GenericTypeVariable) ((JavaType.Array) returnType).getElemType();
-        } else {
+        JavaType.Method declaredMethod = maybeDeclaredMethod.get();
+        JavaType returnType = declaredMethod.getReturnType();
+        while (returnType instanceof JavaType.Array) {
+            returnType = ((JavaType.Array) returnType).getElemType();
+        }
+        if (!(returnType instanceof JavaType.GenericTypeVariable)) {
             return false;
         }
 
-        for (JavaType classParam : clazz.getTypeParameters()) {
-            if (classParam instanceof JavaType.GenericTypeVariable &&
-                ((JavaType.GenericTypeVariable) classParam).getName().equals(genericReturnType.getName())) {
-                return false;
-            }
-        }
-
-        return true;
+        // Type parameters declared by the class are resolved through the receiver, not the assignment target
+        return declaredMethod.getDeclaredFormalTypeNames().contains(((JavaType.GenericTypeVariable) returnType).getName());
     }
 
     /**

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -58,10 +58,9 @@ public class UseVarForGenericMethodInvocations extends Recipe {
             }
 
             // Recipe specific
-            boolean isPrimitive = DeclarationCheck.isPrimitive(vd);
-            boolean usesNoGenerics = !DeclarationCheck.useGenerics(vd);
-            boolean usesTernary = DeclarationCheck.initializedByTernary(vd);
-            if (isPrimitive || usesTernary || usesNoGenerics) {
+            if (DeclarationCheck.isPrimitive(vd) ||
+                    DeclarationCheck.initializedByTernary(vd) ||
+                    !DeclarationCheck.useGenerics(vd)) {
                 return vd;
             }
 
@@ -73,9 +72,7 @@ public class UseVarForGenericMethodInvocations extends Recipe {
             J.MethodInvocation invocation = (J.MethodInvocation) originalInitializer.unwrap();
 
             // If no type parameters and no arguments are present, we assume the type is too hard to determine
-            boolean hasNoTypeParams = invocation.getTypeParameters() == null;
-            boolean argumentsEmpty = allArgumentsEmpty(invocation);
-            if (hasNoTypeParams && argumentsEmpty) {
+            if (invocation.getTypeParameters() == null && allArgumentsEmpty(invocation)) {
                 return vd;
             }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -62,7 +62,8 @@ public class UseVarForObject extends Recipe {
             Expression initializer = vd.getVariables().get(0).getInitializer();
             boolean usesArrayInitializer = initializer instanceof J.NewArray;
             boolean initializedByStaticMethod = DeclarationCheck.initializedByStaticMethod(initializer);
-            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer || initializedByStaticMethod) {
+            boolean initializedByUnresolvableGenericMethod = DeclarationCheck.initializedByUnresolvableGenericMethod(initializer);
+            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer || initializedByStaticMethod || initializedByUnresolvableGenericMethod) {
                 return vd;
             }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -62,8 +62,8 @@ public class UseVarForObject extends Recipe {
             Expression initializer = vd.getVariables().get(0).getInitializer();
             boolean usesArrayInitializer = initializer instanceof J.NewArray;
             boolean initializedByStaticMethod = DeclarationCheck.initializedByStaticMethod(initializer);
-            boolean initializedByUnresolvableGenericMethod = DeclarationCheck.initializedByUnresolvableGenericMethod(initializer);
-            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer || initializedByStaticMethod || initializedByUnresolvableGenericMethod) {
+            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer || initializedByStaticMethod ||
+                    DeclarationCheck.initializedByUnresolvableGenericMethod(initializer)) {
                 return vd;
             }
 

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForObject.java
@@ -56,13 +56,12 @@ public class UseVarForObject extends Recipe {
                 return vd;
             }
 
-            boolean isPrimitive = DeclarationCheck.isPrimitive(vd);
-            boolean usesGenerics = DeclarationCheck.useGenerics(vd);
-            boolean usesTernary = DeclarationCheck.initializedByTernary(vd);
             Expression initializer = vd.getVariables().get(0).getInitializer();
-            boolean usesArrayInitializer = initializer instanceof J.NewArray;
-            boolean initializedByStaticMethod = DeclarationCheck.initializedByStaticMethod(initializer);
-            if (isPrimitive || usesGenerics || usesTernary || usesArrayInitializer || initializedByStaticMethod ||
+            if (DeclarationCheck.isPrimitive(vd) ||
+                    DeclarationCheck.useGenerics(vd) ||
+                    DeclarationCheck.initializedByTernary(vd) ||
+                    initializer instanceof J.NewArray ||
+                    DeclarationCheck.initializedByStaticMethod(initializer) ||
                     DeclarationCheck.initializedByUnresolvableGenericMethod(initializer)) {
                 return vd;
             }

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
@@ -235,7 +235,7 @@ class UseVarForObjectsTest extends VarBaseTest {
             @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
             @Test
             void typeToken() {
-                // `T` is inferred from the `Class<T>` argument rather than from the declared type, so `var` is safe
+                // `T` is inferred from the `Class<T>` argument, not from the declared type
                 //language=java
                 rewriteRun(
                   version(
@@ -447,6 +447,44 @@ class UseVarForObjectsTest extends VarBaseTest {
                   )
                 );
             }
+
+            @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+            @Test
+            void genericMethodInferredFromWildcardBoundedArgument() {
+                //language=java
+                rewriteRun(
+                  java(
+                    """
+                      package com.example.app;
+
+                      import java.util.function.Supplier;
+
+                      class A {
+                        <T> T orElse(Supplier<? extends T> supplier) {
+                          return supplier.get();
+                        }
+                        void m(Supplier<String> supplier) {
+                            String s = orElse(supplier);
+                        }
+                      }
+                      """,
+                    """
+                      package com.example.app;
+
+                      import java.util.function.Supplier;
+
+                      class A {
+                        <T> T orElse(Supplier<? extends T> supplier) {
+                          return supplier.get();
+                        }
+                        void m(Supplier<String> supplier) {
+                            var s = orElse(supplier);
+                        }
+                      }
+                      """
+                  )
+                );
+            }
         }
     }
 
@@ -490,6 +528,58 @@ class UseVarForObjectsTest extends VarBaseTest {
                   class A {
                     void m(Invocation invocation) {
                         String s = invocation.getArgument(0);
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+        @Test
+        void genericMethodDeclaredOnGenericInterface() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  import java.util.List;
+
+                  interface Cache<K> {
+                    <T> T get(K key);
+                    <T> T getAll(List<K> keys);
+                  }
+                  class A {
+                    void m(Cache<String> cache, List<String> keys) {
+                        String s = cache.get("k");
+                        String t = cache.getAll(keys);
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+        @Test
+        void genericMethodInheritedFromSuperclass() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  class Base {
+                    <T> T get(int index) {
+                      return null;
+                    }
+                  }
+                  class Sub extends Base {
+                  }
+                  class A {
+                    void m(Sub sub) {
+                        String s = sub.get(0);
                     }
                   }
                   """

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
@@ -233,6 +233,39 @@ class UseVarForObjectsTest extends VarBaseTest {
             }
 
             @Test
+            void typeToken() {
+                //language=java
+                rewriteRun(
+                  version(
+                    java("""
+                      package com.example.app;
+
+                      class A {
+                        <T> T typeToken(Class<T> clazz) {
+                            return null;
+                        }
+                        void m() {
+                            String s = typeToken(String.class);
+                        }
+                      }
+                      """, """
+                      package com.example.app;
+
+                      class A {
+                        <T> T typeToken(Class<T> clazz) {
+                            return null;
+                        }
+                        void m() {
+                            var s = typeToken(String.class);
+                        }
+                      }
+                      """),
+                    10
+                  )
+                );
+            }
+
+            @Test
             void subType() {
                 //language=java
                 rewriteRun(
@@ -317,7 +350,7 @@ class UseVarForObjectsTest extends VarBaseTest {
 
             @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/550")
             @Test
-            void genericType() {
+            void classLevelGenericType() {
                 rewriteRun(
                   //language=java
                   java(
@@ -344,11 +377,64 @@ class UseVarForObjectsTest extends VarBaseTest {
                   )
                 );
             }
+
+            @Test
+            void genericMethodWithTypeParameters() {
+                //language=java
+                rewriteRun(
+                  java(
+                    """
+                      package com.example.app;
+
+                      class A {
+                        <T> T method() {
+                          return null;
+                        }
+                        void m() {
+                            String strs = new A().<String>method();
+                        }
+                      }
+                      ""","""
+                      package com.example.app;
+
+                      class A {
+                        <T> T method() {
+                          return null;
+                        }
+                        void m() {
+                            var strs = new A().<String>method();
+                        }
+                      }
+                      """
+                  )
+                );
+            }
         }
     }
 
     @Nested
     class NotApplicable {
+
+        @Test
+        void genericMethod() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  class A {
+                    <T, S extends T> S[] method() {
+                      return null;
+                    }
+                    void m() {
+                        String[] strs = method();
+                    }
+                  }
+                  """
+              )
+            );
+        }
 
         @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/608")
         @Test

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForObjectsTest.java
@@ -232,8 +232,10 @@ class UseVarForObjectsTest extends VarBaseTest {
                 );
             }
 
+            @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
             @Test
             void typeToken() {
+                // `T` is inferred from the `Class<T>` argument rather than from the declared type, so `var` is safe
                 //language=java
                 rewriteRun(
                   version(
@@ -378,6 +380,7 @@ class UseVarForObjectsTest extends VarBaseTest {
                 );
             }
 
+            @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
             @Test
             void genericMethodWithTypeParameters() {
                 //language=java
@@ -394,7 +397,8 @@ class UseVarForObjectsTest extends VarBaseTest {
                             String strs = new A().<String>method();
                         }
                       }
-                      ""","""
+                      """,
+                    """
                       package com.example.app;
 
                       class A {
@@ -409,14 +413,93 @@ class UseVarForObjectsTest extends VarBaseTest {
                   )
                 );
             }
+
+            @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+            @Test
+            void genericMethodInferredFromArgument() {
+                //language=java
+                rewriteRun(
+                  java(
+                    """
+                      package com.example.app;
+
+                      class A {
+                        <T> T identity(T t) {
+                          return t;
+                        }
+                        void m() {
+                            String s = identity("x");
+                        }
+                      }
+                      """,
+                    """
+                      package com.example.app;
+
+                      class A {
+                        <T> T identity(T t) {
+                          return t;
+                        }
+                        void m() {
+                            var s = identity("x");
+                        }
+                      }
+                      """
+                  )
+                );
+            }
         }
     }
 
     @Nested
     class NotApplicable {
 
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
         @Test
         void genericMethod() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  class A {
+                    <T> T method() {
+                      return null;
+                    }
+                    void m() {
+                        String s = method();
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+        @Test
+        void genericMethodDeclaredOnInterface() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  interface Invocation {
+                    <T> T getArgument(int index);
+                  }
+                  class A {
+                    void m(Invocation invocation) {
+                        String s = invocation.getArgument(0);
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+        @Test
+        void genericMethodReturningArray() {
             //language=java
             rewriteRun(
               java(
@@ -429,6 +512,50 @@ class UseVarForObjectsTest extends VarBaseTest {
                     }
                     void m() {
                         String[] strs = method();
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+        @Test
+        void genericMethodReturningMultiDimensionalArray() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  class A {
+                    <T> T[][] method() {
+                      return null;
+                    }
+                    void m() {
+                        String[][] strs = method();
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/1187")
+        @Test
+        void genericMethodShadowingClassTypeParameter() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  class A<T> {
+                    <T> T method() {
+                      return null;
+                    }
+                    void m() {
+                        String s = method();
                     }
                   }
                   """


### PR DESCRIPTION
## What's changed?
`UseVarForObject` no longer replaces an explicit type with `var` when the initializer is a generic method invocation whose type parameter is only inferable from the declared type.

For a method declared as:

```java
<T> T getArgument(int index);
```

rewriting:

```java
String s = getArgument(0);
```

to:

```java
var s = getArgument(0);
```

drops the target type that `T` was inferred from, so javac infers `Object` instead of `String`.

A method is treated as unresolvable when one of its **own** type parameters occurs in the declared return type but in none of the declared parameter types. That keeps the recipe applying wherever inference does not depend on the declared type:

- `<T> T identity(T t)` and `<T> T typeToken(Class<T> c)` still convert, because `T` is inferred from the arguments.
- `new A().<String>method()` still converts, because an explicit type witness is present.
- `abstract T doIt()` on `class Outer<T>` still converts, because class type parameters resolve through the receiver rather than the assignment target.

Occurrence checking recurses through arrays, type arguments and generic bounds, and candidate declarations are resolved by name and arity across the declaring type, its supertypes and its interfaces. That covers `S[]`, `T[][]` and `List<T>` returns, generic methods inherited from a superclass or declared on an interface, and a method type parameter shadowing a class type parameter of the same name.

## What's your motivation?
Using `var` here changes the inferred type of the variable and results in compilation errors or incorrect behaviour. A real world example is Mockito's [`InvocationOnMock#getArgument(int)`](https://github.com/mockito/mockito/blob/main/mockito-core/src/main/java/org/mockito/invocation/InvocationOnMock.java#L66), declared as `<T> T getArgument(int index)`, which is where this surfaced.

## Anything in particular you'd like reviewers to focus on?
Whether the detection is precise enough, in both directions: it should not leave `var` off a declaration that would compile fine, and it should not let one through that silently infers `Object`.

The applicability checks in `UseVarForObject` and `UseVarForGenericMethodInvocations` are now inlined into their `if` statements, so the cheap `instanceof` checks reject a declaration before the type hierarchy walk runs. That is a refactor with no behavioural change.

## Have you considered any alternatives or workarounds?
Writing `var argument = this.<String>getMethod();` compiles, but it is more verbose and less idiomatic than keeping the explicit type on the variable.

An earlier iteration relied on `TypeUtils.findDeclaredMethod` failing to match signatures that mention a type parameter. That happened to give the right answer for the common cases, but it was incidental rather than intended, and it broke for generic methods declared on a generic type such as `interface Cache<K> { <T> T get(K key); }`.

## Any additional context
Tests added: `genericMethod`, `genericMethodDeclaredOnInterface`, `genericMethodDeclaredOnGenericInterface`, `genericMethodInheritedFromSuperclass`, `genericMethodReturningArray`, `genericMethodReturningMultiDimensionalArray` and `genericMethodShadowingClassTypeParameter` as not applicable; `typeToken`, `genericMethodWithTypeParameters`, `genericMethodInferredFromArgument` and `genericMethodInferredFromWildcardBoundedArgument` as applicable. The pre-existing `genericType` was renamed to `classLevelGenericType` to distinguish it from the method level cases.

Original fix by @jevanlingen; the detection refinements and tests are review follow-ups.