### PR TITLE
Derive SDKMAN test versions from the candidate list

### DIFF
--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -18,7 +18,16 @@ package org.openrewrite.java.migrate;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.semver.LatestRelease;
 import org.openrewrite.test.RewriteTest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.test.SourceSpecs.text;
@@ -26,18 +35,36 @@ import static org.openrewrite.test.SourceSpecs.text;
 
 class UpdateSdkManTest implements RewriteTest {
 
+    /**
+     * The nightly SDKMAN! candidates refresh drops patch versions as new ones appear, so tests that need an exact
+     * version read a currently available one from the same candidate list the recipe resolves against.
+     */
+    private static String latestPatchVersion(String majorVersion, String distribution) {
+        Pattern pattern = Pattern.compile("^" + majorVersion + "\\.\\d+\\.\\d+-" + distribution + "$");
+        try (InputStream candidates = UpdateSdkMan.class.getResourceAsStream("/sdkman-java.csv");
+             BufferedReader reader = new BufferedReader(new InputStreamReader(candidates, StandardCharsets.UTF_8))) {
+            return reader.lines()
+              .filter(candidate -> pattern.matcher(candidate).matches())
+              .max(new LatestRelease("-" + distribution))
+              .map(candidate -> candidate.substring(0, candidate.length() - distribution.length() - 1))
+              .orElseThrow(() -> new IllegalStateException(
+                String.format("No %s candidate for Java %s in sdkman-java.csv", distribution, majorVersion)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     @DocumentExample
     @Test
     void updateVersionExact() {
+        String version = latestPatchVersion("17", "tem");
         rewriteRun(
-          spec -> spec.recipe(new UpdateSdkMan("17.0.19", null)),
+          spec -> spec.recipe(new UpdateSdkMan(version, null)),
           text(
             """
               java=11.1.2-tem
               """,
-            """
-              java=17.0.19-tem
-              """,
+            "java=" + version + "-tem\n",
             spec -> spec.path(".sdkmanrc")
           )
         );
@@ -59,15 +86,12 @@ class UpdateSdkManTest implements RewriteTest {
 
     @Test
     void updateDistributionOnly() {
+        String version = latestPatchVersion("11", "amzn");
         rewriteRun(
           spec -> spec.recipe(new UpdateSdkMan(null, "amzn")),
           text(
-            """
-              java=11.0.31-zulu
-              """,
-            """
-              java=11.0.31-amzn
-              """,
+            "java=" + version + "-zulu\n",
+            "java=" + version + "-amzn\n",
             spec -> spec.path(".sdkmanrc")
           )
         );


### PR DESCRIPTION
## What's changed?
`UpdateSdkManTest.updateVersionExact` and `UpdateSdkManTest.updateDistributionOnly` now read a currently available patch version from `sdkman-java.csv`, rather than hardcoding one.

## What's your motivation?
The nightly SDKMAN! candidates refresh (`96e8647d`) rolled `17.0.19` to `17.0.20` and `11.0.31` to `11.0.32`, turning CI red on every open pull request:

```
UpdateSdkManTest > updateVersionExact() FAILED
    java.lang.AssertionError: Recipe was expected to make a change but made no changes.
UpdateSdkManTest > updateDistributionOnly() FAILED
    java.lang.AssertionError: Recipe was expected to make a change but made no changes.
```

## Anything in particular you'd like reviewers to focus on?
- #1183 fixed the same class of breakage by asserting on the version basis instead of the exact patch version. That is not sufficient here: these two tests pin a patch version on their **input** as well as their expectation. `UpdateSdkMan` builds `Pattern.compile("^" + ver + "[.-].*")` from that input, so once the candidate list drops `11.0.31`, nothing matches, `idealCandidate` is null and the recipe makes no change at all — a relaxed assertion still fails. I verified that locally before taking this approach.

Reading the version from the candidate list keeps both tests honest about what they cover (`updateVersionExact` still passes a fully qualified version; `updateDistributionOnly` still changes only the distribution) without re-pinning to values that expire.

Verified green against both the pre-refresh candidate list (`17.0.19` / `11.0.31`) and the current one (`17.0.20` / `11.0.32`).