### PR TITLE
Fix `NoGuava*` collection recipes crashing on Groovy sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release:recipes")
     testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")
 
+    testImplementation("org.openrewrite:rewrite-groovy")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
 

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewArrayList.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewArrayList.java
@@ -57,7 +57,6 @@ public class NoGuavaListsNewArrayList extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.ArrayList");
                     return JavaTemplate.builder("new ArrayList<>()")
-                            .contextSensitive()
                             .imports("java.util.ArrayList")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace());
@@ -67,7 +66,6 @@ public class NoGuavaListsNewArrayList extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.ArrayList");
                     return JavaTemplate.builder("new ArrayList<>(#{any(java.util.Collection)})")
-                            .contextSensitive()
                             .imports("java.util.ArrayList")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(),
@@ -77,7 +75,6 @@ public class NoGuavaListsNewArrayList extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.ArrayList");
                     return JavaTemplate.builder("new ArrayList<>(#{any(int)})")
-                            .contextSensitive()
                             .imports("java.util.ArrayList")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(),

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewCopyOnWriteArrayList.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewCopyOnWriteArrayList.java
@@ -55,7 +55,6 @@ public class NoGuavaListsNewCopyOnWriteArrayList extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.concurrent.CopyOnWriteArrayList");
                     return JavaTemplate.builder("new CopyOnWriteArrayList<>()")
-                            .contextSensitive()
                             .imports("java.util.concurrent.CopyOnWriteArrayList")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace());
@@ -65,7 +64,6 @@ public class NoGuavaListsNewCopyOnWriteArrayList extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.concurrent.CopyOnWriteArrayList");
                     return JavaTemplate.builder("new CopyOnWriteArrayList<>(#{any(java.util.Collection)})")
-                            .contextSensitive()
                             .imports("java.util.concurrent.CopyOnWriteArrayList")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewLinkedList.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaListsNewLinkedList.java
@@ -55,7 +55,6 @@ public class NoGuavaListsNewLinkedList extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.LinkedList");
                     return JavaTemplate.builder("new LinkedList<>()")
-                            .contextSensitive()
                             .imports("java.util.LinkedList")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace());
@@ -65,7 +64,6 @@ public class NoGuavaListsNewLinkedList extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Lists");
                     maybeAddImport("java.util.LinkedList");
                     return JavaTemplate.builder("new LinkedList<>(#{any(java.util.Collection)})")
-                            .contextSensitive()
                             .imports("java.util.LinkedList")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewHashMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewHashMap.java
@@ -54,7 +54,6 @@ public class NoGuavaMapsNewHashMap extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Maps");
                     maybeAddImport("java.util.HashMap");
                     return JavaTemplate.builder("new HashMap<>()")
-                            .contextSensitive()
                             .imports("java.util.HashMap")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace());
@@ -63,7 +62,6 @@ public class NoGuavaMapsNewHashMap extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Maps");
                     maybeAddImport("java.util.HashMap");
                     return JavaTemplate.builder("new HashMap<>(#{any(java.util.Map)})")
-                            .contextSensitive()
                             .imports("java.util.HashMap")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewLinkedHashMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewLinkedHashMap.java
@@ -54,7 +54,6 @@ public class NoGuavaMapsNewLinkedHashMap extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Maps");
                     maybeAddImport("java.util.LinkedHashMap");
                     return JavaTemplate.builder("new LinkedHashMap<>()")
-                            .contextSensitive()
                             .imports("java.util.LinkedHashMap")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace());
@@ -63,7 +62,6 @@ public class NoGuavaMapsNewLinkedHashMap extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Maps");
                     maybeAddImport("java.util.LinkedHashMap");
                     return JavaTemplate.builder("new LinkedHashMap<>(#{any(java.util.Map)})")
-                            .contextSensitive()
                             .imports("java.util.LinkedHashMap")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewTreeMap.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewTreeMap.java
@@ -56,7 +56,6 @@ public class NoGuavaMapsNewTreeMap extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Maps");
                     maybeAddImport("java.util.TreeMap");
                     return JavaTemplate.builder("new TreeMap<>()")
-                            .contextSensitive()
                             .imports("java.util.TreeMap")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace());
@@ -65,7 +64,6 @@ public class NoGuavaMapsNewTreeMap extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Maps");
                     maybeAddImport("java.util.TreeMap");
                     return JavaTemplate.builder("new TreeMap<>(#{any(java.util.Comparator)})")
-                            .contextSensitive()
                             .imports("java.util.TreeMap")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
@@ -74,7 +72,6 @@ public class NoGuavaMapsNewTreeMap extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Maps");
                     maybeAddImport("java.util.TreeMap");
                     return JavaTemplate.builder("new TreeMap<>(#{any(java.util.Map)})")
-                            .contextSensitive()
                             .imports("java.util.TreeMap")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewConcurrentHashSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewConcurrentHashSet.java
@@ -52,7 +52,6 @@ public class NoGuavaSetsNewConcurrentHashSet extends Recipe {
                     maybeAddImport("java.util.Collections");
                     maybeAddImport("java.util.concurrent.ConcurrentHashMap");
                     return JavaTemplate.builder("Collections.newSetFromMap(new ConcurrentHashMap<>())")
-                            .contextSensitive()
                             .imports("java.util.Collections")
                             .imports("java.util.concurrent.ConcurrentHashMap")
                             .build()

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewHashSet.java
@@ -54,7 +54,6 @@ public class NoGuavaSetsNewHashSet extends Recipe {
                         maybeRemoveImport("com.google.common.collect.Sets");
                         maybeAddImport("java.util.HashSet");
                         return JavaTemplate.builder("new HashSet<>()")
-                                .contextSensitive()
                                 .imports("java.util.HashSet")
                                 .build()
                                 .apply(getCursor(), method.getCoordinates().replace());
@@ -65,7 +64,6 @@ public class NoGuavaSetsNewHashSet extends Recipe {
                             maybeRemoveImport("com.google.common.collect.Sets");
                             maybeAddImport("java.util.HashSet");
                             return JavaTemplate.builder("new HashSet<>(#{any(java.util.Collection)})")
-                                    .contextSensitive()
                                     .imports("java.util.HashSet")
                                     .build()
                                     .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
@@ -79,7 +77,6 @@ public class NoGuavaSetsNewHashSet extends Recipe {
                     maybeAddImport("java.util.HashSet");
                     maybeAddImport("java.util.Arrays");
                     JavaTemplate newHashSetVarargs = JavaTemplate.builder("new HashSet<>(Arrays.asList(" + method.getArguments().stream().map(a -> "#{any()}").collect(joining(",")) + "))")
-                            .contextSensitive()
                             .imports("java.util.Arrays")
                             .imports("java.util.HashSet")
                             .build();

--- a/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewLinkedHashSet.java
+++ b/src/main/java/org/openrewrite/java/migrate/guava/NoGuavaSetsNewLinkedHashSet.java
@@ -58,7 +58,6 @@ public class NoGuavaSetsNewLinkedHashSet extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Sets");
                     maybeAddImport("java.util.LinkedHashSet");
                     return JavaTemplate.builder("new LinkedHashSet<>()")
-                            .contextSensitive()
                             .imports("java.util.LinkedHashSet")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace());
@@ -68,7 +67,6 @@ public class NoGuavaSetsNewLinkedHashSet extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Sets");
                     maybeAddImport("java.util.LinkedHashSet");
                     return JavaTemplate.builder("new LinkedHashSet<>(#{any(java.util.Collection)})")
-                            .contextSensitive()
                             .imports("java.util.LinkedHashSet")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
@@ -77,7 +75,6 @@ public class NoGuavaSetsNewLinkedHashSet extends Recipe {
                     maybeRemoveImport("com.google.common.collect.Sets");
                     maybeAddImport("java.util.LinkedHashSet");
                     return JavaTemplate.builder("new LinkedHashSet<>(#{any(int)})")
-                            .contextSensitive()
                             .imports("java.util.LinkedHashSet")
                             .build()
                             .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));

--- a/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewHashMapTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/guava/NoGuavaMapsNewHashMapTest.java
@@ -18,10 +18,12 @@ package org.openrewrite.java.migrate.guava;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.groovy.GroovyParser;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
 
 
@@ -31,7 +33,8 @@ class NoGuavaMapsNewHashMapTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .recipe(new NoGuavaMapsNewHashMap())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "guava"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "guava"))
+          .parser(GroovyParser.builder().classpathFromResource(new InMemoryExecutionContext(), "guava"));
     }
 
     @DocumentExample
@@ -83,6 +86,60 @@ class NoGuavaMapsNewHashMapTest implements RewriteTest {
               class Test {
                   Map<Integer, Integer> m = Collections.emptyMap();
                   Map<Integer, Integer> cardinalsWorldSeries = new HashMap<>(m);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceWithNewHashMapWithMapInGroovy() {
+        //language=groovy
+        rewriteRun(
+          groovy(
+            """
+              import com.google.common.collect.Lists
+              import com.google.common.collect.Maps
+
+              class Test extends Specification {
+                  def 'test get_privilege_set'() {
+                      def registry = Mock(Registry)
+
+                      when:
+                      def result = ms.get_privilege_set(null, null, null)
+
+                      then:
+                      result == new PrincipalPrivilegeSet(null
+                              , null
+                              , Maps.newHashMap(Map.of("users",
+                              Lists.newArrayList(new PrivilegeGrantInfo("ALL", 0, "hadoop", PrincipalType.ROLE, true)))))
+                      registry.timer(_) >> timer
+                      timer.record(_, _) >> {}
+                      registry.createId(_ as String) >> id
+                  }
+              }
+              """,
+            """
+              import com.google.common.collect.Lists
+
+              import java.util.HashMap
+
+              class Test extends Specification {
+                  def 'test get_privilege_set'() {
+                      def registry = Mock(Registry)
+
+                      when:
+                      def result = ms.get_privilege_set(null, null, null)
+
+                      then:
+                      result == new PrincipalPrivilegeSet(null
+                              , null
+                              , new HashMap<>(Map.of("users",
+                              Lists.newArrayList(new PrivilegeGrantInfo("ALL", 0, "hadoop", PrincipalType.ROLE, true)))))
+                      registry.timer(_) >> timer
+                      timer.record(_, _) >> {}
+                      registry.createId(_ as String) >> id
+                  }
               }
               """
           )


### PR DESCRIPTION
## What

`org.openrewrite.java.migrate.guava.NoGuavaMapsNewHashMap` throws on Groovy sources:

```
java.lang.IllegalArgumentException: Expected a template that would generate exactly one statement
to replace one statement, but generated 0. Template:
new HashMap<>(__P__.<java.util.Map>/*__p0__*/p())
...
  org.openrewrite.java.migrate.guava.NoGuavaMapsNewHashMap$1.visitMethodInvocation(NoGuavaMapsNewHashMap.java:69)
  org.openrewrite.java.migrate.guava.NoGuavaMapsNewHashMap_1_GroovyVisitor.visitMethodInvocation(...)
```

Found via the Moderne SaaS flagship run of *Java best practices* against the "Netflix + Spring" org, where it puts `Netflix/metacat` into `RepositoryRecipeRunError` on every run. The trigger is `metacat-thrift/src/test/groovy/com/netflix/metacat/thrift/CatalogThriftHiveMetastoreSpec.groovy` — a Spock spec containing `Maps.newHashMap(ImmutableMap.of(...))`, which a sibling recipe in the same composite (`NoGuavaImmutableMapOf`) has already rewritten to `Maps.newHashMap(Map.of(...))` by the time this recipe sees it.

## Why

The templates are marked `.contextSensitive()`. That makes `JavaTemplate` reconstruct and re-parse the *enclosing block* as Java before splicing in the replacement. On a Groovy LST that block routinely contains constructs with no Java equivalent — `def result = ...`, `timer.record(_, _) >> {}`, `registry.createId(_ as String) >> id` — so the reconstructed source does not parse, `parseBlockStatements` returns zero statements, and `maybeReplaceStatement` throws.

None of these templates reference anything from the surrounding scope: they are self-contained expressions (`new HashMap<>(#{any(java.util.Map)})`) whose only external dependency is an import they already declare explicitly. Context sensitivity was never needed here, and dropping it also lets the templates be cached.

- I went with the real fix rather than a language guard (cf. openrewrite/rewrite@e9c478e / rewrite-static-analysis#105, which caught `RecipeRunException` and skipped) — the replacement works correctly on Groovy once the template is context-free, so there is no reason to skip those sources.

## Scope

The same unnecessary `.contextSensitive()` appears across the whole `NoGuava*` collection-factory family, all with the identical latent crash, so they are fixed together:

- `NoGuavaListsNewArrayList`, `NoGuavaListsNewCopyOnWriteArrayList`, `NoGuavaListsNewLinkedList`
- `NoGuavaMapsNewHashMap`, `NoGuavaMapsNewLinkedHashMap`, `NoGuavaMapsNewTreeMap`
- `NoGuavaSetsNewConcurrentHashSet`, `NoGuavaSetsNewHashSet`, `NoGuavaSetsNewLinkedHashSet`

`NoGuavaDirectExecutor` is deliberately left alone — its `Runnable::run` method reference does lose type attribution without context (`MemberReference type is missing or malformed`), so `.contextSensitive()` is load-bearing there.

## Testing

Added `NoGuavaMapsNewHashMapTest#replaceWithNewHashMapWithMapInGroovy`, a `groovy(...)` source spec modelled on the metacat block (Spock `when:`/`then:`, mock interactions, multi-line argument) that reproduces the crash before this change. It needs a `GroovyParser` with Guava on its classpath, and an explicit `testImplementation("org.openrewrite:rewrite-groovy")` so `org.openrewrite.groovy.Assertions` is no longer picked up only transitively.

All 218 tests in `org.openrewrite.java.migrate.guava` pass.