### PR TITLE
Leave files unchanged when legacy Base64 calls cannot be fully migrated

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
+++ b/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
@@ -84,9 +84,8 @@ public class UseJavaUtilBase64 extends Recipe {
                             "Already using a class named Base64 other than java.util.Base64. Manual intervention required."));
                 }
                 if (usesLegacyTypeUntranslatably(cu)) {
-                    // A legacy coder type appears somewhere this recipe cannot retype or rewrite. Migrating
-                    // only part of the file would either not compile or leave a sun.misc reference behind, so
-                    // leave the whole file for a human.
+                    // Migrating only part of the file would either not compile or leave a `sun.misc` reference
+                    // behind, so leave the whole file for a human
                     return cu;
                 }
                 J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
@@ -98,31 +97,18 @@ public class UseJavaUtilBase64 extends Recipe {
             }
 
             /**
-             * True when a legacy coder type appears somewhere this recipe cannot translate. The recipe only
-             * retypes {@code BASE64Encoder} and {@code BASE64Decoder} themselves and only rewrites the
-             * overloads that have a {@code java.util.Base64} equivalent, so the file is left alone when:
-             * <ul>
-             * <li>an expression's static type is {@code CharacterEncoder} or {@code CharacterDecoder},
-             * for example a receiver declared as the legacy supertype, which {@link ChangeType} never
-             * retypes;</li>
-             * <li>a class extends one of the legacy coder types, or instantiates one with an anonymous
-             * class body, since {@code Base64.Encoder} and {@code Base64.Decoder} have no accessible
-             * constructor;</li>
-             * <li>a legacy coder method with no {@code java.util.Base64} equivalent is called, or a
-             * supported overload is called on a receiver that is not typed as {@code BASE64Encoder} or
-             * {@code BASE64Decoder}, for example a subclass declared in another compilation unit;</li>
-             * <li>a legacy coder method or constructor is used as a method reference, which is never
-             * rewritten;</li>
-             * <li>a value is passed to a method that keeps a {@code CharacterEncoder} or
-             * {@code CharacterDecoder} parameter.</li>
-             * </ul>
+             * True when a legacy coder type appears somewhere this recipe cannot translate: an expression statically
+             * typed as {@code CharacterEncoder} or {@code CharacterDecoder}, which {@link ChangeType} never retypes; a
+             * subclass or anonymous body, since {@code Base64.Encoder} has no accessible constructor; a call with no
+             * {@code java.util.Base64} equivalent, or on a receiver not typed as one of the two coders; a method
+             * reference, which is never rewritten; or a value passed to a parameter that stays a legacy coder.
              */
             private boolean usesLegacyTypeUntranslatably(J.CompilationUnit cu) {
                 AtomicBoolean found = new AtomicBoolean(false);
                 new JavaIsoVisitor<AtomicBoolean>() {
                     @Override
                     public J.Import visitImport(J.Import anImport, AtomicBoolean found) {
-                        // Imports are rewritten by ChangeType and are not a place a value can flow through
+                        // `ChangeType` rewrites imports, and no value flows through one
                         return anImport;
                     }
 
@@ -144,8 +130,7 @@ public class UseJavaUtilBase64 extends Recipe {
 
                     @Override
                     public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean found) {
-                        // The type of an anonymous class creation is the anonymous class itself, so
-                        // walk the supertype chain to find `new BASE64Encoder() { ... }` as well
+                        // An anonymous creation's type is the anonymous class, so walk its supertypes too
                         if (newClass.getBody() != null &&
                             (TypeUtils.isAssignableTo(sunPackage + ".CharacterEncoder", newClass.getType()) ||
                              TypeUtils.isAssignableTo(sunPackage + ".CharacterDecoder", newClass.getType())) ||

--- a/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
+++ b/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java
@@ -17,20 +17,25 @@ package org.openrewrite.java.migrate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.template.Semantics;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.staticanalysis.UnnecessaryCatch;
 
 import java.util.Base64;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class UseJavaUtilBase64 extends Recipe {
     private final String sunPackage;
@@ -65,6 +70,9 @@ public class UseJavaUtilBase64 extends Recipe {
         MethodMatcher base64EncodeMethod = new MethodMatcher(sunPackage + ".CharacterEncoder *(byte[])");
         MethodMatcher base64DecodeBuffer = new MethodMatcher(sunPackage + ".CharacterDecoder decodeBuffer(String)");
 
+        MethodMatcher anyEncoderMethod = new MethodMatcher(sunPackage + ".CharacterEncoder *(..)", true);
+        MethodMatcher anyDecoderMethod = new MethodMatcher(sunPackage + ".CharacterDecoder *(..)", true);
+
         MethodMatcher newBase64Encoder = new MethodMatcher(sunPackage + ".BASE64Encoder <constructor>()");
         MethodMatcher newBase64Decoder = new MethodMatcher(sunPackage + ".BASE64Decoder <constructor>()");
 
@@ -75,6 +83,12 @@ public class UseJavaUtilBase64 extends Recipe {
                     return Markup.warn(cu, new IllegalStateException(
                             "Already using a class named Base64 other than java.util.Base64. Manual intervention required."));
                 }
+                if (usesLegacyTypeUntranslatably(cu)) {
+                    // A legacy coder type appears somewhere this recipe cannot retype or rewrite. Migrating
+                    // only part of the file would either not compile or leave a sun.misc reference behind, so
+                    // leave the whole file for a human.
+                    return cu;
+                }
                 J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
 
                 c = (J.CompilationUnit) new ChangeType(sunPackage + ".BASE64Encoder", "java.util.Base64$Encoder", true)
@@ -83,11 +97,137 @@ public class UseJavaUtilBase64 extends Recipe {
                         .getVisitor().visitNonNull(c, ctx);
             }
 
+            /**
+             * True when a legacy coder type appears somewhere this recipe cannot translate. The recipe only
+             * retypes {@code BASE64Encoder} and {@code BASE64Decoder} themselves and only rewrites the
+             * overloads that have a {@code java.util.Base64} equivalent, so the file is left alone when:
+             * <ul>
+             * <li>an expression's static type is {@code CharacterEncoder} or {@code CharacterDecoder},
+             * for example a receiver declared as the legacy supertype, which {@link ChangeType} never
+             * retypes;</li>
+             * <li>a class extends one of the legacy coder types, or instantiates one with an anonymous
+             * class body, since {@code Base64.Encoder} and {@code Base64.Decoder} have no accessible
+             * constructor;</li>
+             * <li>a legacy coder method with no {@code java.util.Base64} equivalent is called, or a
+             * supported overload is called on a receiver that is not typed as {@code BASE64Encoder} or
+             * {@code BASE64Decoder}, for example a subclass declared in another compilation unit;</li>
+             * <li>a legacy coder method or constructor is used as a method reference, which is never
+             * rewritten;</li>
+             * <li>a value is passed to a method that keeps a {@code CharacterEncoder} or
+             * {@code CharacterDecoder} parameter.</li>
+             * </ul>
+             */
+            private boolean usesLegacyTypeUntranslatably(J.CompilationUnit cu) {
+                AtomicBoolean found = new AtomicBoolean(false);
+                new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Import visitImport(J.Import anImport, AtomicBoolean found) {
+                        // Imports are rewritten by ChangeType and are not a place a value can flow through
+                        return anImport;
+                    }
+
+                    @Override
+                    public Expression visitExpression(Expression expression, AtomicBoolean found) {
+                        if (isLegacySupertype(expression.getType())) {
+                            found.set(true);
+                        }
+                        return super.visitExpression(expression, found);
+                    }
+
+                    @Override
+                    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, AtomicBoolean found) {
+                        if (classDecl.getExtends() != null && isLegacyCoderType(classDecl.getExtends().getType())) {
+                            found.set(true);
+                        }
+                        return super.visitClassDeclaration(classDecl, found);
+                    }
+
+                    @Override
+                    public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean found) {
+                        // The type of an anonymous class creation is the anonymous class itself, so
+                        // walk the supertype chain to find `new BASE64Encoder() { ... }` as well
+                        if (newClass.getBody() != null &&
+                            (TypeUtils.isAssignableTo(sunPackage + ".CharacterEncoder", newClass.getType()) ||
+                             TypeUtils.isAssignableTo(sunPackage + ".CharacterDecoder", newClass.getType())) ||
+                            takesLegacySupertypeParameter(newClass.getMethodType())) {
+                            found.set(true);
+                        }
+                        return super.visitNewClass(newClass, found);
+                    }
+
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
+                        if (isLegacyCoderMethod(method.getMethodType())) {
+                            Expression select = method.getSelect();
+                            if (!(encodeToString(method) || base64DecodeBuffer.matches(method)) ||
+                                select == null || !isRetypedCoderClass(select.getType())) {
+                                found.set(true);
+                            }
+                        } else if (takesLegacySupertypeParameter(method.getMethodType())) {
+                            found.set(true);
+                        }
+                        return super.visitMethodInvocation(method, found);
+                    }
+
+                    @Override
+                    public J.MemberReference visitMemberReference(J.MemberReference memberRef, AtomicBoolean found) {
+                        JavaType.Method methodType = memberRef.getMethodType();
+                        if (isLegacyCoderMethod(methodType) ||
+                            methodType == null && isLegacyCoderType(memberRef.getContaining().getType()) ||
+                            methodType != null && (isRetypedCoderClass(methodType.getDeclaringType()) ||
+                                                   takesLegacySupertypeParameter(methodType))) {
+                            found.set(true);
+                        }
+                        return super.visitMemberReference(memberRef, found);
+                    }
+                }.visit(cu, found);
+                return found.get();
+            }
+
+            private boolean isLegacyCoderMethod(JavaType.@Nullable Method methodType) {
+                return methodType != null && (anyEncoderMethod.matches(methodType) || anyDecoderMethod.matches(methodType));
+            }
+
+            private boolean isRetypedCoderClass(@Nullable JavaType type) {
+                return TypeUtils.isOfClassType(type, sunPackage + ".BASE64Encoder") ||
+                       TypeUtils.isOfClassType(type, sunPackage + ".BASE64Decoder");
+            }
+
+            private boolean isLegacySupertype(@Nullable JavaType type) {
+                if (type instanceof JavaType.Array) {
+                    return isLegacySupertype(((JavaType.Array) type).getElemType());
+                }
+                return TypeUtils.isOfClassType(type, sunPackage + ".CharacterEncoder") ||
+                       TypeUtils.isOfClassType(type, sunPackage + ".CharacterDecoder");
+            }
+
+            private boolean isLegacyCoderType(@Nullable JavaType type) {
+                if (type instanceof JavaType.Array) {
+                    return isLegacyCoderType(((JavaType.Array) type).getElemType());
+                }
+                return isRetypedCoderClass(type) || isLegacySupertype(type);
+            }
+
+            private boolean takesLegacySupertypeParameter(JavaType.@Nullable Method methodType) {
+                if (methodType != null) {
+                    for (JavaType parameterType : methodType.getParameterTypes()) {
+                        if (isLegacySupertype(parameterType)) {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            private boolean encodeToString(J.MethodInvocation method) {
+                return base64EncodeMethod.matches(method) &&
+                       ("encode".equals(method.getSimpleName()) || "encodeBuffer".equals(method.getSimpleName()));
+            }
+
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                if (base64EncodeMethod.matches(m) &&
-                    ("encode".equals(method.getSimpleName()) || "encodeBuffer".equals(method.getSimpleName()))) {
+                if (encodeToString(m)) {
                     m = JavaTemplate.builder(useMimeCoder ? "Base64.getMimeEncoder().encodeToString(#{anyArray(byte)})" : "Base64.getEncoder().encodeToString(#{anyArray(byte)})")
                             .imports("java.util.Base64")
                             .build()

--- a/src/test/java/org/openrewrite/java/migrate/UseJavaUtilBase64Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UseJavaUtilBase64Test.java
@@ -251,4 +251,195 @@ class UseJavaUtilBase64Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void unsupportedLegacyOverloadsLeaveTheCompilationUnitAlone() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+
+              import test.sun.misc.BASE64Decoder;
+              import test.sun.misc.BASE64Encoder;
+              import java.io.IOException;
+              import java.io.InputStream;
+              import java.io.OutputStream;
+              import java.nio.ByteBuffer;
+
+              class Test {
+                  void encode(InputStream stream, OutputStream output, byte[] bytes, ByteBuffer buffer) throws IOException {
+                      BASE64Encoder encoder = new BASE64Encoder();
+                      encoder.encode(stream, output);
+                      encoder.encode(bytes, output);
+                      encoder.encode(buffer, output);
+                      String encoded = encoder.encode(buffer);
+                      encoder.encodeBuffer(stream, output);
+                      encoder.encodeBuffer(bytes, output);
+                      encoder.encodeBuffer(buffer, output);
+                      encoded += encoder.encodeBuffer(buffer);
+                  }
+
+                  void decode(InputStream stream, OutputStream output, String text) throws IOException {
+                      BASE64Decoder decoder = new BASE64Decoder();
+                      decoder.decode(stream, output);
+                      decoder.decode(text, output);
+                      decoder.decodeBuffer(stream, output);
+                      decoder.decodeBuffer(text, output);
+                      byte[] first = decoder.decodeBuffer(stream);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void oneUnsupportedOverloadSuppressesTheSupportedRewritesInTheSameFile() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+
+              import test.sun.misc.BASE64Encoder;
+              import java.io.IOException;
+              import java.io.OutputStream;
+
+              class Test {
+                  void test(byte[] bBytes, OutputStream output) throws IOException {
+                      BASE64Encoder encoder = new BASE64Encoder();
+                      String encoded = encoder.encode(bBytes);
+                      encoder.encodeBuffer(bBytes, output);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodReferenceToLegacyCoderLeavesTheCompilationUnitAlone() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+
+              import test.sun.misc.BASE64Encoder;
+              import java.util.function.Function;
+
+              class Test {
+                  Function<byte[], String> test() {
+                      BASE64Encoder encoder = new BASE64Encoder();
+                      return encoder::encode;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void receiverDeclaredAsLegacySupertypeLeavesTheCompilationUnitAlone() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+
+              import test.sun.misc.BASE64Decoder;
+              import test.sun.misc.BASE64Encoder;
+              import test.sun.misc.CharacterDecoder;
+              import test.sun.misc.CharacterEncoder;
+              import java.io.IOException;
+
+              class Test {
+                  void test(byte[] bBytes, String text) throws IOException {
+                      CharacterEncoder encoder = new BASE64Encoder();
+                      String encoded = encoder.encode(bBytes);
+                      encoded += encoder.encodeBuffer(bBytes);
+                      CharacterDecoder decoder = new BASE64Decoder();
+                      byte[] decoded = decoder.decodeBuffer(text);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void subclassOfLegacyEncoderLeavesTheCompilationUnitAlone() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+
+              import test.sun.misc.BASE64Encoder;
+
+              class UrlSafeEncoder extends BASE64Encoder {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void anonymousSubclassOfLegacyDecoderLeavesTheCompilationUnitAlone() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+
+              import test.sun.misc.BASE64Decoder;
+
+              class Test {
+                  BASE64Decoder decoder = new BASE64Decoder() {
+                  };
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void stillMigratesHelperMethodWithLegacyEncoderParameter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package test.sun.misc;
+
+              import test.sun.misc.BASE64Encoder;
+
+              class Test {
+                  String test(byte[] bBytes) {
+                      return encode(new BASE64Encoder(), bBytes);
+                  }
+
+                  String encode(BASE64Encoder encoder, byte[] bBytes) {
+                      return encoder.encode(bBytes);
+                  }
+              }
+              """,
+            """
+              package test.sun.misc;
+
+              import java.util.Base64;
+
+              class Test {
+                  String test(byte[] bBytes) {
+                      return encode(Base64.getEncoder(), bBytes);
+                  }
+
+                  String encode(Base64.Encoder encoder, byte[] bBytes) {
+                      return encoder.encodeToString(bBytes);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
**Suggested review order:** 41 of 52 (Score: 2)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1196

## What's changed?

[`UseJavaUtilBase64`](https://docs.openrewrite.org/recipes/java/migrate/usejavautilbase64) now leaves a source file unchanged when it cannot migrate every use of the legacy coders in it. The legacy coders are `sun.misc.BASE64Encoder` and `sun.misc.BASE64Decoder`, which inherit their coder methods from `sun.misc.CharacterEncoder` and `sun.misc.CharacterDecoder`.

Current main uses `ChangeType` to retype the two legacy coders to `java.util.Base64.Encoder` and `java.util.Base64.Decoder`. It rewrites only those calls for which `java.util.Base64` has an equivalent method, and leaves every other call as written, on a receiver whose type it has just changed.

### Before

```java
BASE64Encoder encoder = new BASE64Encoder();
String encoded = encoder.encode(bBytes);
encoder.encodeBuffer(bBytes, output);
```

### Actual after the recipe

Using current main.

```java
Base64.Encoder encoder = Base64.getEncoder();
String encoded = encoder.encodeToString(bBytes);
encoder.encodeBuffer(bBytes, output);  // Base64.Encoder has no encodeBuffer
```

### Expected after the recipe

`(unchanged)`

The recipe makes no edit at all.

`visitCompilationUnit` keeps its existing whole-file check, `alreadyUsingIncompatibleBase64`, and runs a second one, `usesLegacyTypeUntranslatably`, after it. When the new check reports true, the file is returned unchanged. It reports true when the file contains any of:

- a call to a legacy coder method this recipe cannot rewrite, meaning any coder method other than the three named below, or a call to one of those three on a receiver whose type is not `BASE64Encoder` or `BASE64Decoder` itself;
- an expression whose declared type is `CharacterEncoder` or `CharacterDecoder`, which `ChangeType` never retypes;
- a class extending a legacy coder, or an instantiation with an anonymous class body, such as `new BASE64Decoder() { }`;
- a method reference to a legacy coder, such as `encoder::encode`;
- a call passing a value to a parameter declared as `CharacterEncoder` or `CharacterDecoder`.

A parameter declared as `BASE64Encoder` or `BASE64Decoder` is none of those, since `ChangeType` does retype those two classes, so a file whose only legacy use is such a parameter is still migrated.

## What's your motivation?

**Recipe:** `org.openrewrite.java.migrate.UseJavaUtilBase64`.

The two legacy coders inherit 16 public coder methods from those supertypes, 10 from `CharacterEncoder` and 6 from `CharacterDecoder`. The recipe rewrites 3 of them, the same 3 on current main and on this branch: `encode(byte[])` and `encodeBuffer(byte[])` become `Base64.getEncoder().encodeToString(byte[])`, and `decodeBuffer(String)` becomes `Base64.getDecoder().decode(String)`. Calls to the remaining 13 are left as written, on a receiver current main has just retyped to `Base64.Encoder` or `Base64.Decoder`, neither of which declares them.

The file current main produces therefore does not compile: `javac --release 11` rejects the output block above with `cannot find symbol: method encodeBuffer(byte[],OutputStream)`. The recipe still reports that file as successfully changed, so nothing in the run tells the user the result is broken. `UseJavaUtilBase64` runs inside `Java8toJava11`, `UpgradeToJava17` and `UpgradeToJava21`, so any of those three can turn a Java 8 codebase that compiles into one that does not. Reproduced on 3.41.0 and on 3.42.0-SNAPSHOT built from current main.

### Affected code in real projects

- [`openjdk/jfx` `WebEngine.java`](https://github.com/openjdk/jfx/blob/3b54913c53f5ac079278a934081d87ce7d55173f/modules/javafx.web/src/android/java/javafx/scene/web/WebEngine.java#L478): the Android port of the JavaFX WebView converts a user stylesheet URL to a data URL with the stream overload `new sun.misc.BASE64Encoder().encodeBuffer(in, out)`; the recipe from main replaces the allocation with `Base64.getEncoder()` but cannot rewrite the two-argument `encodeBuffer`, so the output calls `Base64.getEncoder().encodeBuffer(in, out)`, a method `Base64.Encoder` does not declare, and the file no longer compiles.

## Anything in particular you'd like reviewers to focus on?

No existing test expectation changed: the test file has added lines only, and the three tests already in `UseJavaUtilBase64Test` are untouched. Three points:

- The decision is per file, not per call, because `ChangeType` retypes the whole file, so a file mixing a call the recipe can rewrite with one it cannot is now left entirely alone. The check is deliberately wide, so it also refuses some files current main migrates correctly, for example a supported method called on a receiver whose declared type is a type variable, as in `<T extends BASE64Encoder> void write(T coder)` calling `coder.encode(b)`, since a type variable is neither of the two receiver types the first bullet above accepts. I have not measured how often that shape occurs in real code.
- The check runs before `super.visitCompilationUnit(...)`. Checking afterwards and discarding the visit result would not work: rewriting `decodeBuffer(String)` schedules `UnnecessaryCatch` through `doAfterVisit`, because the `sun.misc` `decodeBuffer` declares `throws IOException` while `Base64.Decoder.decode` does not, and a visitor scheduled that way still runs even when `visitCompilationUnit` returns the original tree.
- Two defects present on current main are left unfixed, because the new check reports true for neither: - The recipe adds no `import java.util.Base64;` when the file has no coder variable for `ChangeType` to retype. The check does not visit imports, and nothing else in such a file is flagged, so it is still migrated, still without the import.
- The recipe drops the receiver of a call it rewrites when that receiver is not a `J.Identifier`, because it puts the original receiver back only for identifiers. `factory().encode(b)` is still rewritten to `Base64.getEncoder().encodeToString(b)` and the call to `factory()` is lost. The check accepts it, because `factory()` is typed `BASE64Encoder`, which `ChangeType` does retype.

Fixing either one is a separate change.

## Have you considered any alternatives or workarounds?

A skipped file is now skipped silently. One alternative is to report every skip with `Markup.warn`, as `visitCompilationUnit` already does when `alreadyUsingIncompatibleBase64` finds a class named `Base64` that is not `java.util.Base64`, with a message ending "Manual intervention required." That would tell users which files still need manual work, but it would also mark every skipped file in the diff with a `/*~~(...)~~>*/` comment, which is noisy on a codebase with many `sun.misc` call sites. The switch is one line in `visitCompilationUnit`, plus an updated expected value in the six new tests that expect their input file back unchanged. Tell me which you prefer and I will change it.

## Any additional context

This change adds 7 tests to `UseJavaUtilBase64Test`, bringing that class to 10. Without the code change in this pull request, these 6 tests fail:

- `unsupportedLegacyOverloadsLeaveTheCompilationUnitAlone`
- `oneUnsupportedOverloadSuppressesTheSupportedRewritesInTheSameFile`
- `methodReferenceToLegacyCoderLeavesTheCompilationUnitAlone`
- `receiverDeclaredAsLegacySupertypeLeavesTheCompilationUnitAlone`
- `subclassOfLegacyEncoderLeavesTheCompilationUnitAlone`
- `anonymousSubclassOfLegacyDecoderLeavesTheCompilationUnitAlone`

The seventh test, `stillMigratesHelperMethodWithLegacyEncoderParameter`, passes either way. It covers a helper method whose parameter is declared `BASE64Encoder`, which is still migrated.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

I ran the formatter with the repository's `.editorconfig`. It also wanted to re-indent lines that this change does not touch, so I left those alone and kept the diff limited to this change.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
