### PR TITLE
Do not apply `var` where the declaration cannot legally carry it

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -48,11 +48,23 @@ final class DeclarationCheck {
      * @return true if var is applicable in general
      */
     public static boolean isVarApplicable(Cursor cursor, J.VariableDeclarations vd) {
-        if (isField(vd, cursor) || isMethodParameter(vd, cursor) || !isSingleVariableDefinition(vd) || initializedByTernary(vd)) {
+        if (isField(vd, cursor) || isMethodParameter(vd, cursor) || !isSingleVariableDefinition(vd) ||
+                initializedByTernary(vd) || hasDimensionsAfterName(vd)) {
             return false;
         }
 
         return isInsideMethod(cursor) || isInsideInitializer(cursor, 0);
+    }
+
+    /**
+     * Determine whether the declarator carries C-style array brackets after the variable name, as in {@code int a[]}.
+     * JLS 14.4.1 makes extra array dimensions on a {@code var} declarator a compile-time error.
+     *
+     * @param vd variable definition at hand
+     * @return true iff the variable name is followed by array dimensions
+     */
+    private static boolean hasDimensionsAfterName(J.VariableDeclarations vd) {
+        return !vd.getVariables().get(0).getDimensionsAfterName().isEmpty();
     }
 
     /**

--- a/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocations.java
@@ -87,6 +87,13 @@ public class UseVarForGenericMethodInvocations extends Recipe {
                 return vd;
             }
 
+            // Only a qualified invocation can carry a type witness (JLS 15.12), so an unqualified call whose return
+            // type still mentions a type variable has no way to hold on to the type the declaration pinned down.
+            if (invocation.getSelect() == null && invocation.getTypeParameters() == null &&
+                    invocation.getMethodType() != null && containsGenericTypeVariable(invocation.getMethodType().getReturnType())) {
+                return vd;
+            }
+
             if (vd.getType() instanceof JavaType.FullyQualified) {
                 maybeRemoveImport((JavaType.FullyQualified) vd.getType());
             }

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForGenericMethodInvocationsTest.java
@@ -56,6 +56,33 @@ class UseVarForGenericMethodInvocationsTest implements RewriteTest {
             );
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1219")
+        @Test
+        void forUnqualifiedInvocationNeedingTypeWitness() {
+            // `var contentTypes = <T>contentType(...)` would not parse; a type witness needs a receiver
+            //language=java
+            rewriteRun(
+              version(
+                java("""
+                  package com.example.app;
+
+                  import java.util.function.Predicate;
+
+                  class A {
+                    static <T> Predicate<T> contentType(String... types) {
+                        return null;
+                    }
+                    static <T> Predicate<T> binary() {
+                        final Predicate<T> contentTypes = contentType("application/octet-stream");
+                        return contentTypes;
+                    }
+                  }
+                  """),
+                10
+              )
+            );
+        }
+
         @Nested
         class NotSupportedByOpenRewrite {
             // this is possible because `myList()`s type is fixed to `List<String>` but it is not distinguishable from

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitiveTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitiveTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.migrate.lang.var;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.java.Assertions.java;
@@ -79,6 +80,25 @@ class UseVarForPrimitiveTest extends VarBaseTest {
                   class A {
                     void m() {
                         String s = "a" + "b";
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1218")
+        @Test
+        void forCStyleArrayDeclarator() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  package com.example.app;
+
+                  class A {
+                    void m() {
+                        int address[] = new int[8];
                     }
                   }
                   """


### PR DESCRIPTION
- Fixes #1218
- Fixes #1219

Two declaration shapes cannot legally carry `var`, and the `lang.var` recipes rewrite both into source that does not compile.

### C-style array declarators

A declarator that keeps its brackets after the variable name:

```java
int address[] = new int[8];
```

becomes

```java
var address[] = new int[8];
```

which is a compile-time error — a `var` declarator may not have extra array dimension brackets (JLS 14.4.1).

The guard goes in `DeclarationCheck.isVarApplicable` rather than in `UseVarForPrimitive`, for two reasons. `UseVarForObject` reaches the same shape (`String s[] = getStrings();` produced `var s[] = ...` just as badly), and `isVarApplicable` is already where every sibling recipe bails out for fields, parameters, multiple declarators and ternaries — this is the same class of "`var` is not legal here" constraint.

Bailing out rather than normalizing to `var address = new int[8]` is deliberate: normalizing is not uniformly safe, because `int a[] = {1, 2, 3};` cannot become `var a = {1, 2, 3};` — a bare array initializer has no target type to infer from. A normalizing fix would need its own additional guard; bailing needs none.

### Type witnesses on unqualified invocations

A type witness is only legal on a *qualified* invocation — `this.<T>foo()`, `Type.<T>foo()`, `super.<T>foo()`. `UseVarForGenericMethodInvocations` emitted one on an unqualified call:

```java
static <T extends HttpMessage> BodyReplacer<T> binary() {
    final Predicate<T> contentTypes = contentType("application/octet-stream");
```

became

```java
    final var contentTypes = <T>contentType("application/octet-stream");
```

which does not parse (JLS 15.12 — type arguments follow the `.` of a qualified invocation).

The guard is narrower than "skip when there is no `select`". That would regress the existing `withOwnFactoryMethods` case, where `List<String> strs = myList("one", "two")` legally becomes `var` because `T` is inferable from the arguments and no witness is needed. The witness is only ever synthesized when the resolved return type still mentions a type variable, so that is what the guard keys on.

Suppressing only the witness would not have been enough either: without the declared target type, `T` re-infers to `Object` and the variable silently changes type. Skipping the transformation is the correct outcome.

### Tests

Added to the existing `NotApplicable` nested classes in both test files. Full `lang.var` package: 113 tests, 0 failures. Both new tests fail without the corresponding fix.

Found by compiling the output of `UpgradeToJava25` across a set of open source repositories.
