### PR TITLE
Drop the `rewrite-analysis` dependency from `URLConstructorToURICreate`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,6 @@ dependencies {
     implementation("org.openrewrite.recipe:rewrite-joda:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-jenkins:$rewriteVersion")
     implementation("org.openrewrite:rewrite-templating:$rewriteVersion")
-    implementation("org.openrewrite.meta:rewrite-analysis:$rewriteVersion")
 
     runtimeOnly("org.openrewrite:rewrite-java-8")
     runtimeOnly("org.openrewrite:rewrite-java-11")

--- a/src/main/java/org/openrewrite/java/migrate/net/URLConstructorToURICreate.java
+++ b/src/main/java/org/openrewrite/java/migrate/net/URLConstructorToURICreate.java
@@ -17,13 +17,11 @@ package org.openrewrite.java.migrate.net;
 
 import lombok.Getter;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.analysis.constantfold.ConstantFold;
-import org.openrewrite.analysis.util.CursorUtil;
-import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
@@ -32,6 +30,7 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.net.URI;
@@ -81,19 +80,31 @@ public class URLConstructorToURICreate extends Recipe {
                         }
                         if (arg instanceof J.Identifier &&
                                 TypeUtils.isOfType(arg.getType(), JavaType.Primitive.String)) {
-                            // find constant value of the identifier
-                            try {
-                                return CursorUtil.findCursorForTree(getCursor(), arg)
-                                        .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
-                                        .toNull();
-                            } catch (RecipeRunException e) {
-                                // `ConstantFold` does not support lambdas
-                                return null;
-                            }
-                        } else {
-                            // null indicates no path extractable
-                            return null;
+                            return findLiteralInitializer((J.Identifier) arg);
                         }
+                        // null indicates no path extractable
+                        return null;
+                    }
+
+                    private @Nullable String findLiteralInitializer(J.Identifier identifier) {
+                        for (Cursor c = getCursor(); c != null; c = c.getParent()) {
+                            if (c.getValue() instanceof J.Block) {
+                                for (Statement statement : ((J.Block) c.getValue()).getStatements()) {
+                                    if (statement instanceof J.VariableDeclarations) {
+                                        for (J.VariableDeclarations.NamedVariable variable : ((J.VariableDeclarations) statement).getVariables()) {
+                                            if (variable.getSimpleName().equals(identifier.getSimpleName())) {
+                                                Expression initializer = variable.getInitializer();
+                                                if (initializer instanceof J.Literal && ((J.Literal) initializer).getValue() instanceof String) {
+                                                    return (String) ((J.Literal) initializer).getValue();
+                                                }
+                                                return null;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        return null;
                     }
 
                     private boolean isNotValidPath(@Nullable String path) {

--- a/src/main/java/org/openrewrite/java/migrate/net/URLConstructorToURICreate.java
+++ b/src/main/java/org/openrewrite/java/migrate/net/URLConstructorToURICreate.java
@@ -22,6 +22,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
@@ -29,11 +30,13 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.net.URI;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class URLConstructorToURICreate extends Recipe {
 
@@ -92,9 +95,11 @@ public class URLConstructorToURICreate extends Recipe {
                                 for (Statement statement : ((J.Block) c.getValue()).getStatements()) {
                                     if (statement instanceof J.VariableDeclarations) {
                                         for (J.VariableDeclarations.NamedVariable variable : ((J.VariableDeclarations) statement).getVariables()) {
-                                            if (variable.getSimpleName().equals(identifier.getSimpleName())) {
+                                            if (isSameVariable(identifier, variable)) {
                                                 Expression initializer = variable.getInitializer();
-                                                if (initializer instanceof J.Literal && ((J.Literal) initializer).getValue() instanceof String) {
+                                                if (initializer instanceof J.Literal &&
+                                                        ((J.Literal) initializer).getValue() instanceof String &&
+                                                        !isReassigned(variable)) {
                                                     return (String) ((J.Literal) initializer).getValue();
                                                 }
                                                 return null;
@@ -105,6 +110,44 @@ public class URLConstructorToURICreate extends Recipe {
                             }
                         }
                         return null;
+                    }
+
+                    private boolean isSameVariable(Expression expression, J.VariableDeclarations.NamedVariable variable) {
+                        if (expression instanceof J.FieldAccess) {
+                            return isSameVariable(((J.FieldAccess) expression).getName(), variable);
+                        }
+                        if (!(expression instanceof J.Identifier)) {
+                            return false;
+                        }
+                        JavaType.Variable fieldType = ((J.Identifier) expression).getFieldType();
+                        if (fieldType != null && variable.getVariableType() != null) {
+                            return TypeUtils.isOfType(fieldType, variable.getVariableType());
+                        }
+                        return variable.getSimpleName().equals(((J.Identifier) expression).getSimpleName());
+                    }
+
+                    private boolean isReassigned(J.VariableDeclarations.NamedVariable variable) {
+                        JavaSourceFile sourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
+                        if (sourceFile == null) {
+                            return true;
+                        }
+                        return new JavaIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean reassigned) {
+                                if (isSameVariable(assignment.getVariable(), variable)) {
+                                    reassigned.set(true);
+                                }
+                                return super.visitAssignment(assignment, reassigned);
+                            }
+
+                            @Override
+                            public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp, AtomicBoolean reassigned) {
+                                if (isSameVariable(assignOp.getVariable(), variable)) {
+                                    reassigned.set(true);
+                                }
+                                return super.visitAssignmentOperation(assignOp, reassigned);
+                            }
+                        }.reduce(sourceFile, new AtomicBoolean()).get();
                     }
 
                     private boolean isNotValidPath(@Nullable String path) {

--- a/src/test/java/org/openrewrite/java/migrate/net/URLConstructorToURICreateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/net/URLConstructorToURICreateTest.java
@@ -213,6 +213,72 @@ class URLConstructorToURICreateTest implements RewriteTest {
         );
     }
 
+    @Test
+    void urlCheckReassignedVariablePath() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.net.URL;
+
+              class Test {
+                  void urlConstructor() throws Exception {
+                      String url = "https://test.com";
+                      url = "not/valid/url";
+                      URL url1 = new URL(url);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void urlCheckFieldShadowedByLaterLocalPath() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.net.URL;
+
+              class Test {
+                  private String url = "not/valid/url";
+
+                  void urlConstructor() throws Exception {
+                      System.out.println(new URL(url));
+                      String url = "https://test.com";
+                      System.out.println(url);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void urlCheckFieldReassignedInAnotherMethodPath() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.net.URL;
+
+              class Test {
+                  private String url = "https://test.com";
+
+                  void setUrl() {
+                      this.url = "not/valid/url";
+                  }
+
+                  void urlConstructor() throws Exception {
+                      System.out.println(new URL(url));
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/620")
     @Test
     void urlCheckConstantRelativePath() {

--- a/src/test/java/org/openrewrite/java/migrate/net/URLConstructorToURICreateTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/net/URLConstructorToURICreateTest.java
@@ -183,6 +183,36 @@ class URLConstructorToURICreateTest implements RewriteTest {
         );
     }
 
+    @Test
+    void urlCheckLocalVariableAbsolutePath() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.net.URL;
+
+              class Test {
+                  void urlConstructor() {
+                      String goodURL = "https://test.com";
+                      URL url1 = new URL(goodURL);
+                  }
+              }
+              """,
+            """
+              import java.net.URI;
+              import java.net.URL;
+
+              class Test {
+                  void urlConstructor() {
+                      String goodURL = "https://test.com";
+                      URL url1 = URI.create(goodURL).toURL();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/620")
     @Test
     void urlCheckConstantRelativePath() {


### PR DESCRIPTION
`URLConstructorToURICreate` was the only consumer of `org.openrewrite.meta:rewrite-analysis`, using `ConstantFold` to resolve a `String` identifier back to the literal it was initialized with. That lookup is now a walk over the enclosing blocks for the matching variable declaration, which drops the `RecipeRunException` catch that existed solely because `ConstantFold` throws on a lambda parameter.

To keep the previous behaviour, the walk matches on `JavaType.Variable` rather than on the name — the owner distinguishes a local shadowing a field from the field itself — and refuses to fold a variable that is assigned to anywhere in the file, including through `this`, which is the condition `ConstantFold` expressed as a single assigned value.

Tests cover the local-variable case that was previously untested, plus the reassigned, shadowed-field, and reassigned-through-`this` cases; all 14 pass.