### PR TITLE
Fix annotation handling in `LombokValToFinalVar`

### DIFF
--- a/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
+++ b/src/main/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVar.java
@@ -21,7 +21,6 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.MaybeUsesImport;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeTree;
@@ -89,7 +88,7 @@ public class LombokValToFinalVar extends Recipe {
                 J.Identifier varType = new J.Identifier(Tree.randomId(),
                         typeExpression.getPrefix(),
                         typeExpression.getMarkers(),
-                        service(AnnotationService.class).getAllAnnotations(getCursor()),
+                        typeExpression instanceof J.Identifier ? ((J.Identifier) typeExpression).getAnnotations() : emptyList(),
                         "var",
                         nv.getType(),
                         null);

--- a/src/test/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.java
+++ b/src/test/java/org/openrewrite/java/migrate/lombok/LombokValToFinalVarTest.java
@@ -600,4 +600,33 @@ class LombokValToFinalVarTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void preserveSuppressWarningsAnnotation() {
+        //language=java
+        rewriteRun(
+          version(
+            java(
+              """
+                import lombok.val;
+                class GenericCastDemo<T> {
+                    void bar(Object o) {
+                        @SuppressWarnings("unchecked")
+                        val foo = (T) o;
+                    }
+                }
+                """,
+              """
+                class GenericCastDemo<T> {
+                    void bar(Object o) {
+                        @SuppressWarnings("unchecked")
+                        final var foo = (T) o;
+                    }
+                }
+                """
+            ),
+            17
+          )
+        );
+    }
 }


### PR DESCRIPTION
When building the replacement `var` identifier, the recipe used `AnnotationService.getAllAnnotations(getCursor())`. At that point the cursor is on the `J.VariableDeclarations`, so this returns the annotations of the whole declaration (e.g. a `@SuppressWarnings("unchecked")` on the statement), not the annotations attached to the type expression. Those declaration-level annotations were then attached to the new `var` identifier as well, leaving them printed twice.

This takes the annotations from the type expression itself instead, which is what the new type identifier should carry over. Declaration-level annotations stay where they already are on the `J.VariableDeclarations`.

Added a test covering `@SuppressWarnings("unchecked")` on a `val` declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)