### PR TITLE
Leave Kotlin and Groovy sources to `ListFirstAndLast`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/util/ListFirstAndLast.java
+++ b/src/main/java/org/openrewrite/java/migrate/util/ListFirstAndLast.java
@@ -28,6 +28,8 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +59,10 @@ public class ListFirstAndLast extends Recipe {
                                 new UsesMethod<>(ADD_MATCHER),
                                 new UsesMethod<>(GET_MATCHER),
                                 new UsesMethod<>(REMOVE_MATCHER)
-                        )
+                        ),
+                        // Dropping the index argument leaves Kotlin index access as `list[]`, and Groovy loses its parentheses
+                        Preconditions.not(new KotlinFileChecker<>()),
+                        Preconditions.not(new GroovyFileChecker<>())
                 ),
                 new FirstLastVisitor());
     }

--- a/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/util/ListFirstAndLastTest.java
@@ -21,8 +21,10 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/243")
 class ListFirstAndLastTest implements RewriteTest {
@@ -382,6 +384,54 @@ class ListFirstAndLastTest implements RewriteTest {
                   class Foo {
                       void bar(List<String> collection) {
                           collection.add(collection.size() - 1, "last");
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void kotlinIndexAccess() {
+            rewriteRun(
+              //language=kotlin
+              kotlin(
+                """
+                  class Foo {
+                      fun bar(collection: java.util.ArrayList<String>): String {
+                          return collection[0]
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void kotlinGet() {
+            rewriteRun(
+              //language=kotlin
+              kotlin(
+                """
+                  class Foo {
+                      fun bar(collection: java.util.ArrayList<String>): String {
+                          return collection.get(0)
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void groovyGet() {
+            rewriteRun(
+              //language=groovy
+              groovy(
+                """
+                  class Foo {
+                      String bar(List<String> collection) {
+                          return collection.get(0)
                       }
                   }
                   """


### PR DESCRIPTION
`ListFirstAndLast` rewrites `list.get(0)` to `list.getFirst()`. Kotlin and Groovy sources reach it through the shared `J` model, and in both the rewrite produces something that does not work.

### Kotlin

`xs[0]` is modelled as a `J.MethodInvocation` named `<get>` carrying an `org.openrewrite.kotlin.marker.IndexedAccess` marker, with methodType `java.util.List.get(int)`. `MethodMatcher` dispatches on the method type alone and cannot see the syntactic form, so the recipe fires, renames it, and empties the argument list. The marker then faithfully prints:

```kotlin
assertThat(capturedMdcValues[])
```

```
Syntax error: Expecting an index element.
```

### Groovy

`collection.get(0)` loses its parentheses when the argument list empties:

```groovy
collection.getFirst
```

That parses, and Groovy compiles it as a property read, so it fails at runtime with `MissingPropertyException` rather than at build time. Groovy's subscript form `collection[0]` is unaffected — it resolves to `getAt`, not `get`.

### Fix

`Preconditions.not(new KotlinFileChecker<>())` and `GroovyFileChecker`, which is what the seven `MigrateCollections*` recipes in this same package already do. No new mechanism, and `rewrite-kotlin` and `rewrite-groovy` are already dependencies.

Guarding rather than teaching the recipe to emit valid Kotlin is the right call on the merits, not just for convenience: `getFirst()` is not declared on `kotlin.collections.List`, so there is no correct output for this recipe to produce there. Kotlin's own idiom is `first()`, which would be a separate Kotlin-native recipe.

The sibling `SequencedCollection` recipes were checked and left alone — `IteratorNext` and `StreamFindFirst` gate on `java.util.SequencedCollection` appearing in the receiver's type hierarchy, which Kotlin's mapped collection types do not carry, so a guard there would be untestable dead code.

### Tests

Three cases added to the existing `NoChange` nested class covering Kotlin index access, Kotlin `get(0)`, and Groovy `get(0)`. Each fails without the guard, producing `collection[]`, `collection.getFirst()` and `collection.getFirst` respectively. Full `migrate.util` and `migrate.lang` packages: 669 tests, 0 failures.

Found by compiling the output of `UpgradeToJava25` across a set of open source repositories.
