### PR TITLE
Preserve nullable values in `UseMapOf` prose-map conversions

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/UseMapOf.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
@@ -78,7 +79,9 @@ public class UseMapOf extends Recipe {
                                         new StringJoiner(", ", "Map.ofEntries(", ")") :
                                         new StringJoiner(", ", "Map.of(", ")");
                                 for (J.MethodInvocation put : puts) {
-                                    args.addAll(put.getArguments());
+                                    for (Expression arg : put.getArguments()) {
+                                        args.add(arg.unwrap());
+                                    }
                                     if (useEntries) {
                                         inner.add("Map.entry(#{any()}, #{any()})");
                                     } else {
@@ -317,7 +320,7 @@ public class UseMapOf extends Recipe {
                     /**
                      * If {@code stmt} is {@code targetName.put(k, v)} matching {@link #MAP_PUT},
                      * returns [key, value] as a list; otherwise {@code null}. Returns {@code null}
-                     * if either argument is the {@code null} literal, since {@code Map.of(..)} and
+                     * unless both arguments are proven non-null, since {@code Map.of(..)} and
                      * {@code Map.entry(..)} reject nulls.
                      */
                     private List<Expression> matchPutCallOn(Statement stmt, String targetName) {
@@ -338,11 +341,33 @@ public class UseMapOf extends Recipe {
                             return null;
                         }
                         for (Expression arg : mi.getArguments()) {
-                            if (J.Literal.isLiteralValue( arg, null )) {
+                            if (!isProvablyNonNull(arg)) {
                                 return null;
                             }
                         }
                         return mi.getArguments();
+                    }
+
+                    private boolean isProvablyNonNull(Expression expression) {
+                        expression = expression.unwrap();
+                        if (expression instanceof J.Literal) {
+                            return !J.Literal.isLiteralValue(expression, null);
+                        }
+                        if (expression instanceof J.NewClass ||
+                                expression instanceof J.NewArray ||
+                                expression instanceof J.Lambda ||
+                                expression instanceof J.MemberReference) {
+                            return true;
+                        }
+                        JavaType type = expression.getType();
+                        return type == JavaType.Primitive.Boolean ||
+                               type == JavaType.Primitive.Byte ||
+                               type == JavaType.Primitive.Char ||
+                               type == JavaType.Primitive.Double ||
+                               type == JavaType.Primitive.Float ||
+                               type == JavaType.Primitive.Int ||
+                               type == JavaType.Primitive.Long ||
+                               type == JavaType.Primitive.Short;
                     }
 
                     private boolean expressionReferences(Expression expr, String name) {

--- a/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/UseMapOfTest.java
@@ -574,4 +574,119 @@ class UseMapOfTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void proseMapsWithProvablyNonNullValuesAreCollapsed() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class PrimitiveValues {
+                  Map<String, Integer> values(int first, int second) {
+                      Map<String, Integer> values = new HashMap<>();
+                      values.put("first", first);
+                      values.put("second", second);
+                      return values;
+                  }
+              }
+              """,
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class PrimitiveValues {
+                  Map<String, Integer> values(int first, int second) {
+                      Map<String, Integer> values = new HashMap<>(Map.of(
+                              "first", first,
+                              "second", second));
+                      return values;
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class ParenthesizedValues {
+                  Map<String, Integer> values(int first, int second) {
+                      Map<String, Integer> values = new HashMap<>();
+                      values.put(("first"), first);
+                      values.put(("second"), second);
+                      return values;
+                  }
+              }
+              """,
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class ParenthesizedValues {
+                  Map<String, Integer> values(int first, int second) {
+                      Map<String, Integer> values = new HashMap<>(Map.of(
+                              "first", first,
+                              "second", second));
+                      return values;
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class NewClassValues {
+                  Map<String, Object> values() {
+                      Map<String, Object> values = new HashMap<>();
+                      values.put("first", new Object());
+                      values.put("second", new Object());
+                      return values;
+                  }
+              }
+              """,
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class NewClassValues {
+                  Map<String, Object> values() {
+                      Map<String, Object> values = new HashMap<>(Map.of(
+                              "first", new Object(),
+                              "second", new Object()));
+                      return values;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void proseMapWithUnknownNullableValueIsLeftAlone() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+                  Map<String, Object> prompt(Object card, Object attempt) {
+                      Map<String, Object> values = new HashMap<>();
+                      values.put("card", card);
+                      values.put("attempt", attempt);
+                      return values;
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
**Suggested review order:** 2 of 52 (Score: 9)
**Review first:** https://github.com/openrewrite/rewrite/pull/8508

## What's changed?

Restricts staged `HashMap` conversion to entries whose keys and values are proven non-null. Unknown reference expressions remain unchanged, while values whose non-nullness follows from their expression shape remain eligible.

## What's your motivation?

**Recipe:** [`org.openrewrite.java.migrate.util.UseMapOf`](https://docs.openrewrite.org/recipes/java/migrate/util/usemapof).

I found this by running `org.openrewrite.java.migrate.util.UseMapOf` from `org.openrewrite.recipe:rewrite-migrate-java:3.40.0` on [`PromptRenderer.java` in Symphony-Trello at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/main/java/ch/fmartin/symphony/trello/prompt/PromptRenderer.java). I reproduced the same result with the latest released recipe artifact, `org.openrewrite.recipe:rewrite-migrate-java:3.42.0`. The original target test passes. After the recipe, `WorkflowConfigPromptTest.missingWorkflowAndUnknownTemplateVariablesUseTypedErrors` fails because `attempt == null` reaches `Map.of` and throws `NullPointerException` before the expected application error is created.

### Before

```java
Map<String, Object> context = new HashMap<>();
context.put("card", cardData);
context.put("issue", cardData);
context.put("attempt", attempt);
```

### Actual after the recipe

```java
Map<String, Object> context = new HashMap<>(Map.of(
        "card", cardData,
        "issue", cardData,
        "attempt", attempt));
```

### Expected after the recipe

`(unchanged)`

`HashMap.put` accepts null values, while `Map.of` rejects them. The recipe silently changes the first-attempt runtime behavior from a typed application error to `NullPointerException`.

### Confirmed real-world execution

- Project: [Symphony-Trello](https://github.com/martin-francois/symphony-trello).
- Location: [`PromptRenderer.java` at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/main/java/ch/fmartin/symphony/trello/prompt/PromptRenderer.java).
- Discovery checkout: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d).

## Anything in particular you'd like reviewers to focus on?

Please review the conservative non-null proof. An expression with unknown nullability remains unchanged instead of being treated as non-null without data-flow evidence.

## Have you considered any alternatives or workarounds?

Adding a sentinel for null would change the application's prompt contract. Leaving only the unsafe conversion unchanged preserves behavior without changing the recipe's safe cases.

## Any additional context

Pre-existing tests changed: None.

- Target commit: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d)
- Discovery release: `org.openrewrite.recipe:rewrite-migrate-java:3.40.0`
- Latest verification release: `org.openrewrite.recipe:rewrite-migrate-java:3.42.0`
- Target verification: the selected test passes before the recipe and fails after it with `NullPointerException`
- Focused tests: `UseMapOfTest`
- Related closed issue: https://github.com/openrewrite/rewrite-migrate-java/issues/1092

This change was prepared with AI assistance. I reviewed the target execution evidence, implementation, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
