### PR TITLE
Do not add `final` to a try-with-resources resource

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
@@ -99,7 +99,9 @@ public class LombokValToFinalVar extends Recipe {
                     return varDecls.withTypeExpression(varType);
                 }
 
-                if (varDecls.getModifiers().stream().noneMatch(m -> m.getType() == J.Modifier.Type.Final)) {
+                // Resources of a try-with-resources statement are implicitly final
+                boolean implicitlyFinal = getCursor().getParentTreeCursor().getValue() instanceof J.Try.Resource;
+                if (!implicitlyFinal && varDecls.getModifiers().stream().noneMatch(m -> m.getType() == J.Modifier.Type.Final)) {
                     varDecls = varDecls.withModifiers(ListUtils.concat(
                             new J.Modifier(Tree.randomId(), typeExpression.getPrefix(), Markers.EMPTY,
                                     null, J.Modifier.Type.Final, emptyList()),

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.java
@@ -130,6 +130,41 @@ class LombokValToFinalVarTest implements RewriteTest {
     }
 
     @Test
+    void doNotUseFinal_TryWithResources_statement() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import java.io.StringWriter;
+                import lombok.val;
+
+                class A {
+                    public void foo(String aaa) {
+                        try (val writer = new StringWriter()) {
+                            writer.append(aaa);
+                        }
+                    }
+                }
+                """,
+              """
+                import java.io.StringWriter;
+
+                class A {
+                    public void foo(String aaa) {
+                        try (var writer = new StringWriter()) {
+                            writer.append(aaa);
+                        }
+                    }
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
+
+    @Test
     void preserveStarImport() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
`LombokValToFinalVar` rewrote `val` to `final var` unconditionally. Resources declared in a try-with-resources statement are already implicitly final, so the added `final` modifier is redundant there.

This checks whether the variable declaration's parent is a `J.Try.Resource` and, if so, emits plain `var` instead of `final var`.

```java
// before
try (val writer = new StringWriter()) {
    writer.append(aaa);
}

// after
try (var writer = new StringWriter()) {
    writer.append(aaa);
}
```

Adds a test covering the try-with-resources case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)