### PR TITLE
Oversubscribe test forks in CI to cut wall clock time

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,7 +115,13 @@ tasks.withType(Javadoc::class.java) {
 }
 
 tasks.test {
-    maxHeapSize = "2g"  // Set max heap size to 2GB or adjust as necessary
+    maxHeapSize = "2g"
+    if (System.getenv("CI") != null) {
+        // 47 of the 267 test classes resolve Maven poms over the network, so forks idle on I/O;
+        // oversubscribing the runner's cores packs the remaining work more evenly across them.
+        maxParallelForks = Runtime.getRuntime().availableProcessors() * 3 / 2
+        maxHeapSize = "1500m"
+    }
 }
 
 tasks.withType<JavaCompile> {


### PR DESCRIPTION
## Why

`:test` dominates CI. On the most recent `main` build (9m47s total):

| Phase | Duration |
|---|---|
| Runner setup, checkout, JDK, Gradle setup | ~15s |
| Gradle config | ~13s |
| `:compileJava` | 48s |
| `:jar` / `:javadoc` / `:sourcesJar` | ~5s |
| `:recipeCsvValidate` | 20s |
| `:compileTestJava` | 10s |
| **`:test`** | **8m09s** |

Eliminating every task *except* `:test` would save only ~1.5 min, so `:test` is the only phase worth attacking.

## The problem

`RewriteJavaPlugin` sets `maxParallelForks = availableProcessors()`, and `ubuntu-latest` is 4 vCPU, so 4 forks. Their finish times:

```
Executor 2: 3m47s
Executor 4: 4m55s
Executor 5: 7m27s
Executor 3: 8m07s   <- wall clock is set by this one
```

That's 24m16s of executor time. Evenly packed across 4 forks it would be **6m04s**, so roughly **two minutes is fork imbalance alone**.

Gradle hands out whole test classes, and 47 of the 267 test classes resolve Maven poms over the network. A couple of long, latency-bound classes landed late on two forks, and there was no work left for the other two to steal. There's no single slow test to fix — 1778 tests at ~1.1s of executor time each, largest inter-test gap 41s and tapering smoothly.

## The change

Run 1.5 forks per core in CI. Finer granularity packs better, and the CPU-bound classes can use the cores that the network-bound classes are blocking on.

Heap drops to 1500m so the extra forks fit: 6 x 1500m is ~9g of a 16g runner, where 6 x 2g would have been tight. GitHub scales runner RAM at 4g per core, so 1.5 forks/core at 1500m stays in budget on larger runners too.

Local dev is untouched — the plugin's `availableProcessors() / 2` and the 2g heap still apply when `CI` is unset. Verified both paths resolve as intended.

## Not done here

Moving to an 8-core runner is the bigger lever (`:test` to ~4 min, total ~5m30s), but `runs-on: ubuntu-latest` is hardcoded in `openrewrite/gh-automation/.github/workflows/ci-gradle.yml` and needs an input added there. Happy to follow up if we want it.

Sharding across matrix jobs isn't worth it — each shard re-pays ~1m40s of setup and compile, and since shards start simultaneously they all miss the remote build cache, landing around 4 min for far more complexity.