### PR TITLE
Add JSpecify for Micrometer projects and keep it for Spring projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
     testRuntimeOnly("org.apache.groovy:groovy:4.+")
     testRuntimeOnly("org.jboss.logging:jboss-logging:3.6.0.Final")
     testRuntimeOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
+    testRuntimeOnly("io.micrometer:micrometer-core:1.15.1")
     testRuntimeOnly("org.springframework:spring-core:6.1.13")
     testRuntimeOnly("io.micronaut:micronaut-core:4.10.8")
     testRuntimeOnly("com.google.code.findbugs:jsr305:3.0.2")

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -32,6 +32,7 @@ recipeList:
     groupId: org.jspecify
     artifactId: jspecify
     version: 1.0.0
+    # *ull* matches Nullable, NonNull, NonNullApi and NonNullFields
     onlyIfUsing: org.springframework.lang.*ull*
     acceptTransitive: true
 - org.openrewrite.staticanalysis.AnnotateNullableMethods
@@ -158,6 +159,7 @@ recipeList:
       groupId: org.jspecify
       artifactId: jspecify
       version: 1.0.0
+      # *ull* matches Nullable, NonNull, NonNullApi and NonNullFields
       onlyIfUsing: io.micrometer.core.lang.*ull*
       acceptTransitive: true
   - org.openrewrite.java.migrate.jspecify.MoveAnnotationToArrayType:

--- a/src/main/resources/META-INF/rewrite/jspecify.yml
+++ b/src/main/resources/META-INF/rewrite/jspecify.yml
@@ -25,6 +25,15 @@ preconditions:
   - org.openrewrite.Singleton
 recipeList:
 - org.openrewrite.java.jspecify.MigrateToJSpecify
+# The static analysis recipes below introduce `org.jspecify.annotations.*`, and the Spring
+# migration leaf is deliberately disabled in MigrateToJSpecify, so Spring projects still need
+# the JSpecify dependency.
+- org.openrewrite.java.dependencies.AddDependency:
+    groupId: org.jspecify
+    artifactId: jspecify
+    version: 1.0.0
+    onlyIfUsing: org.springframework.lang.*ull*
+    acceptTransitive: true
 - org.openrewrite.staticanalysis.AnnotateNullableMethods
 - org.openrewrite.staticanalysis.AnnotateNullableParameters
 - org.openrewrite.staticanalysis.AnnotateRequiredParameters
@@ -149,7 +158,7 @@ recipeList:
       groupId: org.jspecify
       artifactId: jspecify
       version: 1.0.0
-      onlyIfUsing: org.springframework.lang.*ull*
+      onlyIfUsing: io.micrometer.core.lang.*ull*
       acceptTransitive: true
   - org.openrewrite.java.migrate.jspecify.MoveAnnotationToArrayType:
       annotationType: io.micrometer.core.lang.*ull*

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
@@ -23,6 +23,8 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 @SuppressWarnings("NotNullFieldNotInitialized")
@@ -38,6 +40,7 @@ class JSpecifyBestPracticesTest implements RewriteTest {
             "jakarta.annotation-api",
             "annotations",
             "spring-core",
+            "micrometer-core",
             "micronaut-core"));
     }
 
@@ -455,6 +458,373 @@ class JSpecifyBestPracticesTest implements RewriteTest {
                       @NonNull
                       public String barField;
                     }
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-core</artifactId>
+                            <version>6.1.13</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jspecify</groupId>
+                            <artifactId>jspecify</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-core</artifactId>
+                            <version>6.1.13</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void migrateFromMicrometerAnnotationsToJspecify() {
+        rewriteRun(
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import io.micrometer.core.lang.NonNull;
+                  import io.micrometer.core.lang.Nullable;
+
+                  public class Test {
+                      @NonNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                      @Nullable
+                      public Foo.Bar foobar;
+                  }
+
+                  interface Foo {
+                    class Bar {
+                      @NonNull
+                      public String barField;
+                    }
+                  }
+                  """,
+                """
+                  import org.jspecify.annotations.NonNull;
+                  import org.jspecify.annotations.Nullable;
+
+                  public class Test {
+                      @NonNull
+                      public String field1;
+                      @Nullable
+                      public String field2;
+                      public Foo.@Nullable Bar foobar;
+                  }
+
+                  interface Foo {
+                    class Bar {
+                      @NonNull
+                      public String barField;
+                    }
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micrometer</groupId>
+                            <artifactId>micrometer-core</artifactId>
+                            <version>1.15.1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micrometer</groupId>
+                            <artifactId>micrometer-core</artifactId>
+                            <version>1.15.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jspecify</groupId>
+                            <artifactId>jspecify</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void migrateFromMicrometerAnnotationsWithExistingJspecifyDependency() {
+        rewriteRun(
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import io.micrometer.core.lang.Nullable;
+
+                  public class Test {
+                      @Nullable
+                      public String field1;
+                  }
+                  """,
+                """
+                  import org.jspecify.annotations.Nullable;
+
+                  public class Test {
+                      @Nullable
+                      public String field1;
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micrometer</groupId>
+                            <artifactId>micrometer-core</artifactId>
+                            <version>1.15.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jspecify</groupId>
+                            <artifactId>jspecify</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void micrometerProjectBuiltWithGradleAlsoGetsTheJspecifyDependency() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import io.micrometer.core.lang.Nullable;
+
+                  public class Test {
+                      @Nullable
+                      public String field;
+                  }
+                  """,
+                """
+                  import org.jspecify.annotations.Nullable;
+
+                  public class Test {
+                      @Nullable
+                      public String field;
+                  }
+                  """
+              )
+            ),
+            //language=groovy
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation "io.micrometer:micrometer-core:1.15.1"
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation "io.micrometer:micrometer-core:1.15.1"
+                    implementation "org.jspecify:jspecify:1.0.0"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void micrometerRecipeDoesNotActivateOnSpringAnnotations() {
+        rewriteRun(
+          spec -> spec.recipeFromResource(
+            "/META-INF/rewrite/jspecify.yml",
+            "org.openrewrite.java.jspecify.MigrateFromMicrometerAnnotations"),
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import org.springframework.lang.Nullable;
+
+                  public class Test {
+                      @Nullable
+                      public String field1;
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-core</artifactId>
+                            <version>6.1.13</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void micrometerRecipeDoesNotActivateWithoutNullnessAnnotations() {
+        rewriteRun(
+          spec -> spec.recipeFromResource(
+            "/META-INF/rewrite/jspecify.yml",
+            "org.openrewrite.java.jspecify.MigrateFromMicrometerAnnotations"),
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  public class Test {
+                      public String field1;
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.foobar</groupId>
+                    <artifactId>foobar-core</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micrometer</groupId>
+                            <artifactId>micrometer-core</artifactId>
+                            <version>1.15.1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addJspecifyDependencyOnSpringOnlyProject() {
+        // The Spring migration leaf is deliberately disabled in MigrateToJSpecify, but the static
+        // analysis recipes in JSpecifyBestPractices still introduce `org.jspecify.annotations.*`,
+        // so a Spring-only project must still get the JSpecify dependency.
+        rewriteRun(
+          mavenProject("foo",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import org.springframework.lang.Nullable;
+
+                  public class Test {
+                      @Nullable
+                      public String field1;
+
+                      public String maybe() {
+                          if (field1 != null) {
+                              return field1;
+                          }
+                          return null;
+                      }
+                  }
+                  """,
+                """
+                  import org.springframework.lang.Nullable;
+
+                  public class Test {
+                      @Nullable
+                      public String field1;
+
+                      public @org.jspecify.annotations.Nullable String maybe() {
+                          if (field1 != null) {
+                              return field1;
+                          }
+                          return null;
+                      }
                   }
                   """
               )

--- a/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/jspecify/JSpecifyBestPracticesTest.java
@@ -789,9 +789,8 @@ class JSpecifyBestPracticesTest implements RewriteTest {
 
     @Test
     void addJspecifyDependencyOnSpringOnlyProject() {
-        // The Spring migration leaf is deliberately disabled in MigrateToJSpecify, but the static
-        // analysis recipes in JSpecifyBestPractices still introduce `org.jspecify.annotations.*`,
-        // so a Spring-only project must still get the JSpecify dependency.
+        // MigrateToJSpecify disables the Spring leaf, but JSpecifyBestPractices still introduces
+        // `org.jspecify.annotations.*`, so a Spring-only project still needs the dependency
         rewriteRun(
           mavenProject("foo",
             //language=java


### PR DESCRIPTION
**Suggested review order:** 3 of 52 (Score: 9)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1204

## What's changed?

The `AddDependency` step of [`MigrateFromMicrometerAnnotations`](https://docs.openrewrite.org/recipes/java/jspecify/migratefrommicrometerannotations) now names the package that this recipe actually migrates:

```diff
-      onlyIfUsing: org.springframework.lang.*ull*
+      onlyIfUsing: io.micrometer.core.lang.*ull*
```

The source rewrite is unchanged: `io.micrometer.core.lang.NonNull` and `Nullable` become `org.jspecify.annotations.*` on main and on this branch alike. The change only corrects the generated build file.

`JSpecifyBestPractices` also gains its own `AddDependency` step, guarded on the Spring package, so a Spring project gets the same `pom.xml` from `JSpecifyBestPractices` as it gets on main today. That second half is not optional, for the reason given under alternatives.

## What's your motivation?

**Recipe:** `org.openrewrite.java.migrate.jakarta.MigrateFromMicrometerToJSpecify`.

### Before

```xml
<dependency>
  <groupId>io.micrometer</groupId>
  <artifactId>micrometer-core</artifactId>
</dependency>
```

### Actual after the recipe

```xml
<!-- annotations migrated, but no JSpecify dependency added -->
```

### Expected after the recipe

```xml
<dependency>
  <groupId>org.jspecify</groupId>
  <artifactId>jspecify</artifactId>
  <version>1.0.0</version>
</dependency>
```

This recipe rewrites `io.micrometer.core.lang.Nullable` and `io.micrometer.core.lang.NonNull` to `org.jspecify.annotations.*`, but on main its `AddDependency` step is guarded on `onlyIfUsing: org.springframework.lang.*ull*`. That option adds the dependency only to a project whose source uses one of the types the pattern matches, here the `org.springframework.lang` types whose simple name contains `ull`. This recipe never matches, rewrites or imports a type from that package, so for a Micrometer project the guard never fires. Every other migration recipe in `jspecify.yml` is guarded on the package that the same recipe migrates.

The output therefore does not compile: the migrated source imports `org.jspecify.annotations`, which the migrated project's own build file does not provide, so javac reports `error: package org.jspecify.annotations does not exist`.

The wrong guard also produces the opposite error, a dependency added to a project that does not need one. On main this recipe adds `org.jspecify:jspecify` to a Spring-only project, one using the `org.springframework.lang` nullness annotations and no Micrometer ones, whose sources it never touches. `MigrateToJSpecify` deliberately leaves `MigrateFromSpringFrameworkAnnotations` out of its recipe list, so such a project run through `MigrateToJSpecify` gets the new dependency and not one changed source file. Both `MigrateToJSpecify` and `JSpecifyBestPractices` run this recipe, so both are affected. Reproduced on 3.40.0, 3.41.0 and 3.42.0-SNAPSHOT from main at 26f898e8.

### Affected code in real projects

- [`facebook/fbthrift` `ThriftAbstractTimer.java`](https://github.com/facebook/fbthrift/blob/29fbba333b8bf088ee851d740655e04ec50a2c55/thrift/lib/java/runtime/src/main/java/com/facebook/swift/service/stats/ThriftAbstractTimer.java#L30): Thrift's Java runtime annotates its Micrometer timer with `io.micrometer.core.lang.Nullable`; the project uses no `org.springframework.lang` types and no JSpecify, so the recipe from main rewrites the annotations to `org.jspecify.annotations.*` while its misdirected `AddDependency` guard never fires, and the migrated source references a package the build does not provide.
- [`rsocket/rsocket-java` `CompositeMetadataUtils.java`](https://github.com/rsocket/rsocket-java/blob/fc64b43ac4000772df7fc8334684b715f63cdd68/rsocket-micrometer/src/main/java/io/rsocket/micrometer/observation/CompositeMetadataUtils.java#L19): the `rsocket-micrometer` module marks return values with `io.micrometer.core.lang.Nullable` and the project uses neither `org.springframework.lang` nor JSpecify, so the recipe from main migrates the annotation but adds no `org.jspecify:jspecify` dependency, and the module no longer compiles.
- [`CorfuDB/CorfuDB` `InfluxNamingConvention.java`](https://github.com/CorfuDB/CorfuDB/blob/ccc3774ad87875655a6bb4726f5045eed4d68350/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/InfluxNamingConvention.java#L5): CorfuDB's metrics naming conventions annotate parameters with `io.micrometer.core.lang.Nullable`; the repository contains no `org.springframework.lang` usage and no JSpecify dependency, so the recipe from main rewrites the annotations without adding the artifact they now need.

## Anything in particular you'd like reviewers to focus on?

No existing test expectation changed. The only deleted line in the whole change is the `onlyIfUsing` line shown above, and `defaults(RecipeSpec)` gains `"micrometer-core"` on the shared parser classpath.

The new step in `JSpecifyBestPractices` is guarded on the Spring package rather than on JSpecify itself, because `AddDependency` does not see annotations that other recipes insert during the same run.

Two limits:

- `JSpecifyBestPractices` can still write `org.jspecify.annotations.*` into a project that uses no nullness library at all. No `AddDependency` guard in `jspecify.yml` matches such a project, so no JSpecify dependency is added and the annotations just written do not resolve. That is a separate defect and this change does not address it.
- There is no multi-module test.

## Have you considered any alternatives or workarounds?

Change only the `onlyIfUsing` line and add nothing to `JSpecifyBestPractices`. That is a one-line diff, and a regression for Spring users. `JSpecifyBestPractices` runs `AnnotateNullableMethods`, `AnnotateNullableParameters`, `AnnotateRequiredParameters` and `NullableOnMethodReturnType` after `MigrateToJSpecify`, and those four write `org.jspecify.annotations.*` into a project whatever nullness library it uses, Spring projects included. On main the wrongly guarded `AddDependency` is the only step in `JSpecifyBestPractices` that adds the JSpecify dependency to a Spring project, so correcting the guard and putting nothing in its place would leave Spring projects with those annotations in their source and without the dependency they need.

Leave `micrometer-core` off the test classpath. It was not declared in `build.gradle.kts`, so the tests resolved it transitively through `rewrite-core`, at 1.9.17, while `spring-core` and `micronaut-core` are pinned there with `testRuntimeOnly`. The version matters, because the `io.micrometer.core.lang` package was removed in Micrometer 1.16, so a future bump of that transitive version would silently break these tests. This change pins `testRuntimeOnly("io.micrometer:micrometer-core:1.15.1")` alongside the existing two. 1.15.1 rather than 1.9.17, because it is what the new tests' build file fixtures declare, and 1.15.x is the last minor line that still contains `io.micrometer.core.lang`.

## Any additional context

This change adds 6 tests to `JSpecifyBestPracticesTest`. Without the code change in this pull request, these 3 new tests fail:

- `migrateFromMicrometerAnnotationsToJspecify`: the Micrometer Maven project does not get the JSpecify dependency.
- `micrometerProjectBuiltWithGradleAlsoGetsTheJspecifyDependency`: the Micrometer Gradle project does not get the JSpecify dependency.
- `micrometerRecipeDoesNotActivateOnSpringAnnotations`: the Micrometer recipe changes a Spring-only project.

The other 3 new tests pass without the code change.

The Gradle test needs `spec.beforeRecipe(withToolingApi())`, and the sources and the build file have to sit in the same project, wrapped in `mavenProject(..)`. Without that wrapper the `onlyIfUsing` option never matches, because the Java sources are not attributed to the Gradle project, and `AddDependency` then silently does nothing.

The other 3 pass either way and pin down behaviour this change keeps as it is: `migrateFromMicrometerAnnotationsWithExistingJspecifyDependency`, `micrometerRecipeDoesNotActivateWithoutNullnessAnnotations` and `addJspecifyDependencyOnSpringOnlyProject`.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
