### PR TITLE
Preserve casts when converting `lombok.val` to `final var`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
@@ -19,17 +19,19 @@ import lombok.Getter;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.MaybeUsesImport;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
 
 import java.time.Duration;
 import java.util.Set;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 
 public class LombokValToFinalVar extends Recipe {
@@ -79,27 +81,32 @@ public class LombokValToFinalVar extends Recipe {
                     (varDecls.getTypeExpression() instanceof J.Identifier && "val".equals(((J.Identifier) varDecls.getTypeExpression()).getSimpleName()))) {
                 maybeRemoveImport(LOMBOK_VAL);
 
-                J.VariableDeclarations.NamedVariable nv = mv.getVariables().get(0);
+                // Manually transform to `var`, rather than using a JavaTemplate, so that the initializer
+                // is carried over untouched; reprinting it can lose type information, such as the type
+                // variable in a cast like `(T) o`.
+                J.VariableDeclarations.NamedVariable nv = varDecls.getVariables().get(0);
+                TypeTree typeExpression = varDecls.getTypeExpression();
+                J.Identifier varType = new J.Identifier(Tree.randomId(),
+                        typeExpression.getPrefix(),
+                        typeExpression.getMarkers(),
+                        service(AnnotationService.class).getAllAnnotations(getCursor()),
+                        "var",
+                        nv.getType(),
+                        null);
                 if (nv.getInitializer() == null) {
-                    // manually transform to var, as val in this case has no sufficient type information
-                    // and the java template parsing would fail, see https://github.com/openrewrite/rewrite/pull/5637
-                    TypeTree typeExpression = varDecls.getTypeExpression();
-                    J.Identifier varType = new J.Identifier(Tree.randomId(),
-                            typeExpression.getPrefix(),
-                            typeExpression.getMarkers(),
-                            service(AnnotationService.class).getAllAnnotations(getCursor()),
-                            "var",
-                            nv.getType(),
-                            null);
+                    // `val` in this case has no sufficient type information, so it becomes a plain `var`,
+                    // see https://github.com/openrewrite/rewrite/pull/5637
                     return varDecls.withTypeExpression(varType);
                 }
 
-                varDecls = JavaTemplate.builder("final var #{} = #{any()};")
-                        .contextSensitive()
-                        .build()
-                        .apply(updateCursor(varDecls), varDecls.getCoordinates().replace(), nv.getSimpleName(), nv.getInitializer());
-                varDecls = varDecls.withVariables(ListUtils.map(varDecls.getVariables(), namedVar -> namedVar
-                        .withInitializer(namedVar.getInitializer().withPrefix(nv.getInitializer().getPrefix()))));
+                if (varDecls.getModifiers().stream().noneMatch(m -> m.getType() == J.Modifier.Type.Final)) {
+                    varDecls = varDecls.withModifiers(ListUtils.concat(
+                            new J.Modifier(Tree.randomId(), typeExpression.getPrefix(), Markers.EMPTY,
+                                    null, J.Modifier.Type.Final, emptyList()),
+                            varDecls.getModifiers()));
+                    varType = varType.withPrefix(Space.SINGLE_SPACE);
+                }
+                varDecls = varDecls.withTypeExpression(varType);
             }
             return varDecls;
         }

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
@@ -115,7 +115,7 @@ class UpgradeToJava25Test implements RewriteTest {
               spec -> spec.after(actual ->
                 assertThat(actual)
                   .contains("<maven.compiler.release>25</maven.compiler.release>")
-                  .containsPattern("maven-compiler-plugin</artifactId>\\s*<version>3\\.15\\.")
+                  .containsPattern("maven-compiler-plugin</artifactId>\\s*<version>3\\.(1[5-9]|[2-9]\\d)\\.")
                   .containsPattern("maven-surefire-plugin</artifactId>\\s*<version>3\\.5\\.")
                   .containsPattern("maven-failsafe-plugin</artifactId>\\s*<version>3\\.5\\.")
                   .contains("<argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>")

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.java
@@ -511,4 +511,58 @@ class LombokValToFinalVarTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void preserveCast() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import lombok.val;
+                class CastDemo {
+                    void bar() {
+                        val foo = (String) "foo";
+                    }
+                }
+                """,
+              """
+                class CastDemo {
+                    void bar() {
+                        final var foo = (String) "foo";
+                    }
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
+
+    @Test
+    void preserveGenericCast() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import lombok.val;
+                class GenericCastDemo<T> {
+                    void bar(Object o) {
+                        val foo = (T) o;
+                    }
+                }
+                """,
+              """
+                class GenericCastDemo<T> {
+                    void bar(Object o) {
+                        final var foo = (T) o;
+                    }
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

`LombokValToFinalVar` built the `final var` declaration with a `JavaTemplate`, which re-prints the initializer expression. Re-printing can lose type information: a cast to a type variable such as `(T) o` came out mangled, because the template parse has no knowledge of the enclosing class's type parameters.

This replaces the template with a direct LST transformation:

- Build the `var` `J.Identifier` (as the existing no-initializer branch already did) and swap it in for the `val` type expression, so both code paths now share that construction.
- Prepend a `final` modifier only when one isn't already present, moving the original type expression's prefix onto the modifier so formatting is preserved.

The initializer is carried over untouched, so casts — including generic ones — survive the conversion. Behavior for declarations without an initializer is unchanged (still a plain `var`, per openrewrite/rewrite#5637).

Also included is a small unrelated test fix: `UpgradeToJava25Test.upgradeToJava25` pinned `maven-compiler-plugin` to `3.15.x` in an assertion pattern, which breaks as soon as a newer minor is released. The pattern now accepts any `3.15+` version.

## Anything in particular you'd like reviewers to focus on?

The prefix/modifier juggling is the part worth a close look — the existing tests cover annotated, already-`final`, multi-variable, and comment-carrying declarations, and two new tests cover the casts: `preserveCast` (`(String) "foo"`) and `preserveGenericCast` (`(T) o`).

I can't run the build locally — dependency resolution needs credentials for `artifacts.codegenomeproject.org` — so I'm relying on CI for verification.

## Have you considered any alternatives or workarounds?

Keeping `JavaTemplate` and making it type-aware. Sidestepping the re-print entirely is simpler, and it also removes the divergence between the initializer and no-initializer code paths.
