### PR TITLE
Leave a Groovy `def` declaration alone instead of splicing `var` into its variable name.

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
+++ b/src/main/java/org/openrewrite/java/migrate/lang/var/DeclarationCheck.java
@@ -74,7 +74,9 @@ final class DeclarationCheck {
      * @return true if single variable definition with initialization and without var
      */
     private static boolean isSingleVariableDefinition(J.VariableDeclarations vd) {
-        TypeTree typeExpression = vd.getTypeExpression();
+        if (!replaceableTypeExpression(vd.getTypeExpression())) {
+            return false;
+        }
 
         boolean definesSingleVariable = vd.getVariables().size() == 1;
         boolean isPureAssigment = JavaType.Primitive.Null == vd.getType();
@@ -90,8 +92,22 @@ final class DeclarationCheck {
 
         initializer = initializer.unwrap();
         boolean isNullAssigment = J.Literal.isLiteralValue(initializer, null);
-        boolean alreadyUseVar = typeExpression instanceof J.Identifier && "var".equals(((J.Identifier) typeExpression).getSimpleName());
-        return !isNullAssigment && !alreadyUseVar;
+        return !isNullAssigment;
+    }
+
+    /**
+     * Groovy parses {@code def x = ...} into an empty {@link J.Identifier} and prints {@code def}
+     * from a marker, so writing {@code var} there splices it onto the name ({@code def varx = ...}).
+     */
+    private static boolean replaceableTypeExpression(@Nullable TypeTree typeExpression) {
+        if (typeExpression == null) {
+            return false;
+        }
+        if (typeExpression instanceof J.Identifier) {
+            String simpleName = ((J.Identifier) typeExpression).getSimpleName();
+            return !simpleName.isEmpty() && !"var".equals(simpleName);
+        }
+        return true;
     }
 
     /**

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForConstructorsTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForConstructorsTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
 
@@ -262,6 +263,21 @@ class UseVarForConstructorsTest implements RewriteTest {
                   ArrayList<String> getList() {
                       return new ArrayList<>();
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotSpliceVarIntoGroovyDef() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+            """
+              def stripVmExtension(File dir) {
+                  def newFile = new File(dir, "child")
+                  assert newFile != null
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitiveTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lang/var/UseVarForPrimitiveTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
 
@@ -33,6 +34,22 @@ class UseVarForPrimitiveTest extends VarBaseTest {
 
     @Nested
     class NotApplicable {
+        @Test
+        void forGroovyDef() {
+            //language=groovy
+            rewriteRun(
+              groovy(
+                """
+                  class A {
+                    void m() {
+                      def count = 1
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
         @Test
         void forShort() {
             //language=java


### PR DESCRIPTION
## What's changed?

`DeclarationCheck.isSingleVariableDefinition` now refuses declarations that expose no type expression for `var` to replace. The single guard covers `UseVarForConstructors`, `UseVarForObject`, `UseVarForGenericsConstructors`, and `UseVarForGenericMethodInvocations`.

## What's your motivation?

The `var` recipes corrupt Groovy `def` declarations, non-idempotently.

```groovy
// before
def newFile = new File(file.parentFile, newName)
assert file.renameTo(newFile) : "Failed to rename ${file} to ${newFile}"

// after one run
def varnewFile = new File(file.parentFile, newName)
assert file.renameTo(newFile) : "Failed to rename ${file} to ${newFile}"

// after a second run on the same file
def varvarnewFile = new File(file.parentFile, newName)
```

Originally hit on `rewrite-migrate-java` 3.42.1 with `rewrite-maven-plugin` 6.46.1, against a real
Maven archetype post-generate script. Still reproduces on `main` at `v3.43.0`.

## Anything in particular you'd like reviewers to focus on?

## Have you considered any alternatives or workarounds?

Applying an `org.openrewrite.FindSourceFiles` precondition of `**/*.java` to the `var`
recipes.