### PR TITLE
Match a distribution whose candidate carries a vendor build

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java
+++ b/src/main/java/org/openrewrite/java/migrate/UpdateSdkMan.java
@@ -42,6 +42,13 @@ import static java.util.stream.Collectors.toList;
 @Value
 public class UpdateSdkMan extends Recipe {
 
+    /**
+     * Candidates carry the vendor build between the version and the distribution, as in `17.0.20+1.1-zulu`, and that
+     * lands in the qualifier the distribution is matched against. Only a build is tolerated ahead of the distribution,
+     * so a variant such as `.crac-zulu` is still a distinct distribution rather than a match for plain `-zulu`.
+     */
+    private static final String BUILD_METADATA = "(\\+[^-]*)?";
+
     @Option(displayName = "Java version",
             description = "The Java version to update to. Use `latest.patch` to upgrade to the latest version within the current major version.",
             required = false,
@@ -96,13 +103,14 @@ public class UpdateSdkMan extends Recipe {
                     String dist = newDistribution == null ? matcher.group(2) : "-" + newDistribution;
                     String newBasis = ver + dist;
                     Pattern majorPattern = Pattern.compile("^" + ver + "[.-].*");
-                    LatestRelease releaseComparator = new LatestRelease(dist);
+                    String distPattern = BUILD_METADATA + dist;
+                    LatestRelease releaseComparator = new LatestRelease(distPattern);
                     String idealCandidate = readSdkmanJavaCandidates().stream()
                             .filter(candidate -> majorPattern.matcher(candidate).matches())
                             .filter(candidate -> releaseComparator.isValid(newBasis, candidate))
                             .max(releaseComparator)
                             .orElse(null);
-                    if (idealCandidate != null && !isRequestedDowngrade(matcher.group(1) + dist, idealCandidate, dist)) {
+                    if (idealCandidate != null && !isRequestedDowngrade(matcher.group(1) + dist, idealCandidate, distPattern)) {
                         return plainText.withText(matcher.replaceFirst("java=" + idealCandidate));
                     }
                 }

--- a/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpdateSdkManTest.java
@@ -180,6 +180,24 @@ class UpdateSdkManTest implements RewriteTest {
               .after(str -> assertThat(str)
                 .startsWith("java=17.0.")
                 .endsWith("-zulu")
+                .doesNotContain(".crac")
+                .actual())
+          )
+        );
+    }
+
+    @Test
+    void distributionIsStillMatchedWhenTheCandidateCarriesAVendorBuild() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateSdkMan("17", null)),
+          text(
+            """
+              java=11.0.28+1.1-zulu
+              """,
+            spec -> spec.path(".sdkmanrc")
+              .after(str -> assertThat(str)
+                .startsWith("java=17.0.")
+                .endsWith("-zulu")
                 .actual())
           )
         );


### PR DESCRIPTION
`UpdateSdkManTest` has four failures on `main`, which fail every open PR. They are not caused by any of them.

### What happened

The automated candidate refresh (`[Auto] SDKMAN! Java candidates as of 2026-08-24T1031`, 4d5227426) changed identifiers to carry the vendor build:

```
-11.0.32-zulu     +11.0.32+1.1-zulu
-17.0.20-zulu     +17.0.20+1.1-zulu
```

38 of the 92 candidates now have one, across `-zulu`, `-ms` and `-librca`.

### Why it breaks distribution matching

`VersionComparator.RELEASE_PATTERN` captures the qualifier as `(?<qualifier>[-.+].*?$)`, so it begins at the first `-`, `.` or `+`. The recipe passes the distribution to `LatestRelease` as the metadata pattern, and `checkVersion` requires the whole qualifier to match it:

| candidate | qualifier | matches `-zulu` |
|---|---|---|
| `17.0.20-zulu` | `-zulu` | yes |
| `17.0.20+1.1-zulu` | `+1.1-zulu` | **no** |

Every candidate for the requested distribution is filtered out, no ideal candidate is found, and the recipe makes no change — which is what the four tests report.

### Fix

Tolerate a build ahead of the distribution when matching:

```java
private static final String BUILD_METADATA = "(\\+[^-]*)?";
```

Deliberately narrow rather than `.*`. A distribution variant is also part of the qualifier — `.crac-zulu` is a different distribution from `-zulu`, and `zuluNonCrac` exists to assert that a plain request does not select the CRaC build. `.*-zulu` would match it and quietly break that guarantee; `(\+[^-]*)?-zulu` cannot, because a variant does not begin with `+`.

The same pattern is used for the downgrade check, so both sides of the comparison agree on what the distribution is.

### Tests

`distributionIsStillMatchedWhenTheCandidateCarriesAVendorBuild` covers an `.sdkmanrc` that already pins a build, and `zuluNonCrac` gains an explicit `doesNotContain(".crac")` so the narrowness above is asserted rather than assumed.

Reverting only the main source fails five tests including the two above; with the fix, `UpdateSdkManTest` is 18/18 and the full suite is green.

### Worth noting separately

An fx candidate now reads `11.0.32-fx+1.1-librca`, where the build sits after the variant. A request whose distribution is `.fx-librca` still will not match it, since the build is not adjacent to the distribution in that layout. No test covers that shape today and none of the current failures involve it, so it is left alone here rather than guessed at.
