### PR TITLE
Raise the build plugins and Lombok processor path that Java 25 needs, and keep Gradle 9 builds configuring

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/search/ModuleOrParentHasDependency.java
+++ b/src/main/java/org/openrewrite/java/migrate/search/ModuleOrParentHasDependency.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.migrate.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class ModuleOrParentHasDependency extends ScanningRecipe<ModuleOrParentHasDependency.Accumulator> {
+
+    @Option(displayName = "Group pattern",
+            description = "Group glob pattern used to match dependencies.",
+            example = "org.projectlombok")
+    String groupIdPattern;
+
+    @Option(displayName = "Artifact pattern",
+            description = "Artifact glob pattern used to match dependencies.",
+            example = "lombok")
+    String artifactIdPattern;
+
+    String displayName = "Module or its reactor parent has dependency";
+
+    String description = "Marks all files in modules that have a matching dependency, and the in-reactor parent poms " +
+            "those modules inherit from. Intended as a precondition for recipes that configure a module through its " +
+            "parent's `pluginManagement`, which a per-module precondition would otherwise keep from being visited.";
+
+    public static class Accumulator {
+        Set<JavaProject> modules = new HashSet<>();
+        Set<Path> parentPoms = new HashSet<>();
+    }
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof SourceFile && hasDependency(tree.getMarkers())) {
+                    tree.getMarkers().findFirst(JavaProject.class).ifPresent(acc.modules::add);
+                    tree.getMarkers().findFirst(MavenResolutionResult.class).ifPresent(mrr -> {
+                        for (MavenResolutionResult p = mrr; p.parentPomIsProjectPom() && p.getParent() != null; p = p.getParent()) {
+                            Path parentPath = p.getParent().getPom().getRequested().getSourcePath();
+                            if (parentPath == null) {
+                                break;
+                            }
+                            acc.parentPoms.add(parentPath);
+                        }
+                    });
+                }
+                return tree;
+            }
+        };
+    }
+
+    private boolean hasDependency(Markers markers) {
+        Optional<MavenResolutionResult> mrr = markers.findFirst(MavenResolutionResult.class);
+        if (mrr.isPresent()) {
+            return !mrr.get().findDependencies(groupIdPattern, artifactIdPattern, null).isEmpty();
+        }
+        Optional<GradleProject> gp = markers.findFirst(GradleProject.class);
+        if (gp.isPresent()) {
+            for (GradleDependencyConfiguration configuration : gp.get().getConfigurations()) {
+                if (configuration.findRequestedDependency(groupIdPattern, artifactIdPattern) != null ||
+                    configuration.findResolvedDependency(groupIdPattern, artifactIdPattern) != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                assert tree != null;
+                Optional<JavaProject> jp = tree.getMarkers().findFirst(JavaProject.class);
+                if (jp.isPresent() && acc.modules.contains(jp.get())) {
+                    return SearchResult.found(tree, "Module has dependency");
+                }
+                if (tree instanceof SourceFile && acc.parentPoms.contains(((SourceFile) tree).getSourcePath())) {
+                    return SearchResult.found(tree, "Parent of a module with the dependency");
+                }
+                return tree;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -174,7 +174,8 @@ description: >-
   With Java 23 the encapsulation of JDK internals made it necessary to configure annotation processors like Lombok explicitly.
   The change is valid for older versions as well.
 preconditions:
-  - org.openrewrite.java.dependencies.search.ModuleHasDependency:
+  # Marks the reactor parent too: `AddAnnotationProcessor` configures a module through its parent's `pluginManagement`.
+  - org.openrewrite.java.migrate.search.ModuleOrParentHasDependency:
       groupIdPattern: org.projectlombok
       artifactIdPattern: lombok
 recipeList:

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -204,6 +204,8 @@ recipeList:
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: 9.1.0
       addIfMissing: false
+  # Gradle 9 removed the JavaPluginConvention, so the wrapper bump above turns a project-level `sourceCompatibility` into an error.
+  - org.openrewrite.gradle.gradle9.UseJavaExtensionBlock
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.apache.maven.plugins
       artifactId: maven-compiler-plugin

--- a/src/main/resources/META-INF/rewrite/java-version-25.yml
+++ b/src/main/resources/META-INF/rewrite/java-version-25.yml
@@ -217,6 +217,29 @@ recipeList:
       groupId: org.apache.maven.plugins
       artifactId: maven-failsafe-plugin
       newVersion: 3.5.x
+  # Plugins whose older lines fail to load on JDK 25 (plexus-utils reflection, ASM without class file version 69).
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-enforcer-plugin
+      newVersion: 3.x
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-assembly-plugin
+      newVersion: 3.x
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-plugin-plugin
+      newVersion: 3.15.x
+      addVersionIfMissing: true
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-checkstyle-plugin
+      newVersion: 3.6.x
+  # A checkstyle pinned on the plugin must be able to parse the pattern-matching `switch` the Java 21 migration writes.
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: com.puppycrawl.tools
+      artifactId: checkstyle
+      newVersion: 10.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: net.bytebuddy
       artifactId: byte-buddy*

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeJavaVersionTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeJavaVersionTest.java
@@ -26,8 +26,10 @@ import org.openrewrite.test.RewriteTest;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.java.Assertions.version;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -125,6 +127,242 @@ class UpgradeJavaVersionTest implements RewriteTest {
                   </project>
                   """,
                 spec -> spec.markers(new JavaVersion(UUID.randomUUID(), "", "", "11.0.15+10", "11.0.15+10"))
+              )
+            );
+        }
+
+        @Test
+        void mavenReleaseThroughCustomPropertyInParentPluginManagement() {
+            rewriteRun(
+              spec -> spec.recipe(new UpgradeJavaVersion(25)),
+              mavenProject("parent",
+                pomXml(
+                  //language=xml
+                  """
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <properties>
+                        <project.build.release.version>8</project.build.release.version>
+                      </properties>
+                      <modules>
+                        <module>child</module>
+                      </modules>
+                      <build>
+                        <pluginManagement>
+                          <plugins>
+                            <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.11.0</version>
+                              <configuration>
+                                <release>${project.build.release.version}</release>
+                              </configuration>
+                            </plugin>
+                          </plugins>
+                        </pluginManagement>
+                      </build>
+                    </project>
+                    """,
+                  //language=xml
+                  """
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <properties>
+                        <project.build.release.version>25</project.build.release.version>
+                      </properties>
+                      <modules>
+                        <module>child</module>
+                      </modules>
+                      <build>
+                        <pluginManagement>
+                          <plugins>
+                            <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.11.0</version>
+                              <configuration>
+                                <release>${project.build.release.version}</release>
+                              </configuration>
+                            </plugin>
+                          </plugins>
+                        </pluginManagement>
+                      </build>
+                    </project>
+                    """
+                ),
+                mavenProject("child",
+                  pomXml(
+                    //language=xml
+                    """
+                      <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1</version>
+                        </parent>
+                        <artifactId>child</artifactId>
+                      </project>
+                      """
+                  )
+                )
+              )
+            );
+        }
+
+        @Test
+        void mavenSourceTargetInParentPluginManagement() {
+            rewriteRun(
+              spec -> spec.recipe(new UpgradeJavaVersion(25)),
+              mavenProject("parent",
+                pomXml(
+                  //language=xml
+                  """
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <modules>
+                        <module>child</module>
+                      </modules>
+                      <build>
+                        <pluginManagement>
+                          <plugins>
+                            <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.1</version>
+                              <configuration>
+                                <source>1.6</source>
+                                <target>1.6</target>
+                              </configuration>
+                            </plugin>
+                          </plugins>
+                        </pluginManagement>
+                      </build>
+                    </project>
+                    """,
+                  //language=xml
+                  """
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <modules>
+                        <module>child</module>
+                      </modules>
+                      <build>
+                        <pluginManagement>
+                          <plugins>
+                            <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.1</version>
+                              <configuration>
+                                <release>25</release>
+                              </configuration>
+                            </plugin>
+                          </plugins>
+                        </pluginManagement>
+                      </build>
+                    </project>
+                    """
+                ),
+                mavenProject("child",
+                  pomXml(
+                    //language=xml
+                    """
+                      <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1</version>
+                        </parent>
+                        <artifactId>child</artifactId>
+                      </project>
+                      """
+                  )
+                )
+              )
+            );
+        }
+
+        @Test
+        void mavenCompilerPropertiesInParentWithTestSourceTarget() {
+            rewriteRun(
+              spec -> spec.recipe(new UpgradeJavaVersion(25)),
+              mavenProject("parent",
+                pomXml(
+                  //language=xml
+                  """
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <properties>
+                        <maven.compiler.target>1.8</maven.compiler.target>
+                        <maven.compiler.source>1.8</maven.compiler.source>
+                        <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+                        <maven.compiler.testSource>1.8</maven.compiler.testSource>
+                      </properties>
+                      <modules>
+                        <module>child</module>
+                      </modules>
+                      <build>
+                        <pluginManagement>
+                          <plugins>
+                            <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.11.0</version>
+                              <configuration>
+                                <source>${maven.compiler.source}</source>
+                                <target>${maven.compiler.target}</target>
+                                <testSource>${maven.compiler.testSource}</testSource>
+                                <testTarget>${maven.compiler.testTarget}</testTarget>
+                              </configuration>
+                            </plugin>
+                          </plugins>
+                        </pluginManagement>
+                      </build>
+                    </project>
+                    """,
+                  spec -> spec.after(actual -> assertThat(actual)
+                    .doesNotContain("1.8")
+                    .contains("25")
+                    .actual())
+                ),
+                mavenProject("child",
+                  pomXml(
+                    //language=xml
+                    """
+                      <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1</version>
+                        </parent>
+                        <artifactId>child</artifactId>
+                      </project>
+                      """
+                  )
+                )
               )
             );
         }

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
@@ -563,6 +563,72 @@ class UpgradeToJava25Test implements RewriteTest {
     }
 
     @Test
+    void addsLombokAnnotationProcessorToReactorParent() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.migrate.EnableLombokAnnotationProcessor"),
+          mavenProject("parent",
+            pomXml(
+              //language=xml
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>child</module>
+                    </modules>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-compiler-plugin</artifactId>
+                                    <version>3.14.0</version>
+                                    <configuration>
+                                        <release>25</release>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                    </build>
+                </project>
+                """,
+              spec -> spec.after(actual ->
+                assertThat(actual)
+                  .containsPattern("<annotationProcessorPaths>(.|\\n)*<path>(.|\\n)*<artifactId>lombok")
+                  .actual()
+              )
+            ),
+            mavenProject("child",
+              pomXml(
+                //language=xml
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>parent</artifactId>
+                          <version>1</version>
+                      </parent>
+                      <artifactId>child</artifactId>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.projectlombok</groupId>
+                              <artifactId>lombok</artifactId>
+                              <version>1.18.40</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Test
     void addsLombokAnnotationProcessor() {
         rewriteRun(
           spec -> spec.cycles(1).expectedCyclesThatMakeChanges(1),

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -214,6 +215,30 @@ class UpgradeToJava25Test implements RewriteTest {
                   .containsPattern("<artifactId>checkstyle</artifactId>\\s*<version>10\\.")
                   .actual())
             )
+          )
+        );
+    }
+
+    @Test
+    void movesProjectLevelCompatibilityIntoJavaBlockForGradle9() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          buildGradle(
+            //language=groovy
+            """
+              plugins { id 'java' }
+              sourceCompatibility = 1.8
+              targetCompatibility = 1.8
+              """,
+            //language=groovy
+            """
+              plugins { id 'java' }
+
+              java {
+                  sourceCompatibility = JavaVersion.VERSION_25
+                  targetCompatibility = JavaVersion.VERSION_25
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
+++ b/src/test/java/org/openrewrite/java/migrate/UpgradeToJava25Test.java
@@ -157,6 +157,68 @@ class UpgradeToJava25Test implements RewriteTest {
     }
 
     @Test
+    void upgradesBuildPluginsThatCannotRunOnJava25() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.migrate.UpgradePluginsForJava25"),
+          mavenProject("project",
+            pomXml(
+              //language=xml
+              """
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-enforcer-plugin</artifactId>
+                                    <version>1.4</version>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-assembly-plugin</artifactId>
+                                <version>2.6</version>
+                            </plugin>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-plugin-plugin</artifactId>
+                                <version>3.6.1</version>
+                            </plugin>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-checkstyle-plugin</artifactId>
+                                <version>3.1.2</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>com.puppycrawl.tools</groupId>
+                                        <artifactId>checkstyle</artifactId>
+                                        <version>8.45</version>
+                                    </dependency>
+                                </dependencies>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """,
+              spec -> spec.after(actual ->
+                assertThat(actual)
+                  .containsPattern("maven-enforcer-plugin</artifactId>\\s*<version>3\\.")
+                  .containsPattern("maven-assembly-plugin</artifactId>\\s*<version>3\\.")
+                  .containsPattern("maven-plugin-plugin</artifactId>\\s*<version>3\\.15\\.")
+                  .containsPattern("maven-checkstyle-plugin</artifactId>\\s*<version>3\\.6\\.")
+                  .containsPattern("<artifactId>checkstyle</artifactId>\\s*<version>10\\.")
+                  .actual())
+            )
+          )
+        );
+    }
+
+    @Test
     void kotlin1xCapsJavaVersionAt24WithComment() {
         // Kotlin 1.x is left untouched: crossing the K2 compiler default introduced in Kotlin 2.0 is source-breaking,
         // so the module stays on Kotlin 1.x and is capped at Java 24 (with an explanatory comment) rather than upgraded.


### PR DESCRIPTION
## What went wrong

`UpgradeToJava25` was applied to ten real Maven and Gradle repositories under Apache, Netflix and Spring Cloud that compiled cleanly on JDK 8/17 beforehand. Afterwards none of them built on JDK 25. The failures fall into three groups:

1. **Build plugins that cannot load on JDK 25 were left alone.** `maven-enforcer-plugin` 1.1.1/1.4 dies with `ExceptionInInitializerError` before the first module compiles (stanbol, incubator-batchee), `maven-assembly-plugin` 2.6 reports `No such archiver: 'zip'` (sdap-mudrod), `maven-plugin-plugin` 3.6.1 fails with `Unsupported class file major version 69` (olingo-odata4), and the `checkstyle` 8.45 that incubator-hugegraph-toolchain pins on `maven-checkstyle-plugin` cannot parse the pattern-matching `switch` that `UpgradeToJava21` writes (`unexpected token: results ->`). Lombok belongs here as well: JDK 23 stopped running annotation processors found on the classpath, and although `EnableLombokAnnotationProcessor` exists for exactly that, its `ModuleHasDependency` precondition only marks the module that declares Lombok. `AddAnnotationProcessor` writes the processor path into the reactor parent's `pluginManagement`, a pom that precondition never marks, so every multi-module build (rocketmq-schema-registry, incubator-hugegraph-toolchain) compiled without Lombok and failed on the getters and `log` fields it should have generated.
2. **Gradle builds broke on the wrapper bump itself.** The wrapper moves to 9.1.0, and Gradle 9 removed the `JavaPluginConvention`, so a build that assigns `sourceCompatibility` on the project (eureka's `subprojects { sourceCompatibility = 1.8 }`) now fails with `Could not set unknown property 'sourceCompatibility'`, even though the recipe had just rewritten that very line to `25`.
3. **Source rewritten past the module's compiler level.** In one batch run the module-level and property-indirected compiler declarations (`<release>${project.build.release.version}</release>` in a parent's `pluginManagement`, `<source>1.6</source>` in a parent, `maven.compiler.source` properties) stayed behind while the sources gained switch expressions, pattern-matching `instanceof` and `IO.println`. Re-running the recipe against the same checkouts raised every one of those declarations, so this could not be reproduced in the recipe itself; the shapes are now pinned down by tests so a regression shows up here first.

## What changed

- `UpgradePluginsForJava25` raises `maven-enforcer-plugin` to 3.x, `maven-assembly-plugin` to 3.x, `maven-plugin-plugin` to 3.15.x and `maven-checkstyle-plugin` to 3.6.x, and bumps a `com.puppycrawl.tools:checkstyle` pinned as a plugin dependency to 10.x, the first line whose parser accepts the Java 21 syntax the migration introduces.
- `EnableLombokAnnotationProcessor` is gated on a new `ModuleOrParentHasDependency` precondition, which marks the modules that depend on Lombok and the in-reactor parent poms they inherit from, so `AddAnnotationProcessor` reaches the pom it targets.
- `UpgradePluginsForJava25` runs `org.openrewrite.gradle.gradle9.UseJavaExtensionBlock` right after the wrapper bump, so `sourceCompatibility` / `targetCompatibility` assigned at project level (including inside `subprojects { }` / `allprojects { }`) move into the `java { }` block before Gradle 9 rejects them.
- `UpgradeJavaVersionTest` gains multi-module cases for a compiler level inherited from the parent's `pluginManagement`, literally, through a custom property, and through the `maven.compiler.*` properties with test-source overrides.

## What is left for the reader

- **Plugin versions managed by a parent outside the repository.** olingo-odata4 declares `maven-plugin-plugin` without a version and inherits 3.6.1 from `org.apache:apache:30`; `UpgradePluginVersion` honours the remote `pluginManagement` even with `addVersionIfMissing`, so the bump does not land and the build still fails at `helpmojo`. Filed as openrewrite/rewrite#8775 rather than worked around here.
- **JAXB in incubator-batchee.** Once the enforcer no longer crashes, `jbatch` fails on `javax.xml.bind.annotation` not existing; `AddJaxbDependenciesWithRuntime` did not add the dependency to that module. That is a Java 11 migration gap unrelated to this change.
- **Non-Java build plugins.** incubator-hugegraph-toolchain now compiles its Java modules and stops in `hugegraph-spark-connector` on `org.scala-tools:maven-scala-plugin` 2.15.2, a long-abandoned Scala plugin with no drop-in successor coordinate.

- **Gradle plugins compiled against removed Gradle APIs.** eureka's `com.netflix.nebula.netflixoss` 11.6.0 needs `org.gradle.util.VersionNumber`, and Hystrix's own `buildSrc` plugin references `org.gradle.util.ConfigureUtil`; both were removed in Gradle 9. Gradle 8.x does not run on JDK 25, so stopping the wrapper short is not an option, and rewriting third-party or in-repo plugin code is beyond a version bump. `MigrateToGradle9` in rewrite-gradle carries the rest of the script-level migration and can be layered on top; the plugin code has to be updated by hand.
- **Kotlin 1.x modules.** spring-cloud-sleuth's `kotlin-maven-plugin` 1.6.21 throws `IllegalArgumentException: 25` when the compiler itself is started on JDK 25. The recipe deliberately does not cross the Kotlin 2.0 boundary, so such modules stay on a JDK 24 toolchain by design; building them with a JDK 25 requires the Kotlin bump first.
- **A newer checkstyle can report new violations.** Raising the checkstyle line to one that parses Java 21 also enables checks the old version did not have; rocketmq-schema-registry now fails `UnnecessaryParentheses` on untouched code after the plugin moved from 2.17 to 3.6.0. That is a style decision for the project rather than something the migration can settle.

## Verification against real repositories

Each repository was reset, the recipe applied from a locally built jar, and the project compiled on JDK 25 (`mvn compile` / `./gradlew testClasses`), before and after this change.

| Repository | Before this change | After this change |
| --- | --- | --- |
| apache/sdap-mudrod | exit 1: `maven-assembly-plugin:2.6` `No such archiver: 'zip'` | **exit 0** (`maven-assembly-plugin` 3.8.0) |
| apache/incubator-batchee | exit 1: `maven-enforcer-plugin:1.1.1` `ExceptionInInitializerError` on the parent | exit 1, but the enforcer runs and every module before `jbatch` compiles; `jbatch` fails on the missing JAXB dependency described above |
| apache/rocketmq-schema-registry | exit 1: checkstyle `UnnecessaryParentheses` on untouched code; with `-Dcheckstyle.skip`, exit 1 on Lombok-generated `log`, getters and constructors | **exit 0 with `-Dcheckstyle.skip`** (Lombok now runs); the checkstyle style finding remains |
| apache/incubator-hugegraph-toolchain | exit 1: `checkstyle` 8.45 `unexpected token: results ->` | exit 1, but checkstyle passes and `hugegraph-client` / `hugegraph-loader` compile; stops at `maven-scala-plugin:2.15.2` in `hugegraph-spark-connector` |
| apache/olingo-odata4 | exit 1: `maven-plugin-plugin:3.6.1` `Unsupported class file major version 69` | exit 1, unchanged; the version is managed by `org.apache:apache:30` (openrewrite/rewrite#8775) |
| spring-cloud/spring-cloud-sleuth | exit 1: `kotlin-maven-plugin:1.6.21` `IllegalArgumentException: 25` | not re-run; Kotlin 1.x stays where it is by design |
| Netflix/eureka, Netflix/Hystrix | exit 1: `sourceCompatibility` unknown property / `org.gradle.util.ConfigureUtil` under Gradle 9.1 | not re-run; the `sourceCompatibility` half is covered by the new unit test, the plugin code is out of reach |
| apache/stanbol | exit 1: `maven-enforcer-plugin:1.4` `ExceptionInInitializerError` on the parent | not re-run; the same enforcer line is exercised by incubator-batchee |

`UpgradeJavaVersionTest` and `UpgradeToJava25Test` pass in full.
